### PR TITLE
Ensure LTV validation only after city check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.9.0",
+        "@eslint/js": "^9.32.0",
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.31.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
-      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
+      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3779,6 +3779,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.9.0",
+    "@eslint/js": "^9.32.0",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/src/components/LocalSimulationForm.tsx
+++ b/src/components/LocalSimulationForm.tsx
@@ -86,7 +86,7 @@ const LocalSimulationForm: React.FC = () => {
     }
   }, [cidade]);
 
-  // Validar LTV quando valores ou cidade validada mudarem
+  // Validar LTV quando valores ou validação da cidade mudarem
   useEffect(() => {
     const empValue = norm(valorEmprestimo);
     const imValue = norm(valorImovel);
@@ -103,7 +103,7 @@ const LocalSimulationForm: React.FC = () => {
     } else {
       setLtvValidation(null);
     }
-  }, [valorEmprestimo, valorImovel, cidade, cityValidation]);
+  }, [valorEmprestimo, valorImovel, cityValidation]);
 
   const handleCitySelect = useCallback((selectedCity: string) => {
     setCidade(selectedCity);

--- a/src/components/LocalSimulationForm.tsx
+++ b/src/components/LocalSimulationForm.tsx
@@ -86,19 +86,24 @@ const LocalSimulationForm: React.FC = () => {
     }
   }, [cidade]);
 
-  // Validar LTV quando valores mudarem
+  // Validar LTV quando valores ou cidade validada mudarem
   useEffect(() => {
     const empValue = norm(valorEmprestimo);
     const imValue = norm(valorImovel);
-    
-    if (empValue > 0 && imValue > 0 && cidade) {
+
+    if (
+      empValue > 0 &&
+      imValue > 0 &&
+      cidade &&
+      cityValidation?.allowCalculation
+    ) {
       validateLTV(empValue, imValue, cidade).then(validation => {
         setLtvValidation(validation);
       });
     } else {
       setLtvValidation(null);
     }
-  }, [valorEmprestimo, valorImovel, cidade]);
+  }, [valorEmprestimo, valorImovel, cidade, cityValidation]);
 
   const handleCitySelect = useCallback((selectedCity: string) => {
     setCidade(selectedCity);


### PR DESCRIPTION
## Summary
- check city validation before running LTV check

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a5c27793c832da5c936e27e202671