### PR TITLE
Fix mobile logo sizing in media section

### DIFF
--- a/src/components/MediaSection.tsx
+++ b/src/components/MediaSection.tsx
@@ -63,7 +63,7 @@ const MediaSection: React.FC = () => {
                 <img
                   src={media.logo}
                   alt={`${media.name} - acesse matéria sobre Libra Crédito`}
-                  className="max-w-full max-h-[80px] object-contain"
+                  className="h-12 w-auto object-contain"
                   loading="lazy"
                 />
               </a>


### PR DESCRIPTION
## Summary
- keep consistent sizing for mobile logos

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-require-imports, etc.)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688cc995ba08832da3616a6f998bdea1