### PR TITLE
Make simulation API configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 
 # API Configuration
 VITE_API_BASE_URL=https://api.exemplo.com
+VITE_SIMULATION_API_URL=https://api-calculos.vercel.app/simulacao
 
 # Ploomes CRM Integration
 VITE_PLOOMES_API_KEY=your_ploomes_api_key_here

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ cp .env.example .env
 # - `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY`
 #   - **Sem valores válidos a aplicação não inicializa**
 # - `VITE_WEBHOOK_URL` (opcional - para webhook de simulações)
+# - `VITE_SIMULATION_API_URL` (opcional - endpoint da API de simulação)
 # - Outras conforme necessário
 ```
 

--- a/src/components/ApiDebugger.tsx
+++ b/src/components/ApiDebugger.tsx
@@ -27,7 +27,8 @@ const ApiDebugger: React.FC = () => {
     try {
       console.log('🔍 Debug: Testando API com', cidade);
       
-      const response = await fetch('https://api-calculos.vercel.app/simulacao', {
+      const apiUrl = import.meta.env.VITE_SIMULATION_API_URL || 'https://api-calculos.vercel.app/simulacao';
+      const response = await fetch(apiUrl, {
         method: 'POST',
         headers: { 
           'Content-Type': 'application/json'

--- a/src/services/blogService.ts
+++ b/src/services/blogService.ts
@@ -890,7 +890,7 @@ export class BlogService {
         carencia: 1,
         
         // URL da API
-        apiUrl: 'https://api-calculos.vercel.app/simulacao',
+        apiUrl: import.meta.env.VITE_SIMULATION_API_URL || 'https://api-calculos.vercel.app/simulacao',
         
         // Configurações gerais
         custoOperacional: 0.5

--- a/src/services/simulationApi.ts
+++ b/src/services/simulationApi.ts
@@ -138,6 +138,7 @@ export const getErrorMessage = (response: any): string => {
  * ```
  */
 export const simulateCredit = async (payload: SimulationPayload): Promise<SimulationResponse> => {
+  const apiUrl = import.meta.env.VITE_SIMULATION_API_URL || 'https://api-calculos.vercel.app/simulacao';
   console.log('Payload enviado:', payload);
   
   // Formatar dados como números simples, não strings
@@ -154,7 +155,7 @@ export const simulateCredit = async (payload: SimulationPayload): Promise<Simula
   console.log('Dados formatados para envio:', formattedData);
 
   try {
-    const response = await fetch('https://api-calculos.vercel.app/simulacao', {
+    const response = await fetch(apiUrl, {
       method: 'POST',
       headers: { 
         'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- make simulation API endpoint configurable via VITE_SIMULATION_API_URL
- add example variable to `.env.example`
- document new setting in README

## Testing
- `npm run lint` *(fails: 68 errors, 230 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68822ac77e88832dadad8c077dd25876