### PR TITLE
Implementa melhorias visuais na simulação

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -224,7 +224,11 @@ const ContactForm: React.FC<ContactFormProps> = ({
             O imóvel que será utilizado como garantia é:
           </legend>
           <div className="flex gap-3" role="radiogroup" aria-labelledby="tipo-imovel-label">
-            <label className="flex-1 flex items-center justify-center gap-2 bg-white/10 px-3 py-3 rounded-lg text-sm font-medium text-libra-navy hover:bg-white/20 focus-within:ring-2 focus-within:ring-white cursor-pointer">
+            <label
+              className={`flex-1 flex items-center justify-center gap-2 rounded-lg text-sm font-medium cursor-pointer ${
+                imovelProprio === 'proprio' ? 'bg-white text-libra-blue' : 'bg-white/50 text-libra-navy'
+              }`}
+            >
               <input
                 type="radio"
                 name="imovelProprioCompact"
@@ -237,7 +241,11 @@ const ContactForm: React.FC<ContactFormProps> = ({
               <Home className="w-4 h-4" />
               Imóvel Próprio
             </label>
-            <label className="flex-1 flex items-center justify-center gap-2 bg-white/10 px-3 py-3 rounded-lg text-sm font-medium text-libra-navy hover:bg-white/20 focus-within:ring-2 focus-within:ring-white cursor-pointer">
+            <label
+              className={`flex-1 flex items-center justify-center gap-2 rounded-lg text-sm font-medium cursor-pointer ${
+                imovelProprio === 'terceiro' ? 'bg-white text-libra-blue' : 'bg-white/50 text-libra-navy'
+              }`}
+            >
               <input
                 type="radio"
                 name="imovelProprioCompact"
@@ -258,8 +266,9 @@ const ContactForm: React.FC<ContactFormProps> = ({
             id="aceite-compact"
             checked={aceitePrivacidade}
             onCheckedChange={(checked) => setAceitePrivacidade(checked as boolean)}
+            className="bg-white"
           />
-          <label htmlFor="aceite-compact" className="text-sm text-white leading-tight">
+          <label htmlFor="aceite-compact" className="text-sm text-white font-bold leading-tight">
             Concordo com a{' '}
             <Link
               to="/politica-privacidade"
@@ -273,11 +282,18 @@ const ContactForm: React.FC<ContactFormProps> = ({
 
         <Button
           type="submit"
-          disabled={loading || !aceitePrivacidade}
+          disabled={
+            loading ||
+            !nome ||
+            !email ||
+            !telefone ||
+            !imovelProprio ||
+            !aceitePrivacidade
+          }
           onClick={(e) => {
-            if (!nome || !email || !telefone || !imovelProprio) {
+            if (!nome || !email || !telefone || !imovelProprio || !aceitePrivacidade) {
               e.preventDefault();
-              alert('Por favor, preencha todos os campos antes de solicitar a análise.');
+              alert('Por favor, preencha todos os campos para prosseguir.');
             }
           }}
           className={`w-full h-14 text-base font-semibold bg-gradient-to-r from-yellow-400 to-yellow-500 text-libra-navy hover:from-yellow-500 hover:to-yellow-600 ${buttonClassName}`}
@@ -391,7 +407,11 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 </div>
               </legend>
               <div className="flex gap-4" role="radiogroup" aria-labelledby="tipo-imovel-legend">
-                <label className="flex items-center gap-2 text-sm bg-libra-light/60 px-3 py-2 rounded-md shadow-sm hover:bg-libra-light focus-within:outline focus-within:outline-libra-blue text-libra-navy">
+                <label
+                  className={`flex items-center gap-2 text-sm px-3 py-2 rounded-md shadow-sm cursor-pointer ${
+                    imovelProprio === 'proprio' ? 'bg-white text-libra-blue' : 'bg-libra-light/60 text-libra-navy'
+                  }`}
+                >
                   <input
                     type="radio"
                     name="imovelProprio"
@@ -404,7 +424,11 @@ const ContactForm: React.FC<ContactFormProps> = ({
                   />
                   Imóvel Próprio
                 </label>
-                <label className="flex items-center gap-2 text-sm bg-libra-light/60 px-3 py-2 rounded-md shadow-sm hover:bg-libra-light focus-within:outline focus-within:outline-libra-blue text-libra-navy">
+                <label
+                  className={`flex items-center gap-2 text-sm px-3 py-2 rounded-md shadow-sm cursor-pointer ${
+                    imovelProprio === 'terceiro' ? 'bg-white text-libra-blue' : 'bg-libra-light/60 text-libra-navy'
+                  }`}
+                >
                   <input
                     type="radio"
                     name="imovelProprio"
@@ -428,8 +452,9 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 id="aceite"
                 checked={aceitePrivacidade}
                 onCheckedChange={(checked) => setAceitePrivacidade(checked as boolean)}
+                className="bg-white"
               />
-              <label htmlFor="aceite" className="text-sm text-gray-600 leading-tight bg-libra-light/60 px-3 py-2 rounded-md shadow-sm focus-within:outline focus-within:outline-libra-blue">
+              <label htmlFor="aceite" className="text-sm font-bold text-gray-600 leading-tight bg-libra-light/60 px-3 py-2 rounded-md shadow-sm focus-within:outline focus-within:outline-libra-blue">
                 Tenho ciência e concordo que meus dados de contato aqui informados poderão ser
                 utilizados pela Libra Crédito de acordo com os termos da{' '}
                 <Link
@@ -444,11 +469,18 @@ const ContactForm: React.FC<ContactFormProps> = ({
 
             <Button
               type="submit"
-              disabled={loading || !aceitePrivacidade}
+              disabled={
+                loading ||
+                !nome ||
+                !email ||
+                !telefone ||
+                !imovelProprio ||
+                !aceitePrivacidade
+              }
               onClick={(e) => {
-                if (!nome || !email || !telefone || !imovelProprio) {
+                if (!nome || !email || !telefone || !imovelProprio || !aceitePrivacidade) {
                   e.preventDefault();
-                  alert('Por favor, preencha todos os campos antes de solicitar a análise.');
+                  alert('Por favor, preencha todos os campos para prosseguir.');
                 }
               }}
               className="w-full h-14 text-base font-semibold bg-gradient-to-r from-yellow-400 to-yellow-500 text-libra-navy hover:from-yellow-500 hover:to-yellow-600"

--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -129,12 +129,12 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
   if (isMobile) {
     // Layout Mobile - Sucinto e direto
     return (
-      <div className="bg-[#33cc99] rounded-xl p-4 text-libra-navy shadow-xl">
+      <div className="bg-[#22c55e] rounded-xl p-4 text-libra-navy shadow-xl">
         {/* Header compacto */}
         <div className="flex items-center gap-2 mb-4">
-          <CheckCircle className="w-5 h-5 text-[#003399]" />
+          <CheckCircle className="w-5 h-5 text-white" />
           <div>
-            <h3 className="font-bold text-[#003399]">Simulação Pronta!</h3>
+            <h3 className="font-bold text-white">Simulação Pronta!</h3>
           </div>
         </div>
 
@@ -218,21 +218,21 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
   
   // Layout Desktop - Adaptação do Mobile na Lateral
   return (
-    <div className="bg-[#33cc99] rounded-xl p-4 text-libra-navy shadow-xl">
+    <div className="bg-[#22c55e] rounded-xl p-4 text-libra-navy shadow-xl">
       {/* Header compacto */}
       <div className="flex items-center justify-between mb-3">
       <div className="flex items-center gap-2">
-          <CheckCircle className="w-5 h-5 text-[#003399]" />
-          <h3 className="text-lg font-bold text-[#003399]">Simulação Pronta!</h3>
+          <CheckCircle className="w-5 h-5 text-white" />
+          <h3 className="text-lg font-bold text-white">Simulação Pronta!</h3>
         </div>
         <Button
           onClick={onNewSimulation}
           variant="outline"
-          className="bg-white/10 border-white/30 text-[#003399] hover:bg-white/20 text-xs px-3 py-2"
+          className="bg-white/10 border-white/30 text-white hover:bg-white/20 text-xs px-3 py-2"
           size="sm"
         >
-          <Calculator className="w-3 h-3 mr-1 text-[#003399]" />
-          Nova Simulação
+          <Calculator className="w-3 h-3 mr-1 text-white" />
+          <span className="font-bold">Nova Simulação</span>
         </Button>
       </div>
 

--- a/src/utils/apiMessageAnalyzer.ts
+++ b/src/utils/apiMessageAnalyzer.ts
@@ -16,7 +16,6 @@ export interface ApiMessageAnalysis {
  * Analisa a mensagem da API e determina o tipo de resposta
  */
 export const analyzeApiMessage = (message: string): ApiMessageAnalysis => {
-  const lowerMessage = message.toLowerCase();
   
   // Padrão 1: Limite 30% geral
   // "Em Guaxupé - MG, o valor máximo de empréstimo deverá corresponder a no máximo 30 % do valor do imóvel. Ajuste o montante solicitado para R$ 60000.0."

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
         content: [
@@ -152,5 +153,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Resumo
- altera cor do quadro de resultados para verde #22c55e
- destaca textos de resultado em branco e negrito
- melhora radio de tipo de imóvel e checkbox do aceite
- bloqueia envio do formulário até todos campos serem preenchidos
- ajusta importação do plugin do Tailwind

## Testes
- `npm run lint` *(falhou: diversos erros pré‑existentes)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688cfab5fd5c832db7a9e4d0fd2e569b