### PR TITLE
Trigger popup on page load

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -42,24 +42,20 @@ const Header: React.FC = () => {
   const navigate = useNavigate();
   const { isMobile } = useDevice();
 
-  // Lazy load popup apenas após 2 segundos (post-LCP)
+  // Carrega o popup assim que o componente é montado
   useEffect(() => {
-    const timer = setTimeout(() => {
-      const currentPath = location.pathname;
-      const allowedPaths = ['/', '/simulacao'];
-      
-      if (allowedPaths.includes(currentPath)) {
-        const storageKey = `popup_seen_${currentPath.replace('/', 'home')}`;
-        const hasSeenPopup = localStorage.getItem(storageKey);
-        
-        if (!hasSeenPopup) {
-          setShouldShowDialog(true);
-          setIsInfoPopupOpen(true);
-        }
-      }
-    }, 2000);
+    const currentPath = location.pathname;
+    const allowedPaths = ['/', '/simulacao'];
 
-    return () => clearTimeout(timer);
+    if (allowedPaths.includes(currentPath)) {
+      const storageKey = `popup_seen_${currentPath.replace('/', 'home')}`;
+      const hasSeenPopup = localStorage.getItem(storageKey);
+
+      if (!hasSeenPopup) {
+        setShouldShowDialog(true);
+        setIsInfoPopupOpen(true);
+      }
+    }
   }, [location.pathname]);
 
   const handleClosePopup = (e: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
## Summary
- adjust header pop-up logic so it opens immediately

## Testing
- `npm run lint` *(fails: 64 errors, 234 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688d09eab700832d818b8438da011566