### PR TITLE
Update result colors and property selection styling

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -225,7 +225,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
             O imóvel que será utilizado como garantia é:
           </legend>
           <div className="flex gap-3" role="radiogroup" aria-labelledby="tipo-imovel-label">
-            <label className="flex-1 flex items-center justify-center gap-2 bg-white/10 px-3 py-3 rounded-lg text-sm font-medium text-white hover:bg-white/20 focus-within:ring-2 focus-within:ring-white cursor-pointer">
+            <label className="flex-1 flex items-center justify-center gap-2 bg-white/10 px-3 py-3 rounded-lg text-sm font-medium text-libra-navy hover:bg-white/20 focus-within:ring-2 focus-within:ring-white cursor-pointer">
               <input
                 type="radio"
                 name="imovelProprioCompact"
@@ -238,7 +238,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
               <Home className="w-4 h-4" />
               Imóvel Próprio
             </label>
-            <label className="flex-1 flex items-center justify-center gap-2 bg-white/10 px-3 py-3 rounded-lg text-sm font-medium text-white hover:bg-white/20 focus-within:ring-2 focus-within:ring-white cursor-pointer">
+            <label className="flex-1 flex items-center justify-center gap-2 bg-white/10 px-3 py-3 rounded-lg text-sm font-medium text-libra-navy hover:bg-white/20 focus-within:ring-2 focus-within:ring-white cursor-pointer">
               <input
                 type="radio"
                 name="imovelProprioCompact"
@@ -392,7 +392,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 </div>
               </legend>
               <div className="flex gap-4" role="radiogroup" aria-labelledby="tipo-imovel-legend">
-                <label className="flex items-center gap-2 text-sm bg-libra-light/60 px-3 py-2 rounded-md shadow-sm hover:bg-libra-light focus-within:outline focus-within:outline-libra-blue">
+                <label className="flex items-center gap-2 text-sm bg-libra-light/60 px-3 py-2 rounded-md shadow-sm hover:bg-libra-light focus-within:outline focus-within:outline-libra-blue text-libra-navy">
                   <input
                     type="radio"
                     name="imovelProprio"
@@ -405,7 +405,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                   />
                   Imóvel Próprio
                 </label>
-                <label className="flex items-center gap-2 text-sm bg-libra-light/60 px-3 py-2 rounded-md shadow-sm hover:bg-libra-light focus-within:outline focus-within:outline-libra-blue">
+                <label className="flex items-center gap-2 text-sm bg-libra-light/60 px-3 py-2 rounded-md shadow-sm hover:bg-libra-light focus-within:outline focus-within:outline-libra-blue text-libra-navy">
                   <input
                     type="radio"
                     name="imovelProprio"

--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -139,7 +139,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
         </div>
 
         {/* Valor da parcela destacado */}
-        <div className="bg-green-50 rounded-lg p-4 mb-4 text-green-700">
+        <div className="bg-green-50 rounded-lg p-4 mb-4 text-libra-navy">
           {amortizacao === 'SAC' && primeiraParcela ? (
             <div>
               <div className="text-xs font-medium mb-3 text-center">Sistema SAC - Parcelas Decrescentes</div>
@@ -173,7 +173,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
         </div>
 
         {/* Renda mínima */}
-        <div className="bg-green-50 rounded-lg p-3 mb-4 text-center relative text-green-700">
+        <div className="bg-green-50 rounded-lg p-3 mb-4 text-center relative text-libra-navy">
           <div className="text-sm mb-1 flex items-center justify-center gap-1">
             <span className="font-bold">Renda necessária</span>
             <TooltipInfo content="Renda familiar podendo ser composta por até 4 pessoas">
@@ -237,7 +237,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
       </div>
 
       {/* Valor da parcela e renda mínima em layout compacto */}
-      <div className="mb-3 text-green-700">
+      <div className="mb-3 text-libra-navy">
         {amortizacao === 'SAC' && primeiraParcela ? (
           <div className="bg-green-50 rounded-lg p-3">
             <div className="text-xs font-medium mb-2 text-center">Sistema SAC - Parcelas Decrescentes</div>


### PR DESCRIPTION
## Summary
- change result parcel and income text color to `libra-navy`
- use `libra-navy` for property type radio labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a5c83f0bc832d85e1b5e54962f62d