### PR TITLE
Fix Supabase image uploads

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -168,7 +168,6 @@ export const supabase = createClient<Database>(
     },
     global: {
       headers: {
-        'Content-Type': 'application/json',
         'Accept': 'application/json'
       }
     }
@@ -463,7 +462,8 @@ export const supabaseApi = {
       .from('blog-images')
       .upload(filePath, file, {
         cacheControl: '3600',
-        upsert: false
+        upsert: false,
+        contentType: file.type
       });
 
     if (error) throw error;

--- a/src/lib/supabaseLazy.ts
+++ b/src/lib/supabaseLazy.ts
@@ -43,7 +43,6 @@ async function loadSupabaseClient() {
         },
         global: {
           headers: {
-            'Content-Type': 'application/json',
             'Accept': 'application/json'
           }
         }
@@ -294,7 +293,8 @@ async function loadSupabaseClient() {
             .from('blog-images')
             .upload(filePath, file, {
               cacheControl: '3600',
-              upsert: false
+              upsert: false,
+              contentType: file.type
             });
 
           if (error) throw error;


### PR DESCRIPTION
## Summary
- remove `Content-Type` from Supabase global headers
- explicitly set `contentType` when uploading blog images

## Testing
- `npm test`
- `npm run lint` *(fails: cannot satisfy project lint rules)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688b804c93c8832d9f7b366528089d61