### PR TITLE
Fix service worker registration race

### DIFF
--- a/index.html
+++ b/index.html
@@ -462,7 +462,10 @@
     <!-- Service Worker Registration after interaction -->
     <script>
       if ('serviceWorker' in navigator) {
+        let swRegistered = false;
         const registerSW = () => {
+          if (swRegistered) return;
+          swRegistered = true;
           navigator.serviceWorker.register('/sw.js')
             .then(reg => console.log('SW registered:', reg))
             .catch(err => console.log('SW registration failed:', err));
@@ -472,9 +475,7 @@
           window.addEventListener(event, registerSW, { once: true, passive: true });
         });
 
-        window.addEventListener('load', () => {
-          setTimeout(registerSW, 5000);
-        });
+        window.addEventListener('load', () => setTimeout(registerSW, 5000));
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- avoid registering the service worker multiple times

## Testing
- `npm test`
- `npm run lint` *(fails: `@typescript-eslint/no-require-imports` etc.)*
- `npm run build`
- `node /tmp/test-sw.js`

------
https://chatgpt.com/codex/tasks/task_e_688a6154999c832da629c885c080f660