### PR TITLE
Update success page button styles

### DIFF
--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -22,11 +22,8 @@ const Confirmacao = () => {
         <p className="text-base text-gray-700">Recebemos seus dados e já estamos analisando sua solicitação.</p>
         <p className="text-base text-gray-700">Em breve, um de nossos especialistas entrará em contato com você.</p>
         <div className="flex flex-col sm:flex-row gap-4 mt-4">
-          <Button asChild variant="white" className="px-6">
+          <Button asChild variant="default" className="px-6">
             <Link to="/quem-somos">Conheça a Libra</Link>
-          </Button>
-          <Button asChild variant="goldContrast" className="px-6">
-            <Link to="/atendimento">Iniciar atendimento automatizado</Link>
           </Button>
         </div>
         <p className="text-sm text-gray-600 mt-4">


### PR DESCRIPTION
## Summary
- on the confirmation page, switch the "Conheça a Libra" button to primary blue style and remove the extra atendimento button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d0a48ba1c832dad6cab6413cf33b9