### PR TITLE
Reduce header logo size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -340,7 +340,7 @@
 
   /* Prevent logo resizing on tap in iOS */
   .header-logo {
-    @apply h-full w-auto pointer-events-none;
+    @apply h-[80%] w-auto pointer-events-none;
     max-width: none;
     -webkit-user-drag: none;
   }


### PR DESCRIPTION
## Summary
- restore original header container heights
- limit `.header-logo` elements to 80% height for smaller logos

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ceb3b2a1c832d88f2516ae038a71f