### PR TITLE
Reduce header logo size

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -106,11 +106,11 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
         <div className="border-b border-gray-100">
         <div className="container mx-auto px-4">
           {/* Height increased 20% for desktop */}
-          <div className="flex items-center justify-between h-[62px] lg:h-[82px]">
+          <div className="flex items-center justify-between h-[50px] lg:h-[66px]">
             {/* Logo e slogan */}
             <div className="flex items-center gap-6">
               <Link to="/" className="flex items-center tap-transparent">
-                <div className="h-[62px] lg:h-[82px] overflow-hidden flex items-center">
+                <div className="h-[50px] lg:h-[66px] overflow-hidden flex items-center">
                   <img
                     src="/images/optimized/logo-header.webp"
                     alt="Libra Crédito - Home Equity com garantia de imóvel"

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -64,10 +64,10 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
 
       {/* Header principal */}
       <div className="container mx-auto px-4">
-        <div className="flex items-center justify-between h-16">
+        <div className="flex items-center justify-between h-[52px]">
           <div className="flex items-center">
             <Link to="/" aria-label="Página inicial da Libra Crédito" className="tap-transparent">
-              <div className="h-16 overflow-hidden flex items-center">
+              <div className="h-[52px] overflow-hidden flex items-center">
                 <img
                   src="/images/optimized/logo-header.webp"
                   alt="Libra Crédito"

--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -34,10 +34,10 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
       data-mobile="true"
       className={`fixed top-0 left-0 right-0 z-[9999] bg-white border-b border-gray-200 shadow-sm ${hasNotch ? 'pt-safe-top' : ''}`}
     >
-      <div className="h-16 px-4 flex items-center justify-between">
+      <div className="h-[52px] px-4 flex items-center justify-between">
         {/* Logo */}
         <Link to="/" className="flex items-center tap-transparent" aria-label="Ir para página inicial da Libra Crédito">
-          <div className="h-16 overflow-hidden flex items-center">
+          <div className="h-[52px] overflow-hidden flex items-center">
             <img
               src="/images/optimized/logo-header.webp"
               alt="Libra Crédito - Simulação de crédito com garantia de imóvel"


### PR DESCRIPTION
## Summary
- shrink logo containers in header components to 80% of previous size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ceb3b2a1c832d88f2516ae038a71f