### PR TITLE
Adjust RA banner placement

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -101,6 +101,11 @@ const Footer: React.FC = () => {
               </a>
             </div>
 
+            {/* Selo Reclame Aqui - apenas desktop */}
+            <div className="hidden md:flex justify-center mt-4">
+              <RASeal id="ra-seal-desktop" />
+            </div>
+
             {/* Botão Voltar ao Topo - apenas desktop */}
             <button
               onClick={scrollToTop}
@@ -111,10 +116,9 @@ const Footer: React.FC = () => {
               <span className="hidden md:inline">Voltar ao topo</span>
             </button>
           </div>
-
-          {/* Selo Reclame Aqui - posicionado à direita no desktop e centralizado no mobile */}
-          <div className="col-span-3 md:col-span-1 md:col-start-3 flex justify-center md:justify-end mt-4">
-            <RASeal />
+          {/* Selo Reclame Aqui - mobile */}
+          <div className="col-span-3 md:hidden flex justify-center mt-4">
+            <RASeal id="ra-seal-mobile" />
           </div>
         </div>
 

--- a/src/components/RASeal.tsx
+++ b/src/components/RASeal.tsx
@@ -1,20 +1,26 @@
 import { useEffect } from 'react';
 
-const RASeal = () => {
+interface RASealProps {
+  id?: string;
+}
+
+const RASeal: React.FC<RASealProps> = ({ id = 'ra-verified-seal' }) => {
   useEffect(() => {
-    const container = document.getElementById('ra-verified-seal');
+    const container = document.getElementById(id);
     if (!container) return;
+    // Avoid adding the script multiple times to the same container
+    if (container.querySelector('script')) return;
     const script = document.createElement('script');
     script.type = 'text/javascript';
-    script.id = 'ra-embed-verified-seal';
+    script.id = `ra-embed-verified-seal-${id}`;
     script.src = 'https://s3.amazonaws.com/raichu-beta/ra-verified/bundle.js';
     script.dataset.id = 'Y21PdzlSbG1iOEw4ZWVzMDpsaWJyYS1jcmVkaXRvLXNvbHVjb2VzLWZpbmFuY2VpcmFz';
-    script.dataset.target = 'ra-verified-seal';
+    script.dataset.target = id;
     script.dataset.model = '2';
     container.appendChild(script);
-  }, []);
+  }, [id]);
 
-  return <div id="ra-verified-seal" />;
+  return <div id={id} />;
 };
 
 export default RASeal;


### PR DESCRIPTION
## Summary
- update `RASeal` component to allow custom id
- move RASeal between social icons and "Voltar ao topo" button on desktop
- keep RASeal centered below the button on mobile

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68823547a794832db48f31dc59596323