### PR TITLE
Optimize LCP thumbnail loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,12 @@
         display: block;
         image-rendering: -webkit-optimize-contrast;
         image-rendering: crisp-edges;
+        filter: blur(20px);
+        transition: filter 0.6s ease;
+      }
+
+      .video-thumbnail.loaded {
+        filter: blur(0);
       }
       
       /* Hero video container otimizado */
@@ -319,7 +325,7 @@
               <div class="hero-video aspect-video" style="contain-intrinsic-size:480px 360px; contain:strict; will-change:auto; transform:translateZ(0);">
                 <div class="relative w-full h-full overflow-hidden w-full h-full">
                   <button class="w-full h-full cursor-pointer relative bg-black flex items-center justify-center hero-video group" type="button" aria-label="Reproduzir vídeo: Vídeo institucional Libra Crédito">
-                    <img src="/images/thumbnail-libra.webp" alt="Miniatura do Vídeo institucional Libra Crédito" width="480" height="360" class="video-thumbnail" loading="eager" fetchpriority="high" decoding="sync">
+                    <img id="hero-thumbnail" src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAAAAAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAALABQDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAEC/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/EABUBAQEAAAAAAAAAAAAAAAAAAAAF/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AyIKaICAP/9k=" data-src="/images/thumbnail-libra.webp" alt="Miniatura do Vídeo institucional Libra Crédito" width="480" height="360" class="video-thumbnail blur-up" loading="lazy" fetchpriority="high" decoding="async">
                     <div class="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition-colors duration-200">
                       <div class="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-lg group-hover:bg-red-700 transition-all duration-200 group-hover:scale-105">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play w-8 h-8 md:w-10 md:h-10 text-white ml-1">
@@ -346,6 +352,20 @@
     
     
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        const img = document.getElementById('hero-thumbnail');
+        if (!img) return;
+        const highSrc = img.getAttribute('data-src');
+        if (!highSrc) return;
+        const highImg = new Image();
+        highImg.src = highSrc;
+        highImg.decode().then(() => {
+          img.src = highSrc;
+          img.classList.add('loaded');
+        });
+      });
+    </script>
     
     <!-- Service Worker Registration -->
     <script>

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Play } from 'lucide-react';
 
 interface OptimizedYouTubeProps {
@@ -17,6 +17,8 @@ const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
   thumbnailSrc
 }) => {
   const [isLoaded, setIsLoaded] = useState(false);
+  const [thumbSrc, setThumbSrc] = useState<string>('data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAAAAAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAALABQDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAEC/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/EABUBAQEAAAAAAAAAAAAAAAAAAAAF/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AyIKaICAP/9k=');
+  const [loadedFull, setLoadedFull] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   // Função simplificada para carregamento
@@ -26,6 +28,16 @@ const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
 
   // Usar apenas thumbnail local - sem fallback complexo
   const thumbnailImage = thumbnailSrc || `/images/thumbnail-libra.webp`;
+
+  // Carrega thumbnail em alta resolução assim que possível
+  useEffect(() => {
+    const img = new Image();
+    img.src = thumbnailImage;
+    img.onload = () => {
+      setThumbSrc(thumbnailImage);
+      setLoadedFull(true);
+    };
+  }, [thumbnailImage]);
 
   return (
     <div className={`relative w-full h-full overflow-hidden ${className}`}>
@@ -38,14 +50,14 @@ const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
         >
           {/* Thumbnail otimizada - sem picture element complexo */}
           <img
-            src={thumbnailImage}
+            src={thumbSrc}
             alt={`Miniatura do ${title}`}
             width="480"
             height="360"
-            className="video-thumbnail"
-            loading="eager"
-            fetchPriority="high"
-            decoding="sync"
+            className={`video-thumbnail blur-up${loadedFull ? ' loaded' : ''}`}
+            loading={priority ? 'eager' : 'lazy'}
+            fetchPriority={priority ? 'high' : 'auto'}
+            decoding="async"
           />
 
           {/* Overlay simplificado - usando apenas CSS */}

--- a/src/styles/critical-inline.css
+++ b/src/styles/critical-inline.css
@@ -113,6 +113,12 @@ p { font-weight: 300; }
   width: 100%;
   height: 100%;
   object-fit: cover;
+  filter: blur(20px);
+  transition: filter 0.6s ease;
+}
+
+.video-thumbnail.loaded {
+  filter: blur(0);
 }
 
 /* Loading States */


### PR DESCRIPTION
## Summary
- blur low-quality placeholder for hero video thumbnail
- swap to high-res image once loaded
- add blur-up handling in React component

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68823b73eb18832da343fe8288b45566