### PR TITLE
Add critters build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "vite build",
     "build:analyze": "vite build --mode production",
     "build:critical": "vite build && node scripts/async-css.mjs",
+    "build:critters": "vite build && node scripts/extract-critical.mjs",
     "build:dev": "vite build --mode development",
     "build:prod": "vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npm run build:prod",
+  "buildCommand": "npm run build:critters",
   "outputDirectory": "dist",
   "installCommand": "npm ci --include=optional --legacy-peer-deps",
   "framework": "vite",


### PR DESCRIPTION
## Summary
- add `build:critters` npm script to inline above-the-fold CSS
- use the new script in `vercel.json` build command

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-unused-vars` and other warnings)*
- `npm run typecheck`
- `npm run build:critters`

------
https://chatgpt.com/codex/tasks/task_e_688a79e95a04832da25c5984ba5bec9e