### PR TITLE
Reduce header logo size

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -113,9 +113,9 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
                   <img
                     src="/images/optimized/logo-header.webp"
                     alt="Libra Crédito - Home Equity com garantia de imóvel"
-                    className="h-[85%] w-auto pointer-events-none max-w-none"
-                    width="150"
-                    height="150"
+                    className="h-[68%] w-auto pointer-events-none max-w-none"
+                    width="120"
+                    height="120"
                   />
                 </div>
               </Link>

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -69,7 +69,9 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
                 <img
                   src="/images/optimized/logo-header.webp"
                   alt="Libra Crédito"
-                  className="h-[85%] w-auto pointer-events-none max-w-none"
+                  className="h-[68%] w-auto pointer-events-none max-w-none"
+                  width="120"
+                  height="120"
                 />
               </div>
             </Link>

--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -40,9 +40,9 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
             <img
               src="/images/optimized/logo-header.webp"
               alt="Libra Crédito - Simulação de crédito com garantia de imóvel"
-              className="h-[85%] w-auto pointer-events-none max-w-none"
-              width="150"
-              height="150"
+              className="h-[68%] w-auto pointer-events-none max-w-none"
+              width="120"
+              height="120"
             />
           </div>
         </Link>


### PR DESCRIPTION
## Summary
- shrink header logo in DesktopHeader, MobileHeader, SimpleMobileHeader

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688a1a62e884832dbf93f70e74cab694