### PR TITLE
Improve mobile info icons and validation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ const TooltipProvider = lazy(() => import('@/components/ui/tooltip').then(m => (
 
 // Import homepage directly (not lazy) for faster LCP
 import Index from "./pages/Index";
+import { Toaster } from '@/components/ui/toast';
 
 // Lazy load other components
 const Vantagens = lazy(() => import("./pages/Vantagens"));
@@ -95,6 +96,7 @@ const App = () => {
             </Routes>
           </Suspense>
         </BrowserRouter>
+        <Toaster />
       </MobileProvider>
     </QueryClientProvider>
   );

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -61,6 +61,7 @@ import SimulationResultDisplay from './SimulationResultDisplay';
 import { analyzeApiMessage, ApiMessageAnalysis } from '@/utils/apiMessageAnalyzer';
 import { analyzeLocalMessage } from '@/utils/localMessageAnalyzer';
 import { formatBRL, norm } from '@/utils/formatters';
+import { toast } from '@/components/ui/use-toast';
 
 const SimulationForm: React.FC = () => {
   const { sessionId, trackSimulation } = useUserJourney();
@@ -119,8 +120,16 @@ const SimulationForm: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
-    if (!validation.formularioValido || !sessionId) return;
+
+    if (!validation.formularioValido) {
+      toast({
+        description: 'Preencha todos os campos primeiro para receber a sua simulação',
+        variant: 'warning'
+      });
+      return;
+    }
+
+    if (!sessionId) return;
 
     setLoading(true);
     setErro('');

--- a/src/components/form/AmortizationField.tsx
+++ b/src/components/form/AmortizationField.tsx
@@ -1,8 +1,7 @@
 
 import React from 'react';
 import Calculator from 'lucide-react/dist/esm/icons/calculator';
-import Info from 'lucide-react/dist/esm/icons/info';
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import ResponsiveInfo from '@/components/ui/ResponsiveInfo';
 
 interface AmortizationFieldProps {
   value: string;
@@ -14,12 +13,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange }
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
         Escolha a Amortização
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Info className="w-3 h-3 text-gray-500 cursor-pointer" />
-          </TooltipTrigger>
-          <TooltipContent>SAC: parcelas maiores no início e que vão diminuindo com o tempo. PRICE: parcelas fixas ao longo do contrato.</TooltipContent>
-        </Tooltip>
+        <ResponsiveInfo content="SAC: parcelas maiores no início e que vão diminuindo com o tempo. PRICE: parcelas fixas ao longo do contrato." />
       </label>
       <div className="flex items-center gap-2">
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">

--- a/src/components/form/GuaranteeAmountField.tsx
+++ b/src/components/form/GuaranteeAmountField.tsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import { Input } from '@/components/ui/input';
 import Home from 'lucide-react/dist/esm/icons/home';
-import Info from 'lucide-react/dist/esm/icons/info';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import ResponsiveInfo from '@/components/ui/ResponsiveInfo';
 
 interface GuaranteeAmountFieldProps {
   value: string;
@@ -20,12 +19,7 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
         Digite o valor do Imóvel em Garantia
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Info className="w-3 h-3 text-gray-500 cursor-pointer" />
-          </TooltipTrigger>
-          <TooltipContent>Insira aqui o valor da garantia (valor do imóvel a ser considerado na operação).</TooltipContent>
-        </Tooltip>
+        <ResponsiveInfo content="Insira aqui o valor da garantia (valor do imóvel a ser considerado na operação)." />
       </label>
       <div className="flex items-center gap-2">
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">

--- a/src/components/form/LoanAmountField.tsx
+++ b/src/components/form/LoanAmountField.tsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import { Input } from '@/components/ui/input';
 import DollarSign from 'lucide-react/dist/esm/icons/dollar-sign';
-import Info from 'lucide-react/dist/esm/icons/info';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import ResponsiveInfo from '@/components/ui/ResponsiveInfo';
 
 interface LoanAmountFieldProps {
   value: string;
@@ -15,12 +14,7 @@ const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange }) =>
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
         Digite o valor desejado do Empréstimo
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Info className="w-3 h-3 text-gray-500 cursor-pointer" />
-          </TooltipTrigger>
-          <TooltipContent>Insira aqui o valor que você pretende pegar de empréstimo.</TooltipContent>
-        </Tooltip>
+        <ResponsiveInfo content="Insira aqui o valor que você pretende pegar de empréstimo." />
       </label>
       <div className="flex items-center gap-2">
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">

--- a/src/components/ui/ResponsiveInfo.tsx
+++ b/src/components/ui/ResponsiveInfo.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Info from 'lucide-react/dist/esm/icons/info';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+} from '@/components/ui/dialog';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+interface ResponsiveInfoProps {
+  content: React.ReactNode;
+}
+
+const ResponsiveInfo: React.FC<ResponsiveInfoProps> = ({ content }) => {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <Dialog>
+        <DialogTrigger asChild>
+          <Info className="w-3 h-3 text-gray-500 cursor-pointer" />
+        </DialogTrigger>
+        <DialogContent className="p-4 text-sm max-w-xs mx-auto">
+          {typeof content === 'string' ? <p>{content}</p> : content}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Info className="w-3 h-3 text-gray-500 cursor-pointer" />
+      </TooltipTrigger>
+      <TooltipContent>{content}</TooltipContent>
+    </Tooltip>
+  );
+};
+
+export default ResponsiveInfo;


### PR DESCRIPTION
## Summary
- add `ResponsiveInfo` component to make info buttons usable on mobile
- update form fields to use new info component
- display toast message when form submission is attempted without required data
- mount `Toaster` globally for toast notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ccf00bacc832db943552fc0bab0e6