### PR TITLE
Add typewriter effect for hero sections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "sharp": "^0.34.3",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
+        "typed.js": "^2.1.0",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -6435,6 +6436,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/typed.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed.js/-/typed.js-2.1.0.tgz",
+      "integrity": "sha512-bDuXEf7YcaKN4g08NMTUM6G90XU25CK3bh6U0THC/Mod/QPKlEt9g/EjvbYB8x2Qwr2p6J6I3NrsoYaVnY6wsQ==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.8.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sharp": "^0.34.3",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "typed.js": "^2.1.0",
     "uuid": "^10.0.0"
   },
   "devDependencies": {

--- a/src/components/HeroAnimated.tsx
+++ b/src/components/HeroAnimated.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
+import TypewriterText from './TypewriterText';
 import HeroButton from '@/components/ui/HeroButton';
 import { ChevronDown, Shield } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -18,38 +19,6 @@ const HeroAnimated: React.FC = () => {
     "Consolidação Estratégica de Débitos"
   ];
 
-  const [currentTextIndex, setCurrentTextIndex] = useState(0);
-  const [fadeClass, setFadeClass] = useState('opacity-100');
-
-  useEffect(() => {
-    let intervalId: NodeJS.Timeout;
-    let timeoutId: NodeJS.Timeout;
-    
-    const animateText = () => {
-      // Fade out
-      setFadeClass('opacity-0');
-      
-      // Após fade out, trocar texto e fazer fade in
-      timeoutId = setTimeout(() => {
-        setCurrentTextIndex((prev) => {
-          const nextIndex = (prev + 1) % alternatingTexts.length;
-          return nextIndex;
-        });
-        // Pequeno delay para garantir que o texto mudou antes do fade in
-        setTimeout(() => {
-          setFadeClass('opacity-100');
-        }, 50);
-      }, 400);
-    };
-
-    // Começar animação após 3 segundos da montagem
-    intervalId = setInterval(animateText, 3000);
-
-    return () => {
-      if (intervalId) clearInterval(intervalId);
-      if (timeoutId) clearTimeout(timeoutId);
-    };
-  }, []);
 
   const scrollToSimulator = () => {
     navigate('/simulacao');
@@ -102,11 +71,7 @@ const HeroAnimated: React.FC = () => {
                 id="hero-heading"
                 className="text-xl md:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight"
               >
-                <span 
-                  className={`block whitespace-nowrap transition-opacity duration-500 ${fadeClass}`}
-                >
-                  {alternatingTexts[currentTextIndex]}
-                </span>
+                <TypewriterText strings={alternatingTexts} />
                 <span className="block text-green-700">é na Libra!</span>
               </h1>
               

--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import TypewriterText from './TypewriterText';
 import HeroButton from '@/components/ui/HeroButton';
 import { ChevronDown, Shield } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -8,6 +9,14 @@ import { useIsMobile } from '@/hooks/use-mobile';
 const HeroPremium: React.FC = () => {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
+
+  const alternatingTexts = [
+    'Crédito com Garantia de Imóvel',
+    'Home Equity',
+    'Capital de Giro Inteligente',
+    'Empréstimo com Garantia de Imóvel',
+    'Consolidação Estratégica de Débitos',
+  ];
 
   const scrollToSimulator = () => {
     navigate('/simulacao');
@@ -60,7 +69,7 @@ const HeroPremium: React.FC = () => {
                 id="hero-heading"
                 className="text-xl md:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight"
               >
-                <span className="block whitespace-nowrap">Crédito com Garantia de Imóvel</span>
+                <TypewriterText strings={alternatingTexts} />
                 <span className="block text-green-700">é mais simples na Libra!</span>
               </h1>
               <ul className="mt-2 space-y-1 text-sm md:text-base lg:text-lg text-[#003399] font-medium">

--- a/src/components/TypewriterText.tsx
+++ b/src/components/TypewriterText.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'react';
+import Typed from 'typed.js';
+
+export default function TypewriterText({ strings }: { strings: string[] }) {
+  const el = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const typed = new Typed(el.current!, {
+      strings,
+      typeSpeed: 50,
+      backSpeed: 30,
+      backDelay: 1500,
+      loop: true,
+    });
+    return () => typed.destroy();
+  }, [strings]);
+
+  return <span ref={el} />;
+}


### PR DESCRIPTION
## Summary
- add typed.js dependency
- create `TypewriterText` component using typed.js
- show animated hero heading using `TypewriterText`
- update premium hero to use typewriter text

## Testing
- `npm run lint` *(fails: 70 errors, 240 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6888c1ec4974832db06add6143a243d5