### PR TITLE
Update LTV message logic for mobile views

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -485,7 +485,7 @@ const SimulationForm: React.FC = () => {
         </Card>
 
         {/* Resultado ou Complemento */}
-        {(resultado || (isLtvMessage && apiMessage)) && (
+        {(resultado || (!isMobile && isLtvMessage && apiMessage)) && (
           <div data-result-section="true" className={`${showSideComplement ? '' : 'mt-4'} scroll-mt-header`}>
             {resultado ? (
               <SimulationResultDisplay


### PR DESCRIPTION
## Summary
- show the SmartApiMessage in the result section only when not on mobile

## Testing
- `npm run lint` *(fails: 66 errors, 238 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688a6969fdd4832db53a58b7780adf86