### PR TITLE
Fix Portal de Clientes styling in mobile menu

### DIFF
--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -95,13 +95,14 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
               
               {/* Portal de Clientes */}
               {onPortalClientes && (
-                <li className="pt-2 border-t border-gray-100">
+                <li role="none">
                   <button
                     onClick={() => {
                       onPortalClientes();
                       setIsMenuOpen(false);
                     }}
-                    className="w-full text-left py-3 px-2 text-sm font-medium text-libra-blue hover:bg-blue-50 rounded-md transition-colors"
+                    className="w-full text-left py-3 px-2 text-[1.0938rem] font-medium text-libra-navy hover:text-libra-blue hover:bg-gray-50 rounded-md transition-colors flex items-center min-h-[44px]"
+                    role="menuitem"
                   >
                     Portal de Clientes
                   </button>


### PR DESCRIPTION
## Summary
- apply standard menu styling for "Portal de Clientes" in `SimpleMobileHeader`

## Testing
- `npm run lint` *(fails: 64 errors, 234 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688d07373920832db22f08d911206dc9