### PR TITLE
Fix autoplay on iOS

### DIFF
--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -64,7 +64,7 @@ const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
         <iframe
           ref={iframeRef}
           className="absolute inset-0 w-full h-full"
-          src={`https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&autoplay=1&rel=0&modestbranding=1&preload=metadata`}
+          src={`https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&autoplay=1&mute=1&rel=0&modestbranding=1&preload=metadata`}
           title={title}
           frameBorder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
## Summary
- allow OptimizedYouTube component to autoplay with a single tap on iOS

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden, and many other lint errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688cd994b31c832d8ecb34757e0d9008