### PR TITLE
Fix tooltip close button style

### DIFF
--- a/src/components/ui/ResponsiveInfo.tsx
+++ b/src/components/ui/ResponsiveInfo.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import Info from 'lucide-react/dist/esm/icons/info';
+import X from 'lucide-react/dist/esm/icons/x';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import {
   Dialog,
   DialogTrigger,
   DialogContent,
+  DialogClose,
 } from '@/components/ui/dialog';
 import { useIsMobile } from '@/hooks/use-mobile';
 
@@ -21,8 +23,16 @@ const ResponsiveInfo: React.FC<ResponsiveInfoProps> = ({ content }) => {
         <DialogTrigger asChild>
           <Info className="w-3 h-3 text-gray-500 cursor-pointer" />
         </DialogTrigger>
-        <DialogContent className="p-4 text-sm max-w-xs mx-auto">
+        <DialogContent className="p-4 text-sm max-w-xs mx-auto flex flex-col gap-4">
           {typeof content === 'string' ? <p>{content}</p> : content}
+          <div className="flex justify-end">
+            <DialogClose
+              aria-label="Fechar"
+              className="flex h-10 w-10 items-center justify-center rounded-full border bg-white text-gray-700 shadow"
+            >
+              <X className="h-4 w-4" />
+            </DialogClose>
+          </div>
         </DialogContent>
       </Dialog>
     );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">Fechar</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>


### PR DESCRIPTION
## Summary
- revert dialog component styling
- add bottom close button to mobile tooltips

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688cfbe20a4c832da4b110071df7c274