### PR TITLE
Add scroll helper and refactor scroll calls

### DIFF
--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -4,6 +4,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import { Button } from '@/components/ui/button';
 import { Link, useNavigate } from 'react-router-dom';
 import WaveSeparator from '@/components/ui/WaveSeparator';
+import scrollToTarget from '@/utils/scrollToTarget';
 
 const usageOptions = [
   {
@@ -130,28 +131,19 @@ const Benefits: React.FC = () => {
                 onClick={() => {
                   const testimonialsSection = document.getElementById('testimonials');
                   if (testimonialsSection) {
-                    const videoContainer = testimonialsSection.querySelector('.aspect-video');
+                    const videoContainer = testimonialsSection.querySelector('.aspect-video') as HTMLElement | null;
                     const extraOffset = window.innerHeight * 0.15; // Deslocamento adicional de 15%
+
                     if (videoContainer) {
-                      const rect = videoContainer.getBoundingClientRect();
                       const windowHeight = window.innerHeight;
                       const headerOffset = 120;
-                      const centerOffset = (windowHeight - rect.height) / 2;
-                      const targetPosition = rect.top + window.pageYOffset - centerOffset - headerOffset + extraOffset;
-
-                      window.scrollTo({
-                        top: targetPosition,
-                        behavior: 'smooth'
-                      });
+                      const centerOffset =
+                        (windowHeight - videoContainer.getBoundingClientRect().height) / 2;
+                      const offset = -centerOffset - headerOffset + extraOffset;
+                      scrollToTarget(videoContainer, offset);
                     } else {
                       const headerOffset = 120;
-                      const rect = testimonialsSection.getBoundingClientRect();
-                      const offsetPosition = rect.top + window.pageYOffset - headerOffset + extraOffset;
-
-                      window.scrollTo({
-                        top: offsetPosition,
-                        behavior: 'smooth'
-                      });
+                      scrollToTarget(testimonialsSection as HTMLElement, -headerOffset + extraOffset);
                     }
                   }
                 }}

--- a/src/components/HeroAnimated.tsx
+++ b/src/components/HeroAnimated.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, Shield } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import OptimizedYouTube from './OptimizedYouTube';
 import { useIsMobile } from '@/hooks/use-mobile';
+import scrollToTarget from '@/utils/scrollToTarget';
 
 const HeroAnimated: React.FC = () => {
   const navigate = useNavigate();
@@ -34,22 +35,14 @@ const HeroAnimated: React.FC = () => {
     if (card) {
       const headerOffset = window.innerWidth < 768 ? 96 : 108;
       const trustbarRect = trustbar?.getBoundingClientRect();
-      const cardRect = card.getBoundingClientRect();
       const trustbarHeight = trustbarRect ? trustbarRect.height : 0;
-      const cardHeight = cardRect.height;
-      const centerOffset = (window.innerHeight - cardHeight) / 2;
-      const baseTarget =
-        cardRect.top +
-        window.pageYOffset -
-        headerOffset -
-        trustbarHeight -
-        centerOffset;
-
+      const centerOffset =
+        (window.innerHeight - card.getBoundingClientRect().height) / 2;
       const isMobileView = window.innerWidth < 768;
       const additionalScroll = window.innerHeight * (isMobileView ? 0.22 : 0.18);
-      const target = baseTarget + additionalScroll;
+      const offset = -headerOffset - trustbarHeight - centerOffset + additionalScroll;
 
-      window.scrollTo({ top: target, behavior: 'smooth' });
+      scrollToTarget(card as HTMLElement, offset);
     }
   };
 

--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, Shield } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import OptimizedYouTube from './OptimizedYouTube';
 import { useIsMobile } from '@/hooks/use-mobile';
+import scrollToTarget from '@/utils/scrollToTarget';
 
 const HeroPremium: React.FC = () => {
   const navigate = useNavigate();
@@ -29,22 +30,14 @@ const HeroPremium: React.FC = () => {
     if (card) {
       const headerOffset = window.innerWidth < 768 ? 96 : 108;
       const trustbarRect = trustbar?.getBoundingClientRect();
-      const cardRect = card.getBoundingClientRect();
       const trustbarHeight = trustbarRect ? trustbarRect.height : 0;
-      const cardHeight = cardRect.height;
-      const centerOffset = (window.innerHeight - cardHeight) / 2;
-      const baseTarget =
-        cardRect.top +
-        window.pageYOffset -
-        headerOffset -
-        trustbarHeight -
-        centerOffset;
-
+      const centerOffset =
+        (window.innerHeight - card.getBoundingClientRect().height) / 2;
       const isMobileView = window.innerWidth < 768;
       const additionalScroll = window.innerHeight * (isMobileView ? 0.22 : 0.18);
-      const target = baseTarget + additionalScroll;
+      const offset = -headerOffset - trustbarHeight - centerOffset + additionalScroll;
 
-      window.scrollTo({ top: target, behavior: 'smooth' });
+      scrollToTarget(card as HTMLElement, offset);
     }
   };
 

--- a/src/components/form/CityAutocomplete.tsx
+++ b/src/components/form/CityAutocomplete.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { MapPin } from 'lucide-react';
 import { searchCities } from '@/utils/cityLtvService';
+import scrollToTarget from '@/utils/scrollToTarget';
 
 interface CityAutocompleteProps {
   value?: string;
@@ -65,19 +66,12 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
 
   // Function to scroll input to top of viewport
   const scrollToInput = (): void => {
-    if (inputRef.current && window.innerWidth < 768) { // Only on mobile
+    if (inputRef.current && window.innerWidth < 768) {
       setTimeout(() => {
         if (!inputRef.current) return;
-        const headerHeight = 80; // Approximate header height
-        const rect = inputRef.current.getBoundingClientRect();
-        const elementTop = rect.top + window.pageYOffset;
-        const targetPosition = elementTop - headerHeight;
-        
-        window.scrollTo({
-          top: targetPosition,
-          behavior: 'smooth'
-        });
-      }, 300); // Delay to allow keyboard to appear
+        const headerHeight = 80;
+        scrollToTarget(inputRef.current as HTMLElement, -headerHeight);
+      }, 300);
     }
   };
 

--- a/src/utils/scrollToTarget.ts
+++ b/src/utils/scrollToTarget.ts
@@ -1,0 +1,13 @@
+export const scrollToTarget = (
+  element: HTMLElement | null,
+  offset = 0
+): void => {
+  if (!element) return;
+  const rect = element.getBoundingClientRect();
+  const top = rect.top + window.pageYOffset + offset;
+  requestAnimationFrame(() => {
+    window.scrollTo({ top, behavior: 'smooth' });
+  });
+};
+
+export default scrollToTarget;


### PR DESCRIPTION
## Summary
- implement `scrollToTarget` utility for smooth scrolling
- refactor direct `window.scrollTo` logic in Benefits, Hero components and CityAutocomplete

## Testing
- `npm run lint` *(fails: 70 errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6889167274e4832da675822ef9c846bb