### PR TITLE
Update footer year to 2025

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -124,7 +124,7 @@ const Footer: React.FC = () => {
 
         {/* Informações Legais */}
         <div className="text-center border-t border-white/20 pt-6 md:pt-8">
-          <p className="text-sm md:text-base text-white">&copy; 2024 Libra Crédito. Todos os direitos reservados.</p>
+          <p className="text-sm md:text-base text-white">&copy; 2025 Libra Crédito. Todos os direitos reservados.</p>
           <p className="mt-2 text-sm md:text-base text-white/90">
             CNPJ: 34.308.576/0001-32 | Rua Eliseu Guilherme, 879, sala 01 – Jardim Sumaré, Ribeirão Preto – SP, 14025-020
           </p>


### PR DESCRIPTION
## Summary
- update footer text to show 2025 instead of 2024

## Testing
- `npm test`
- `npm run lint` *(fails: 66 errors, 234 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688cc61ffcb8832da408366fad1fe04f