### PR TITLE
Adjust hero video sizing

### DIFF
--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -77,26 +77,26 @@ const HeroPremium: React.FC = () => {
                   <Shield className="w-4 h-4 md:w-5 md:h-5 flex-shrink-0" aria-hidden="true" />
                   <span className="text-center">Atendimento Premium, Segurança e Velocidade!</span>
                 </li>
+                <li className="list-none">
+                  <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full max-w-sm mx-auto pt-3 sm:pt-4">
+                    <HeroButton
+                      onClick={scrollToSimulator}
+                      variant="primary"
+                    >
+                      Simular Agora
+                    </HeroButton>
+                    <HeroButton
+                      onClick={goToVantagens}
+                      variant="secondary"
+                    >
+                      Conheça as Vantagens
+                    </HeroButton>
+                  </div>
+                </li>
                 <li>
                   Taxas a partir de <span className="font-bold text-green-700">1,19% a.m.</span> • Até 180 meses • 100% online
                 </li>
               </ul>
-            </div>
-
-            {/* Botões */}
-            <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full max-w-sm mx-auto pt-3 sm:pt-4">
-              <HeroButton
-                onClick={scrollToSimulator}
-                variant="primary"
-              >
-                Simular Agora
-              </HeroButton>
-              <HeroButton
-                onClick={goToVantagens}
-                variant="secondary"
-              >
-                Conheça as Vantagens
-              </HeroButton>
             </div>
           </div>
 

--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -81,9 +81,6 @@ const HeroPremium: React.FC = () => {
                   Taxas a partir de <span className="font-bold text-green-700">1,19% a.m.</span> • Até 180 meses • 100% online
                 </li>
               </ul>
-              <p className="text-lg md:text-xl lg:text-2xl text-[#003399] font-semibold">
-                Crédito inteligente para quem construiu patrimonio.
-              </p>
             </div>
 
             {/* Botões */}
@@ -103,7 +100,8 @@ const HeroPremium: React.FC = () => {
             </div>
           </div>
 
-            <div className="w-full max-w-xl lg:max-w-lg xl:max-w-none mx-auto">
+            {/* Vídeo reduzido para exibir as ondas seguintes na dobra inicial */}
+            <div className="w-full max-w-md mx-auto">
             <div className="hero-video aspect-video">
               <OptimizedYouTube
                 videoId="E9lwL6R2l1s"
@@ -113,6 +111,9 @@ const HeroPremium: React.FC = () => {
                 thumbnailSrc="/images/optimized/video-thumbnail.webp"
               />
             </div>
+            <p className="text-lg md:text-xl lg:text-2xl text-[#003399] font-semibold mt-2 text-center">
+              Crédito inteligente para quem construiu patrimonio.
+            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- reduce the hero video max width so the waves are visible on desktop
- keep tagline below the video

## Testing
- `npm run lint` *(fails: 70 errors, 240 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6888d25b1c70832d99a39e66b3bb83c1