### PR TITLE
Fix analytics snippet and heading styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,12 +276,12 @@
       }
     }
     </script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-XXXXXX"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'UA-XXXXXX', { send_page_view: false });
+      gtag('config', 'G-XXXXXXX', { send_page_view: false });
     </script>
   </head>
 

--- a/src/styles/critical-inline.css
+++ b/src/styles/critical-inline.css
@@ -24,7 +24,12 @@ body {
 html, body { height: 100%; }
 #root { height: 100%; }
 
-h1, h2, h3, h4, h5, h6 { font-weight: 700; }
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 700;
+}
+h1 {
+  font-size: 2em;
+}
 p { font-weight: 300; }
 
 /* Header Critical */


### PR DESCRIPTION
## Summary
- add GA4 snippet
- specify default `h1` font-size so browser updates don't break layout

## Testing
- `npm run lint` *(fails: 301 problems (71 errors, 230 warnings))*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68822e49eb34832db668f1c42d31d3fb