### PR TITLE
Update font to Comfortaa

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
     <title>Libra Crédito | Empréstimo com Garantia de Imóvel</title>
     <meta name="description" content="Crédito com garantia de imóvel com as melhores taxas do mercado." />
     
-    <!-- Performance Critical Resource Hints -->
-    <link rel="preload" href="/fonts/Montserrat-Regular.ttf" as="font" type="font/ttf" crossorigin>
-    <link rel="preload" href="/fonts/Montserrat-Bold.ttf" as="font" type="font/ttf" crossorigin>
-    <link rel="preload" href="/fonts/Montserrat-Thin.ttf" as="font" type="font/ttf" crossorigin>
+    <!-- Google Font -->
+    <style>
+    @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap');
+    </style>
 
     <!-- Main stylesheet -->
     <link rel="stylesheet" href="/assets/css/index.css">
@@ -54,7 +54,7 @@
       body {
         line-height: 1.5;
         -webkit-font-smoothing: antialiased;
-        font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+        font-family: 'Comfortaa', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
         font-weight: 300;
         background: #ffffff;
         overflow-x: hidden;

--- a/src/components/ModernCTA.tsx
+++ b/src/components/ModernCTA.tsx
@@ -62,14 +62,14 @@ const ModernCTA: React.FC<ModernCTAProps> = ({
               </div>
             </div>
 
-            {/* Título com efeito usando Montserrat */}
+            {/* Título com efeito usando Comfortaa */}
             <h2 className={`${isMobile ? 'text-2xl' : 'text-3xl lg:text-4xl'} font-bold mb-4 text-white relative font-sans`}>
               <span className="bg-gradient-to-r from-white via-[#00ccff]/80 to-white bg-clip-text text-transparent">
                 {title}
               </span>
             </h2>
 
-            {/* Subtítulo usando Montserrat */}
+            {/* Subtítulo usando Comfortaa */}
             <p className={`${isMobile ? 'text-base px-2' : 'text-lg'} mb-8 text-gray-300 max-w-2xl mx-auto leading-relaxed font-sans`}>
               {subtitle}
             </p>
@@ -119,7 +119,7 @@ const ModernCTA: React.FC<ModernCTAProps> = ({
               </Button>
             </div>
 
-            {/* Texto de segurança usando Montserrat */}
+            {/* Texto de segurança usando Comfortaa */}
             <p className="mt-6 text-sm text-gray-400 font-sans">
               🔒 Simulação gratuita e sem compromisso • Dados protegidos
             </p>

--- a/src/index.css
+++ b/src/index.css
@@ -1,26 +1,4 @@
-@font-face {
-  font-family: 'Montserrat';
-  src: url('/fonts/Montserrat-Regular.ttf') format('truetype');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Montserrat';
-  src: url('/fonts/Montserrat-Bold.ttf') format('truetype');
-  font-weight: 700;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Montserrat';
-  src: url('/fonts/Montserrat-Thin.ttf') format('truetype');
-  font-weight: 100;
-  font-style: normal;
-  font-display: swap;
-}
+@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/src/styles/critical-inline.css
+++ b/src/styles/critical-inline.css
@@ -7,7 +7,7 @@
 body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-family: 'Comfortaa', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-weight: 300;
   background: #ffffff;
   overflow-x: hidden;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,9 +28,9 @@ export default {
                         '2xl': '1536px',  // Desktop grande
                 },
 		extend: {
-			fontFamily: {
-				sans: ['Montserrat', 'sans-serif'],
-			},
+                        fontFamily: {
+                                sans: ['Comfortaa', 'sans-serif'],
+                        },
 			// Tamanhos de fonte otimizados para mobile
 			fontSize: {
 				'xs': ['0.75rem', { lineHeight: '1rem' }],


### PR DESCRIPTION
## Summary
- use Comfortaa font from Google Fonts instead of Montserrat
- update Tailwind config default sans font
- tweak critical CSS and inline styles
- adjust comments referencing the font

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888c8830d94832d90a497efe37c58ab