### PR TITLE
Fix autoplay on iOS

### DIFF
--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -18,10 +18,26 @@ const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
 }) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const shouldPlayRef = useRef(false);
 
   // Função simplificada para carregamento
   const loadVideo = useCallback(() => {
+    shouldPlayRef.current = true;
     setIsLoaded(true);
+  }, []);
+
+  const handleIframeLoad = useCallback(() => {
+    if (shouldPlayRef.current && iframeRef.current?.contentWindow) {
+      iframeRef.current.contentWindow.postMessage(
+        JSON.stringify({ event: "command", func: "playVideo", args: [] }),
+        "*"
+      );
+      iframeRef.current.contentWindow.postMessage(
+        JSON.stringify({ event: "command", func: "setVolume", args: [100] }),
+        "*"
+      );
+      shouldPlayRef.current = false;
+    }
   }, []);
 
   // Usar thumbnail otimizada menor (65KB vs 525KB)
@@ -63,6 +79,7 @@ const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
       ) : (
         <iframe
           ref={iframeRef}
+          onLoad={handleIframeLoad}
           className="absolute inset-0 w-full h-full"
           src={`https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&autoplay=1&rel=0&modestbranding=1&preload=metadata`}
           title={title}


### PR DESCRIPTION
## Summary
- allow OptimizedYouTube component to autoplay with a single tap on iOS and start with volume

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden, and other lint errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688cd994b31c832d8ecb34757e0d9008