### PR TITLE
Increase G1 logo size on mobile

### DIFF
--- a/src/components/MediaSection.tsx
+++ b/src/components/MediaSection.tsx
@@ -60,7 +60,9 @@ const MediaSection: React.FC = () => {
                 className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200 flex items-center justify-center"
                 aria-label={`Ver matéria da ${media.name}`}
               >
-                <div className="h-12 w-full flex items-center justify-center">
+                <div
+                  className={`w-full flex items-center justify-center ${media.name === 'G1 Globo' ? 'h-14' : 'h-12'}`}
+                >
                   <img
                     src={media.logo}
                     alt={`${media.name} - acesse matéria sobre Libra Crédito`}


### PR DESCRIPTION
## Summary
- enlarge the G1 logo in the media section on small screens so it matches the size of the Cidade On logo

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d0b9b67a8832da0f14ba6bf976440