### PR TITLE
Fix hero text placement on mobile

### DIFF
--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -77,15 +77,6 @@ const HeroPremium: React.FC = () => {
                 <li className="text-lg md:text-xl lg:text-2xl">
                   Crédito inteligente para quem construiu patrimônio!
                 </li>
-                <li className="flex items-center justify-center gap-2 bg-green-50 rounded-md py-1 px-2 lg:hidden">
-                  <Shield
-                    className="w-4 h-4 md:w-5 md:h-5 flex-shrink-0"
-                    aria-hidden="true"
-                  />
-                  <span className="text-center">
-                    Atendimento Premium, Segurança e Velocidade!
-                  </span>
-                </li>
               </ul>
             </div>
           </div>
@@ -101,9 +92,16 @@ const HeroPremium: React.FC = () => {
                 thumbnailSrc="/images/optimized/video-thumbnail.webp"
               />
             </div>
+            {/* Texto abaixo do vídeo em telas mobile */}
+            <div className="flex lg:hidden items-center justify-center gap-2 bg-green-50 rounded-md py-1 px-2 mt-2">
+              <Shield className="w-4 h-4 md:w-5 md:h-5 flex-shrink-0" aria-hidden="true" />
+              <span className="text-center text-[#003399]">
+                Atendimento Premium, Segurança e Velocidade!
+              </span>
+            </div>
             <div className="hidden lg:flex items-center justify-center gap-2 bg-green-50 rounded-md py-1 px-2 mt-2">
               <Shield className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
-              <span className="text-center">
+              <span className="text-center text-[#003399]">
                 Atendimento Premium, Segurança e Velocidade!
               </span>
             </div>


### PR DESCRIPTION
## Summary
- remove the premium text from the hero list
- show "Atendimento Premium, Segurança e Velocidade!" below the video on mobile
- color the premium text using `text-[#003399]`

## Testing
- `npm run lint` *(fails: 66 errors, 237 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688a36948bf4832d84fd0f74a2178f47