### PR TITLE
Fix async CSS injection and rebuild

### DIFF
--- a/scripts/async-css.mjs
+++ b/scripts/async-css.mjs
@@ -21,13 +21,13 @@ async function asyncCss() {
     const preloadLink = `<link rel="preload" href="${cssPath}" as="style" onload="this.onload=null;this.rel='stylesheet'">`;
     const noscriptLink = `<noscript><link rel="stylesheet" href="${cssPath}"></noscript>`;
 
+    // Remove any existing stylesheet link tags before injecting preload
+    indexHtml = indexHtml.replace(/<link[^>]*rel="stylesheet"[^>]*>/g, '');
+
     indexHtml = indexHtml.replace(
       /<\/head>/,
       `  ${preloadLink}\n  ${noscriptLink}\n</head>`
     );
-
-    // Remove the original link tag
-    indexHtml = indexHtml.replace(/<link rel="stylesheet" href=".*">/, '');
 
     await fs.writeFile(indexPath, indexHtml);
     console.log('Successfully added async CSS loading to index.html');


### PR DESCRIPTION
## Summary
- update `scripts/async-css.mjs` to remove **all** stylesheet links before inserting the preload+noscript pair
- rebuild with `npm run build:critical`

## Testing
- `npm install`
- `npm run build:critical`

------
https://chatgpt.com/codex/tasks/task_e_688a79df9d6c832d88caa30ef0e6350d