### PR TITLE
Add rollup visualizer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Altere esses campos na seção **"DFI, Prestamista e Taxa Administrativa"** e cl
 # Desenvolvimento
 npm run dev              # Servidor de desenvolvimento
 npm run build           # Build para produção
+npm run build:stats     # Gera stats.html com visualização do bundle
 npm run preview         # Preview do build
 
 # Qualidade de código

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "build:analyze": "vite build --mode production",
+    "build:stats": "STATS=1 vite build",
     "build:critical": "vite build && node scripts/async-css.mjs",
     "build:dev": "vite build --mode development",
     "build:prod": "vite build",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import compression from "vite-plugin-compression";
+import { visualizer } from "rollup-plugin-visualizer";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -21,6 +22,11 @@ export default defineConfig(({ mode }) => ({
       algorithm: 'brotliCompress',
       ext: '.br',
       filter: /\.(js|css)$/i,
+    }),
+    process.env.STATS && visualizer({
+      filename: 'stats.html',
+      template: 'treemap',
+      open: true,
     })
   ].filter(Boolean),
   resolve: {


### PR DESCRIPTION
## Summary
- integrate rollup-plugin-visualizer
- add `build:stats` script and docs

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build:stats`

------
https://chatgpt.com/codex/tasks/task_e_688a79e09a5c832d8d61b5db81dce4a9