### PR TITLE
Fix Safari idle callback

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx'
 import './index.css';
 import './styles/overflow-fix.css';
+import { requestIdleCallback as requestIdleCb } from './utils/performance';
 
 // Renderização direta com createRoot para LCP otimizado
 const renderApp = () => {
@@ -10,7 +11,7 @@ const renderApp = () => {
   document.documentElement.lang = 'pt-BR';
   
   // Skip Link para acessibilidade - lazy load
-  requestIdleCallback(() => {
+  requestIdleCb(() => {
     const skipLink = document.createElement('a');
     skipLink.href = '#main-content';
     skipLink.className = 'sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-white focus:text-libra-navy focus:rounded';


### PR DESCRIPTION
## Summary
- use `requestIdleCallback` polyfill to initialize accessibility skip link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a2c55e468832db679ea4d01150afe