### PR TITLE
Fix logo resizing on iOS

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -114,7 +114,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
                   <img
                     src="/images/optimized/logo-header.webp"
                     alt="Libra Crédito - Home Equity com garantia de imóvel"
-                    className="h-[68%] w-auto pointer-events-none max-w-none"
+                    className="header-logo"
                     width="120"
                     height="120"
                   />

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -71,7 +71,7 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
                 <img
                   src="/images/optimized/logo-header.webp"
                   alt="Libra Crédito"
-                  className="h-[68%] w-auto pointer-events-none max-w-none"
+                  className="header-logo"
                   width="120"
                   height="120"
                 />

--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -41,7 +41,7 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
             <img
               src="/images/optimized/logo-header.webp"
               alt="Libra Crédito - Simulação de crédito com garantia de imóvel"
-              className="h-[68%] w-auto pointer-events-none max-w-none"
+              className="header-logo"
               width="120"
               height="120"
             />

--- a/src/index.css
+++ b/src/index.css
@@ -337,6 +337,13 @@
     @apply min-h-[48px] min-w-[44px];
     -webkit-tap-highlight-color: transparent;
   }
+
+  /* Prevent logo resizing on tap in iOS */
+  .header-logo {
+    @apply h-full w-auto pointer-events-none;
+    max-width: none;
+    -webkit-user-drag: none;
+  }
   
   /* Garantir que textos secundários tenham contraste suficiente */
   .text-gray-500, 


### PR DESCRIPTION
## Summary
- avoid logo shrinking on tap by adding `.header-logo` utility
- update all header components to use the new class

## Testing
- `npm run test`
- `npm run lint` *(fails: 66 errors, 234 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688cde48daac832d8e420f536ffae4a9