### PR TITLE
Remove extra hero button

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,7 +419,6 @@
               </div>
               <div class="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full max-w-sm mx-auto pt-3 sm:pt-4">
                 <button class="w-full cta-button px-6 py-3 text-sm sm:px-8 sm:py-4 sm:text-base font-bold bg-gradient-to-r from-[#003399] to-[#0055CC] text-white" type="button">Simular Agora</button>
-                <button class="w-full cta-button px-6 py-3 text-sm sm:px-8 sm:py-4 sm:text-base font-bold bg-transparent border-2 border-[#003399] text-[#003399] hover:bg-[#003399] hover:text-white" type="button">Conheça as Vantagens</button>
               </div>
             </div>
             <div class="w-full max-w-xl lg:max-w-lg xl:max-w-none mx-auto">

--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -22,9 +22,6 @@ const HeroPremium: React.FC = () => {
     navigate('/simulacao');
   };
 
-  const goToVantagens = () => {
-    navigate('/vantagens');
-  };
 
   const scrollToBenefits = () => {
     const card = document.getElementById('capital-giro-card');
@@ -84,12 +81,6 @@ const HeroPremium: React.FC = () => {
                       variant="primary"
                     >
                       Simular Agora
-                    </HeroButton>
-                    <HeroButton
-                      onClick={goToVantagens}
-                      variant="secondary"
-                    >
-                      Conheça as Vantagens
                     </HeroButton>
                   </div>
                 </li>


### PR DESCRIPTION
## Summary
- remove the button linking to the advantages page from the hero section
- keep only the "Simular Agora" call to action

## Testing
- `npm run lint` *(fails: 70 errors, 240 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68890c615e3c832d89b4086b61bdeab3