### PR TITLE
Improve LCP by loading hero image directly

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,12 +149,6 @@
         display: block;
         image-rendering: -webkit-optimize-contrast;
         image-rendering: crisp-edges;
-        filter: blur(20px);
-        transition: filter 0.6s ease;
-      }
-
-      .video-thumbnail.loaded {
-        filter: blur(0);
       }
       
       /* Hero video container otimizado */
@@ -325,7 +319,7 @@
               <div class="hero-video aspect-video" style="contain-intrinsic-size:480px 360px; contain:strict; will-change:auto; transform:translateZ(0);">
                 <div class="relative w-full h-full overflow-hidden w-full h-full">
                   <button class="w-full h-full cursor-pointer relative bg-black flex items-center justify-center hero-video group" type="button" aria-label="Reproduzir vídeo: Vídeo institucional Libra Crédito">
-                    <img id="hero-thumbnail" src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAAAAAAD/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAALABQDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAEC/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/EABUBAQEAAAAAAAAAAAAAAAAAAAAF/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AyIKaICAP/9k=" data-src="/images/video-thumbnail.webp" alt="Miniatura do Vídeo institucional Libra Crédito" width="480" height="360" class="video-thumbnail blur-up" loading="lazy" fetchpriority="high" decoding="async">
+                    <img id="hero-thumbnail" src="/images/video-thumbnail.webp" alt="Miniatura do Vídeo institucional Libra Crédito" width="480" height="360" class="video-thumbnail" loading="eager" fetchpriority="high" decoding="async">
                     <div class="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition-colors duration-200">
                       <div class="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-lg group-hover:bg-red-700 transition-all duration-200 group-hover:scale-105">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play w-8 h-8 md:w-10 md:h-10 text-white ml-1">
@@ -352,20 +346,7 @@
     
     
     <script type="module" src="/src/main.tsx"></script>
-    <script>
-      document.addEventListener('DOMContentLoaded', function () {
-        const img = document.getElementById('hero-thumbnail');
-        if (!img) return;
-        const highSrc = img.getAttribute('data-src');
-        if (!highSrc) return;
-        const highImg = new Image();
-        highImg.src = highSrc;
-        highImg.decode().then(() => {
-          img.src = highSrc;
-          img.classList.add('loaded');
-        });
-      });
-    </script>
+    
     
     <!-- Service Worker Registration -->
     <script>


### PR DESCRIPTION
## Summary
- load the real hero image directly and eager
- remove lazy-loading script and blur filter for hero image

## Testing
- `npm run lint` *(fails: 70 errors, 230 warnings)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68825729f684832dbcea239a26b5dbb8