### PR TITLE
Fix hydration error from React

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { hydrateRoot } from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import App from './App.tsx'
 import './index.css';
 import './styles/overflow-fix.css';
@@ -21,9 +21,9 @@ const setupAccessibility = () => {
 const renderApp = () => {
   setupAccessibility();
   
-  const root = document.getElementById('root');
-  if (root) {
-    hydrateRoot(root, <App />);
+  const rootEl = document.getElementById('root');
+  if (rootEl) {
+    createRoot(rootEl).render(<App />);
   }
 };
 


### PR DESCRIPTION
## Summary
- use `createRoot` instead of `hydrateRoot` when mounting the app

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars etc.)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688238563420832d83066b1ce13a8be8