### PR TITLE
Add success page after simulation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ const SimulacaoLocal = lazy(() => import("./pages/SimulacaoLocal"));
 const Home2 = lazy(() => import("../temp-files/experimental-pages/Home2"));
 const TestWebhook = lazy(() => import("../temp-files/test-pages/TestWebhook"));
 const Confirmacao = lazy(() => import("./pages/Confirmacao"));
+const Sucesso = lazy(() => import("./pages/Sucesso"));
 
 const Loading = () => (
   <div className="min-h-screen flex items-center justify-center bg-gray-50">
@@ -90,6 +91,7 @@ const App = () => {
               <Route path="/simulacao-wizard" element={<SimulacaoWizard />} />
               <Route path="/wizard-test" element={<SimpleWizardTest />} />
               <Route path="/confirmacao" element={<Confirmacao />} />
+              <Route path="/sucesso" element={<Sucesso />} />
               <Route path="/home2" element={<Home2 />} />
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -132,7 +132,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
       const mensagemSucesso = `🎉 Solicitação enviada com sucesso!\n\n✅ Seus dados foram registrados\n✅ Nossa equipe entrará em contato em breve\n📞 Fique atento ao telefone e e-mail cadastrados`;
       
       alert(mensagemSucesso);
-      navigate('/quem-somos');
+      navigate('/sucesso');
       
       // Limpar formulário
       setNome('');

--- a/src/pages/Sucesso.tsx
+++ b/src/pages/Sucesso.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import MobileLayout from '@/components/MobileLayout';
+
+const Sucesso = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    document.title = 'Solicitação Recebida | Libra Crédito';
+    const metaDescription = document.querySelector('meta[name="description"]');
+    if (metaDescription) {
+      metaDescription.setAttribute(
+        'content',
+        'Agradecemos a sua simulação. Em breve nossa equipe entrará em contato.'
+      );
+    }
+
+    const timer = setTimeout(() => {
+      navigate('/quem-somos');
+    }, 5000);
+
+    return () => clearTimeout(timer);
+  }, [navigate]);
+
+  return (
+    <MobileLayout>
+      <div className="flex flex-col items-center justify-center py-12 px-4 text-center space-y-6 bg-white">
+        <h1 className="text-2xl font-bold text-libra-navy">🎉 Muito obrigado!</h1>
+        <p className="text-base text-gray-700">Recebemos sua solicitação e nossos consultores entrarão em contato em breve.</p>
+        <p className="text-base text-gray-700">Fique atento aos telefones (16) 3600-7956 ou (16) 99636-0424.</p>
+        <p className="text-sm text-gray-600 mt-4">Você será redirecionado em instantes...</p>
+      </div>
+    </MobileLayout>
+  );
+};
+
+export default Sucesso;


### PR DESCRIPTION
## Summary
- add Success page component and route
- redirect contact form to success page

## Testing
- `npm run lint` *(fails: 66 errors)*
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ccf4a2b9c832dad92431bdcf43fdb