### PR TITLE
Fix hero shield icon color

### DIFF
--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -95,14 +95,14 @@ const HeroPremium: React.FC = () => {
             </div>
             {/* Texto abaixo do vídeo em telas mobile */}
             <div className="flex lg:hidden items-center justify-center gap-2 bg-green-50 rounded-md py-1 px-2 mt-2">
-              <Shield className="w-4 h-4 md:w-5 md:h-5 flex-shrink-0" aria-hidden="true" />
+              <Shield className="w-4 h-4 md:w-5 md:h-5 flex-shrink-0 text-[#003399]" aria-hidden="true" />
               <span className="text-center text-[#003399]">
 
                 Atendimento Premium, Segurança e Velocidade!
               </span>
             </div>
             <div className="hidden lg:flex items-center justify-center gap-2 bg-green-50 rounded-md py-1 px-2 mt-2">
-              <Shield className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+              <Shield className="w-4 h-4 flex-shrink-0 text-[#003399]" aria-hidden="true" />
               <span className="text-center text-[#003399]">
                 Atendimento Premium, Segurança e Velocidade!
               </span>


### PR DESCRIPTION
## Summary
- color the shield icon by the premium banner text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and then many lint errors)*
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a42add2c4832d8ad2f4086817bfb1