### PR TITLE
Enable mobile info drawers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import ScrollToTop from '@/components/ScrollToTop';
 import { MobileProvider } from '@/hooks/useMobileContext';
+import { Toaster } from '@/components/ui/toaster';
 
 // Lazy load TooltipProvider para LCP
 const TooltipProvider = lazy(() => import('@/components/ui/tooltip').then(m => ({ default: m.TooltipProvider })));
@@ -57,6 +58,7 @@ const App = () => {
       <MobileProvider>
         <BrowserRouter>
           <ScrollToTop />
+          <Toaster />
           <Suspense fallback={<Loading />}>
             <Routes>
               <Route path="/" element={<Index />} />

--- a/src/components/InfoTooltip.tsx
+++ b/src/components/InfoTooltip.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Info from 'lucide-react/dist/esm/icons/info';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { Drawer, DrawerTrigger, DrawerContent, DrawerTitle } from '@/components/ui/drawer';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+interface InfoTooltipProps {
+  content: React.ReactNode;
+  className?: string;
+}
+
+const InfoTooltip: React.FC<InfoTooltipProps> = ({ content, className }) => {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <Drawer>
+        <DrawerTrigger asChild>
+          <button type="button" className={className} aria-label="Informações">
+            <Info className="w-3 h-3 text-gray-500" />
+          </button>
+        </DrawerTrigger>
+        <DrawerContent>
+          <div className="p-4 text-sm text-gray-700">
+            <DrawerTitle className="mb-2 text-base font-semibold">Informações</DrawerTitle>
+            {content}
+          </div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" className={className} aria-label="Informações">
+          <Info className="w-3 h-3 text-gray-500" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{content}</TooltipContent>
+    </Tooltip>
+  );
+};
+
+export default InfoTooltip;

--- a/src/components/LoanSimulator.tsx
+++ b/src/components/LoanSimulator.tsx
@@ -44,6 +44,7 @@ import { Input } from '@/components/ui/input';
 import { Slider } from '@/components/ui/slider';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import InfoTooltip from './InfoTooltip';
 import HelpCircle from 'lucide-react/dist/esm/icons/help-circle';
 import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
 import Info from 'lucide-react/dist/esm/icons/info';
@@ -253,16 +254,9 @@ const LoanSimulator: React.FC = () => {
                   <div className={`bg-libra-light ${isMobile ? 'p-4' : 'p-6'} rounded-lg text-center`}>
                     <div className="flex items-center justify-center gap-1 mb-2">
                       <p className={`${isMobile ? 'text-xs' : 'text-sm'} text-gray-700`} id="requiredIncomeLabel">Renda familiar necessária:</p>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button type="button" aria-label="Mais informações sobre renda necessária">
-                            <HelpCircle className="w-3 h-3 md:w-4 md:h-4 text-gray-600" aria-hidden="true" />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p className={`${isMobile ? 'text-xs' : 'text-sm'}`}>A renda familiar necessária é calculada com base no comprometimento máximo de 30% da renda com a parcela, para evitar o superendividamento.</p>
-                        </TooltipContent>
-                      </Tooltip>
+                      <InfoTooltip
+                        content={<p className={`${isMobile ? 'text-xs' : 'text-sm'}`}>A renda familiar necessária é calculada com base no comprometimento máximo de 30% da renda com a parcela, para evitar o superendividamento.</p>}
+                      />
                     </div>
                     <p className={`${isMobile ? 'text-2xl' : 'text-3xl'} font-bold text-libra-navy`} aria-labelledby="requiredIncomeLabel">{formatCurrency(requiredIncome)}</p>
                     <p className={`${isMobile ? 'text-xs' : 'text-xs'} text-gray-700 mt-2`}>*Valores aproximados, sujeitos à análise de crédito</p>
@@ -271,16 +265,9 @@ const LoanSimulator: React.FC = () => {
                   <div className={`bg-libra-light ${isMobile ? 'p-4' : 'p-6'} rounded-lg text-center`}>
                     <div className="flex items-center justify-center gap-1 mb-2">
                       <p className={`${isMobile ? 'text-xs' : 'text-sm'} text-gray-700`} id="propertyValueLabel">Avaliação do imóvel mínima necessária:</p>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button type="button" aria-label="Mais informações sobre avaliação do imóvel">
-                            <Info className="w-3 h-3 md:w-4 md:h-4 text-gray-600" aria-hidden="true" />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p className={`${isMobile ? 'text-xs' : 'text-sm'}`}>Dependendo das características do imóvel (tipo, região e documentação), a avaliação mínima necessária pode ser até {formatCurrency(maxPropertyValue)}.</p>
-                        </TooltipContent>
-                      </Tooltip>
+                      <InfoTooltip
+                        content={<p className={`${isMobile ? 'text-xs' : 'text-sm'}`}>Dependendo das características do imóvel (tipo, região e documentação), a avaliação mínima necessária pode ser até {formatCurrency(maxPropertyValue)}.</p>}
+                      />
                     </div>
                     <p className={`${isMobile ? 'text-2xl' : 'text-3xl'} font-bold text-libra-navy`} aria-labelledby="propertyValueLabel">{formatCurrency(minPropertyValue)}</p>
                     <p className={`${isMobile ? 'text-xs' : 'text-xs'} text-gray-700 mt-2`}>*Dependendo das características do imóvel (tipo, região e documentação), pode ser necessário até {formatCurrency(maxPropertyValue)}</p>

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -61,6 +61,7 @@ import SimulationResultDisplay from './SimulationResultDisplay';
 import { analyzeApiMessage, ApiMessageAnalysis } from '@/utils/apiMessageAnalyzer';
 import { analyzeLocalMessage } from '@/utils/localMessageAnalyzer';
 import { formatBRL, norm } from '@/utils/formatters';
+import { toast } from '@/components/ui/sonner';
 
 const SimulationForm: React.FC = () => {
   const { sessionId, trackSimulation } = useUserJourney();
@@ -119,8 +120,13 @@ const SimulationForm: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
-    if (!validation.formularioValido || !sessionId) return;
+    if (!validation.formularioValido || !sessionId) {
+      toast({
+        title: 'Preencha todos os campos para prosseguir',
+        variant: 'warning'
+      });
+      return;
+    }
 
     setLoading(true);
     setErro('');
@@ -429,9 +435,9 @@ const SimulationForm: React.FC = () => {
               {/* Botões */}
               <div className="flex gap-2 pt-2">
                 <Button
-                type="submit"
-                disabled={!validation.formularioValido || loading}
-                className="flex-1 bg-green-500 hover:bg-green-600 text-white py-2 text-sm font-semibold min-h-[44px]"
+                  type="submit"
+                  disabled={loading}
+                  className="flex-1 bg-green-500 hover:bg-green-600 text-white py-2 text-sm font-semibold min-h-[44px]"
                 >
                   {loading ? (
                     <div className="flex items-center gap-2">

--- a/src/components/form/AmortizationField.tsx
+++ b/src/components/form/AmortizationField.tsx
@@ -1,8 +1,7 @@
 
 import React from 'react';
 import Calculator from 'lucide-react/dist/esm/icons/calculator';
-import Info from 'lucide-react/dist/esm/icons/info';
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import InfoTooltip from '../InfoTooltip';
 
 interface AmortizationFieldProps {
   value: string;
@@ -14,12 +13,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange }
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
         Escolha a Amortização
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Info className="w-3 h-3 text-gray-500 cursor-pointer" />
-          </TooltipTrigger>
-          <TooltipContent>SAC: parcelas maiores no início e que vão diminuindo com o tempo. PRICE: parcelas fixas ao longo do contrato.</TooltipContent>
-        </Tooltip>
+        <InfoTooltip content="SAC: parcelas maiores no início e que vão diminuindo com o tempo. PRICE: parcelas fixas ao longo do contrato." />
       </label>
       <div className="flex items-center gap-2">
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">

--- a/src/components/form/GuaranteeAmountField.tsx
+++ b/src/components/form/GuaranteeAmountField.tsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import { Input } from '@/components/ui/input';
 import Home from 'lucide-react/dist/esm/icons/home';
-import Info from 'lucide-react/dist/esm/icons/info';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import InfoTooltip from '../InfoTooltip';
 
 interface GuaranteeAmountFieldProps {
   value: string;
@@ -20,12 +19,7 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
         Digite o valor do Imóvel em Garantia
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Info className="w-3 h-3 text-gray-500 cursor-pointer" />
-          </TooltipTrigger>
-          <TooltipContent>Insira aqui o valor da garantia (valor do imóvel a ser considerado na operação).</TooltipContent>
-        </Tooltip>
+        <InfoTooltip content="Insira aqui o valor da garantia (valor do imóvel a ser considerado na operação)." />
       </label>
       <div className="flex items-center gap-2">
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">

--- a/src/components/form/LoanAmountField.tsx
+++ b/src/components/form/LoanAmountField.tsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import { Input } from '@/components/ui/input';
 import DollarSign from 'lucide-react/dist/esm/icons/dollar-sign';
-import Info from 'lucide-react/dist/esm/icons/info';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import InfoTooltip from '../InfoTooltip';
 
 interface LoanAmountFieldProps {
   value: string;
@@ -15,12 +14,7 @@ const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange }) =>
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
         Digite o valor desejado do Empréstimo
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Info className="w-3 h-3 text-gray-500 cursor-pointer" />
-          </TooltipTrigger>
-          <TooltipContent>Insira aqui o valor que você pretende pegar de empréstimo.</TooltipContent>
-        </Tooltip>
+        <InfoTooltip content="Insira aqui o valor que você pretende pegar de empréstimo." />
       </label>
       <div className="flex items-center gap-2">
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">


### PR DESCRIPTION
## Summary
- add InfoTooltip component that uses Drawer on mobile and Tooltip on desktop
- use InfoTooltip in all form fields and loan simulator
- show toast if submit clicked before form is valid
- display Toaster globally for messages

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-require-imports` etc.)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688a6e692e3c832da4b356df7665e81e