### PR TITLE
Adjust hero text placement

### DIFF
--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -81,9 +81,6 @@ const HeroPremium: React.FC = () => {
                   Taxas a partir de <span className="font-bold text-green-700">1,19% a.m.</span> • Até 180 meses • 100% online
                 </li>
               </ul>
-              <p className="text-lg md:text-xl lg:text-2xl text-[#003399] font-semibold">
-                Crédito inteligente para quem construiu patrimonio.
-              </p>
             </div>
 
             {/* Botões */}
@@ -103,7 +100,7 @@ const HeroPremium: React.FC = () => {
             </div>
           </div>
 
-            <div className="w-full max-w-xl lg:max-w-lg xl:max-w-none mx-auto">
+            <div className="w-full max-w-lg lg:max-w-md xl:max-w-none mx-auto">
             <div className="hero-video aspect-video">
               <OptimizedYouTube
                 videoId="E9lwL6R2l1s"
@@ -113,6 +110,9 @@ const HeroPremium: React.FC = () => {
                 thumbnailSrc="/images/optimized/video-thumbnail.webp"
               />
             </div>
+            <p className="text-lg md:text-xl lg:text-2xl text-[#003399] font-semibold mt-2 text-center">
+              Crédito inteligente para quem construiu patrimonio.
+            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- rearrange `HeroPremium` markup so the 'Crédito inteligente...' tagline appears below the video
- slightly reduce hero video width on desktop

## Testing
- `npm run lint` *(fails: 70 errors, 240 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6888d25b1c70832d99a39e66b3bb83c1