### PR TITLE
Fix unmuted YouTube autoplay

### DIFF
--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -87,7 +87,7 @@ const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
           ref={iframeRef}
           onLoad={handleIframeLoad}
           className="absolute inset-0 w-full h-full"
-          src={`https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&autoplay=1&mute=1&rel=0&modestbranding=1&preload=metadata`}
+          src={`https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&autoplay=1&rel=0&modestbranding=1&preload=metadata`}
           title={title}
           frameBorder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
## Summary
- remove `mute=1` from YouTube embed so video plays with sound

## Testing
- `npm run lint` *(fails: 64 errors, 234 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688cfe3a0768832da4d229706a3f6a2f