### PR TITLE
Adjust hero layout spacing

### DIFF
--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -4,12 +4,10 @@ import HeroButton from '@/components/ui/HeroButton';
 import { ChevronDown, Shield } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import OptimizedYouTube from './OptimizedYouTube';
-import { useIsMobile } from '@/hooks/use-mobile';
 import scrollToTarget from '@/utils/scrollToTarget';
 
 const HeroPremium: React.FC = () => {
   const navigate = useNavigate();
-  const isMobile = useIsMobile();
 
   const alternatingTexts = [
     'Crédito com Garantia de Imóvel',
@@ -42,14 +40,14 @@ const HeroPremium: React.FC = () => {
 
   return (
     <section
-      className="min-h-[60vh] md:min-h-[65vh] lg:min-h-[70vh] xl:min-h-[calc(100vh-280px)] py-4 md:py-8 bg-white relative flex flex-col justify-center"
+      className="min-h-[55vh] md:min-h-[50vh] lg:min-h-[55vh] xl:min-h-[calc(100vh-320px)] py-3 md:py-6 bg-white relative flex flex-col justify-center"
       aria-labelledby="hero-heading"
       role="banner"
     >
       <div className="container mx-auto px-4 md:px-6 relative z-10 flex-grow flex flex-col justify-center">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-8 items-center">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6 items-center">
           {/* Lado Esquerdo */}
-          <div className="text-[#003399] max-w-lg mx-auto space-y-4 md:space-y-5 text-center flex flex-col items-center">
+          <div className="text-[#003399] max-w-lg mx-auto space-y-3 md:space-y-4 text-center flex flex-col items-center">
             <div>
               <h1
                 id="hero-heading"
@@ -60,7 +58,7 @@ const HeroPremium: React.FC = () => {
                   é mais simples na Libra!
                 </span>
               </h1>
-              <ul className="mt-2 space-y-2 md:space-y-3 text-sm md:text-base lg:text-lg text-[#003399] font-medium">
+              <ul className="mt-2 space-y-1 md:space-y-2 text-sm md:text-base lg:text-base text-[#003399] font-medium lg:scale-[0.85]">
                 <li className="flex items-center justify-center gap-2 bg-green-50 rounded-md py-1 px-2">
                   <Shield
                     className="w-4 h-4 md:w-5 md:h-5 flex-shrink-0"
@@ -71,13 +69,13 @@ const HeroPremium: React.FC = () => {
                   </span>
                 </li>
                 <li className="list-none">
-                  <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full max-w-sm mx-auto pt-2 sm:pt-3">
+                  <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full max-w-sm mx-auto pt-1 sm:pt-2 lg:scale-[0.85]">
                     <HeroButton onClick={scrollToSimulator} variant="primary">
                       Simular Agora
                     </HeroButton>
                   </div>
                 </li>
-                <li className="mt-2 lg:mt-4 text-sm md:text-lg lg:text-2xl">
+                <li className="mt-1 lg:mt-2 text-sm md:text-lg lg:text-xl">
                   Taxas a partir de{' '}
                   <span className="font-bold text-green-700">1,19% a.m.</span> •
                   Até 180 meses • 100% online
@@ -87,7 +85,7 @@ const HeroPremium: React.FC = () => {
           </div>
 
           {/* Vídeo reduzido para exibir as ondas seguintes na dobra inicial */}
-          <div className="w-full max-w-md lg:w-[85%] lg:max-w-lg mx-auto">
+          <div className="w-full max-w-md lg:w-[85%] lg:max-w-lg mx-auto lg:scale-[0.85]">
             <div className="hero-video aspect-video">
               <OptimizedYouTube
                 videoId="E9lwL6R2l1s"
@@ -97,14 +95,14 @@ const HeroPremium: React.FC = () => {
                 thumbnailSrc="/images/optimized/video-thumbnail.webp"
               />
             </div>
-            <p className="text-lg md:text-xl lg:text-2xl text-[#003399] font-semibold mt-3 text-center">
+            <p className="text-lg md:text-xl lg:text-xl text-[#003399] font-semibold mt-2 text-center lg:scale-[0.85]">
               Crédito inteligente para quem construiu patrimônio.
             </p>
           </div>
         </div>
 
         {/* Botão Saiba Mais */}
-        <div className="flex justify-center mt-5 md:mt-7">
+        <div className="flex justify-center mt-4 md:mt-6 lg:scale-[0.85]">
           <button
             onClick={scrollToBenefits}
             className="text-[#003399] flex flex-col items-center gap-1 opacity-90 hover:opacity-100 transition-opacity"

--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -23,6 +23,7 @@ const HeroPremium: React.FC = () => {
 
   const scrollToBenefits = () => {
     const card = document.getElementById('capital-giro-card');
+    const trustbar = document.getElementById('trustbar');
     if (card) {
       const headerOffset = window.innerWidth < 768 ? 96 : 108;
       const trustbarRect = trustbar?.getBoundingClientRect();
@@ -40,25 +41,25 @@ const HeroPremium: React.FC = () => {
 
   return (
     <section
-      className="min-h-[55vh] md:min-h-[50vh] lg:min-h-[55vh] xl:min-h-[calc(100vh-320px)] py-3 md:py-6 bg-white relative flex flex-col justify-center"
+      className="min-h-[50vh] md:min-h-[45vh] lg:min-h-[50vh] xl:min-h-[calc(100vh-340px)] py-2 md:py-4 bg-white relative flex flex-col justify-center"
       aria-labelledby="hero-heading"
       role="banner"
     >
       <div className="container mx-auto px-4 md:px-6 relative z-10 flex-grow flex flex-col justify-center">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6 items-center">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 lg:gap-4 items-center">
           {/* Lado Esquerdo */}
-          <div className="text-[#003399] max-w-lg mx-auto space-y-3 md:space-y-4 text-center flex flex-col items-center">
+          <div className="text-[#003399] max-w-lg mx-auto space-y-2 md:space-y-3 text-center flex flex-col items-center">
             <div>
               <h1
                 id="hero-heading"
-                className="text-xl md:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight"
+                className="text-xl md:text-3xl lg:text-4xl font-extrabold mb-3 leading-tight"
               >
                 <TypewriterText strings={alternatingTexts} />
                 <span className="block text-green-700">
                   é mais simples na Libra!
                 </span>
               </h1>
-              <ul className="mt-2 space-y-1 md:space-y-2 text-sm md:text-base lg:text-base text-[#003399] font-medium lg:scale-[0.85]">
+              <ul className="mt-1 space-y-1 md:space-y-2 text-sm md:text-base lg:text-base text-[#003399] font-medium lg:scale-[0.85]">
                 <li className="flex items-center justify-center gap-2 bg-green-50 rounded-md py-1 px-2">
                   <Shield
                     className="w-4 h-4 md:w-5 md:h-5 flex-shrink-0"
@@ -69,7 +70,7 @@ const HeroPremium: React.FC = () => {
                   </span>
                 </li>
                 <li className="list-none">
-                  <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full max-w-sm mx-auto pt-1 sm:pt-2 lg:scale-[0.85]">
+                  <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full max-w-sm mx-auto pt-0 sm:pt-1 lg:scale-[0.85]">
                     <HeroButton onClick={scrollToSimulator} variant="primary">
                       Simular Agora
                     </HeroButton>
@@ -95,14 +96,14 @@ const HeroPremium: React.FC = () => {
                 thumbnailSrc="/images/optimized/video-thumbnail.webp"
               />
             </div>
-            <p className="text-lg md:text-xl lg:text-xl text-[#003399] font-semibold mt-2 text-center lg:scale-[0.85]">
+            <p className="text-lg md:text-xl lg:text-xl text-[#003399] font-semibold mt-1 text-center lg:scale-[0.85]">
               Crédito inteligente para quem construiu patrimônio.
             </p>
           </div>
         </div>
 
         {/* Botão Saiba Mais */}
-        <div className="flex justify-center mt-4 md:mt-6 lg:scale-[0.85]">
+        <div className="flex justify-center mt-3 md:mt-5 lg:scale-[0.85]">
           <button
             onClick={scrollToBenefits}
             className="text-[#003399] flex flex-col items-center gap-1 opacity-90 hover:opacity-100 transition-opacity"


### PR DESCRIPTION
## Summary
- tighten hero layout spacing
- keep scaled-down video and text but remove unused mobile hook

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68892fabf684832dabd08bdcd6d74960