### PR TITLE
Update G1 logo asset usage

### DIFF
--- a/temp-files/experimental-pages/BenefitsSection2.tsx
+++ b/temp-files/experimental-pages/BenefitsSection2.tsx
@@ -143,7 +143,7 @@ const BenefitsSection2: React.FC = () => {
               <div className="flex items-center space-x-3">
                 <div className="w-10 h-8 flex items-center justify-center">
                   <img
-                    src="/images/media/G1-logo-1.png"
+                    src="/images/optimized/media/G1-logo-1.webp"
                     alt="G1 Globo"
                     className="max-w-full max-h-full object-contain"
                     loading="lazy"


### PR DESCRIPTION
## Summary
- reference optimized G1 logo in BenefitsSection2

## Testing
- `npm run lint` *(fails: 66 errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688cf7a18fd4832d9df3002b123fdce0