### PR TITLE
Refatora fluxo final da simulação

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ const Home2 = lazy(() => import("../temp-files/experimental-pages/Home2"));
 const TestWebhook = lazy(() => import("../temp-files/test-pages/TestWebhook"));
 const Confirmacao = lazy(() => import("./pages/Confirmacao"));
 const Sucesso = lazy(() => import("./pages/Sucesso"));
+const Atendimento = lazy(() => import("./pages/Atendimento"));
 
 const Loading = () => (
   <div className="min-h-screen flex items-center justify-center bg-gray-50">
@@ -92,6 +93,7 @@ const App = () => {
               <Route path="/simulacao-wizard" element={<SimulacaoWizard />} />
               <Route path="/wizard-test" element={<SimpleWizardTest />} />
               <Route path="/confirmacao" element={<Confirmacao />} />
+              <Route path="/atendimento" element={<Atendimento />} />
               <Route path="/sucesso" element={<Sucesso />} />
               <Route path="/home2" element={<Home2 />} />
               <Route path="*" element={<NotFound />} />

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -128,11 +128,8 @@ const ContactForm: React.FC<ContactFormProps> = ({
         aceitaPolitica: aceitePrivacidade
       });
       
-      // Mensagem de sucesso mais detalhada
-      const mensagemSucesso = `🎉 Solicitação enviada com sucesso!\n\n✅ Seus dados foram registrados\n✅ Nossa equipe entrará em contato em breve\n📞 Fique atento ao telefone e e-mail cadastrados`;
-      
-      alert(mensagemSucesso);
-      navigate('/sucesso');
+      // Redirecionar diretamente para a página de confirmação
+      navigate('/confirmacao');
       
       // Limpar formulário
       setNome('');

--- a/src/pages/Atendimento.tsx
+++ b/src/pages/Atendimento.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import MobileLayout from '@/components/MobileLayout';
+import AgentChat from '@/components/AgentChat';
+
+const Atendimento = () => {
+  useEffect(() => {
+    document.title = 'Atendimento Automatizado | Libra Crédito';
+    const metaDescription = document.querySelector('meta[name="description"]');
+    if (metaDescription) {
+      metaDescription.setAttribute(
+        'content',
+        'Tire suas dúvidas sobre crédito com garantia de imóvel no atendimento automatizado da Libra Crédito.'
+      );
+    }
+  }, []);
+
+  return (
+    <MobileLayout>
+      <AgentChat />
+    </MobileLayout>
+  );
+};
+
+export default Atendimento;
+

--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 import MobileLayout from '@/components/MobileLayout';
+import { Button } from '@/components/ui/button';
+import { Link } from 'react-router-dom';
 
 const Confirmacao = () => {
   useEffect(() => {
@@ -19,17 +21,16 @@ const Confirmacao = () => {
         <h1 className="text-2xl font-bold text-libra-navy">✅ Simulação enviada com sucesso!</h1>
         <p className="text-base text-gray-700">Recebemos seus dados e já estamos analisando sua solicitação.</p>
         <p className="text-base text-gray-700">Em breve, um de nossos especialistas entrará em contato com você.</p>
-        <p className="text-base text-gray-700">Você também pode falar com a gente agora mesmo pelo WhatsApp:</p>
-        <a
-          href="https://wa.me/5516996360424?text=Olá,%20acabei%20de%20fazer%20uma%20simulação%20no%20site%20e%20gostaria%20de%20falar%20com%20um%20especialista"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="botao-principal bg-libra-blue text-white font-semibold rounded-full px-8 py-3 hover:bg-libra-blue/90 transition-colors"
-        >
-          Falar com um especialista no WhatsApp
-        </a>
+        <div className="flex flex-col sm:flex-row gap-4 mt-4">
+          <Button asChild variant="white" className="px-6">
+            <Link to="/quem-somos">Conheça a Libra</Link>
+          </Button>
+          <Button asChild variant="goldContrast" className="px-6">
+            <Link to="/atendimento">Iniciar atendimento automatizado</Link>
+          </Button>
+        </div>
         <p className="text-sm text-gray-600 mt-4">
-          📞 Importante: você receberá tentativas de contato pelo número (16) 3600-7956. Fique atento!
+          📞 Fique atento ao telefone (16) 3600-7956 para nosso contato.
         </p>
       </div>
     </MobileLayout>


### PR DESCRIPTION
## Summary
- remove success popup flow from contact form
- add new Atendimento page with embedded chatbot
- keep user on confirmation page with links
- route /confirmacao and /atendimento in App

## Testing
- `npm run lint` *(fails: no-unused-vars and other lint errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688cea297f68832da608ec417a4b55f4