### PR TITLE
Use header red color for rates slider

### DIFF
--- a/src/pages/Vantagens.tsx
+++ b/src/pages/Vantagens.tsx
@@ -264,7 +264,7 @@ const Vantagens: React.FC = () => {
                       <div className={`${isMobile ? 'h-2' : 'h-3'} rounded-full bg-gray-100 overflow-hidden`}>
                         <div
                           className={`h-full transition-all duration-500 ease-out ${
-                            item.destaque ? 'bg-libra-navy' : 'bg-red-400/70'
+                            item.destaque ? 'bg-libra-navy' : 'bg-red-600'
                           }`}
                           style={{
                             width: `${animatedValues[index] ?? 0}%`,


### PR DESCRIPTION
## Summary
- match the benefits page slider color with the 'Simular Agora' button

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars and other lint errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688cc7203fe4832dbcb0e41423f3d5d8