### PR TITLE
Refactor Supabase configuration

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -19,13 +19,15 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+import {
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  SUPABASE_OPTIONS,
+  IS_SUPABASE_CONFIGURED
+} from './supabaseConfig';
 
-// Configurações do Supabase - opcionais para desenvolvimento
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-// Variáveis de fallback para desenvolvimento quando Supabase não está configurado
-const isSupabaseConfigured = !!(supabaseUrl && supabaseAnonKey);
+// Configurações do Supabase
+const isSupabaseConfigured = IS_SUPABASE_CONFIGURED;
 
 if (!isSupabaseConfigured) {
   console.warn('⚠️ Supabase não configurado: VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY não definidas');
@@ -34,8 +36,8 @@ if (!isSupabaseConfigured) {
 
 // Log para debug (apenas em development)
 if (typeof window !== 'undefined' && import.meta.env.DEV) {
-  console.log('Supabase URL:', supabaseUrl);
-  console.log('Supabase Key:', supabaseAnonKey?.substring(0, 20) + '...');
+  console.log('Supabase URL:', SUPABASE_URL);
+  console.log('Supabase Key:', SUPABASE_ANON_KEY?.substring(0, 20) + '...');
 }
 
 // Tipos TypeScript para as tabelas
@@ -160,19 +162,9 @@ export interface Database {
 
 // Cliente Supabase tipado com fallback para desenvolvimento
 export const supabase = createClient<Database>(
-  supabaseUrl || 'https://wprkpdqnmibxphiofoqk.supabase.co', 
-  supabaseAnonKey || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndwcmtwZHFubWlieHBoaW9mb3FrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MDk4NTA0ODMsImV4cCI6MjAyNTQyNjQ4M30.sb_publishable_xjn_ruSWUfyiqoMIrQfcOw_-YVtj5lr',
-  {
-    auth: {
-      persistSession: false // Não precisamos de autenticação de usuário
-    },
-    global: {
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
-      }
-    }
-  }
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  SUPABASE_OPTIONS
 );
 
 // Flag para verificar se Supabase está funcionando

--- a/src/lib/supabaseConfig.ts
+++ b/src/lib/supabaseConfig.ts
@@ -1,0 +1,13 @@
+export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || 'https://wprkpdqnmibxphiofoqk.supabase.co';
+export const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || 'sb_publishable_xjn_ruSWUfyiqoMIrQfcOw_-YVtj5lr';
+export const IS_SUPABASE_CONFIGURED = !!(import.meta.env.VITE_SUPABASE_URL && import.meta.env.VITE_SUPABASE_ANON_KEY);
+
+export const SUPABASE_HEADERS = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json'
+};
+
+export const SUPABASE_OPTIONS = {
+  auth: { persistSession: false },
+  global: { headers: SUPABASE_HEADERS }
+};

--- a/src/lib/supabaseLazy.ts
+++ b/src/lib/supabaseLazy.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Database, SimulacaoData, ParceiroData, UserJourneyData, BlogPostData } from './supabase';
+import { SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_OPTIONS } from './supabaseConfig';
 
 // Cache do cliente para evitar múltiplas inicializações
 let supabaseClient: any = null;
@@ -32,28 +33,18 @@ async function loadSupabaseClient() {
   // Inicia o carregamento
   loadingPromise = import('@supabase/supabase-js')
     .then(async ({ createClient }) => {
-      // Configurações do Supabase
-      const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://wprkpdqnmibxphiofoqk.supabase.co';
-      const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'sb_publishable_xjn_ruSWUfyiqoMIrQfcOw_-YVtj5lr';
-
       // Criar cliente
-      const client = createClient<Database>(supabaseUrl, supabaseAnonKey, {
-        auth: {
-          persistSession: false // Não precisamos de autenticação de usuário
-        },
-        global: {
-          headers: {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
-          }
-        }
-      });
+      const client = createClient<Database>(
+        SUPABASE_URL,
+        SUPABASE_ANON_KEY,
+        SUPABASE_OPTIONS
+      );
 
       // Debug apenas em development
       if (typeof window !== 'undefined' && import.meta.env.DEV) {
         console.log('Supabase client loaded lazily');
-        console.log('Supabase URL:', supabaseUrl);
-        console.log('Supabase Key:', supabaseAnonKey?.substring(0, 20) + '...');
+        console.log('Supabase URL:', SUPABASE_URL);
+        console.log('Supabase Key:', SUPABASE_ANON_KEY?.substring(0, 20) + '...');
       }
 
       // Cache do cliente


### PR DESCRIPTION
## Summary
- centralize shared Supabase options in `supabaseConfig`
- use the shared config in both client implementations

## Testing
- `npm run lint` *(fails: 68 errors, 230 warnings)*
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68822acbd5e0832d91a06949c5da1c76