### PR TITLE
Enhance button border radius

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background shadow-sm transition-colors transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:shadow-md disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-h-[48px]",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium ring-offset-background shadow-sm transition-colors transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:shadow-md disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-h-[48px]",
   {
     variants: {
       variant: {
@@ -28,10 +28,10 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-9 rounded-full px-3",
+        lg: "h-11 rounded-full px-8",
         // Tamanho suficiente para áreas de toque acessíveis
-        xl: "h-14 rounded-md px-8 py-4 text-lg",
+        xl: "h-14 rounded-full px-8 py-4 text-lg",
         // Aumentado para melhor área de toque
         icon: "h-12 w-12 min-w-12", 
       },

--- a/src/index.css
+++ b/src/index.css
@@ -121,7 +121,7 @@
   
   /* Mobile Button Styles */
   .mobile-button {
-    @apply touch-target font-semibold rounded-lg px-6 transition-colors;
+    @apply touch-target font-semibold rounded-full px-6 transition-colors;
     -webkit-tap-highlight-color: transparent;
     touch-action: manipulation;
   }
@@ -136,7 +136,7 @@
 
   /* Reusable CTA styles */
   .cta-button {
-    @apply rounded-lg shadow-sm transition-colors transition-transform duration-200 ease-in-out focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-libra-blue focus-visible:ring-offset-2;
+    @apply rounded-full shadow-sm transition-colors transition-transform duration-200 ease-in-out focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-libra-blue focus-visible:ring-offset-2;
   }
 
   .cta-button:hover {


### PR DESCRIPTION
## Summary
- smooth mobile button look by using `rounded-full`
- make `.cta-button` pill-shaped with `rounded-full`
- update core button component variants for oval shape

## Testing
- `npm test`
- `npm run lint` *(fails: 66 errors, 234 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688cd888153c832da8825eb8eab8e966