### PR TITLE
Add red highlighting for contact form fields

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -10,6 +10,7 @@ import { useUserJourney } from '@/hooks/useUserJourney';
 import Home from 'lucide-react/dist/esm/icons/home';
 import Building from 'lucide-react/dist/esm/icons/building';
 import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
+import { cn } from '@/lib/utils';
 
 interface ContactFormProps {
   simulationResult: {
@@ -41,6 +42,12 @@ const ContactForm: React.FC<ContactFormProps> = ({
   const [imovelProprio, setImovelProprio] = useState<'proprio' | 'terceiro' | ''>('');
   const [aceitePrivacidade, setAceitePrivacidade] = useState(false);
   const [loading, setLoading] = useState(false);
+
+  const invalidNome = nome.trim() === '';
+  const invalidEmail = email.trim() === '';
+  const invalidTelefone = telefone.trim() === '';
+  const invalidImovelProprio = imovelProprio === '';
+  const invalidAceite = !aceitePrivacidade;
 
   // Função para aplicar máscara de telefone
   const formatPhoneNumber = (value: string) => {
@@ -180,7 +187,11 @@ const ContactForm: React.FC<ContactFormProps> = ({
             value={nome}
             onChange={(e) => setNome(e.target.value)}
             placeholder="Nome Completo"
-            className={`rounded-lg h-12 focus:shadow-md ${inputClassName}`}
+            className={cn(
+              'rounded-lg h-12 focus:shadow-md',
+              inputClassName,
+              invalidNome && 'border-red-500 focus:border-red-500 focus:ring-red-500'
+            )}
             required
             aria-required="true"
           />
@@ -196,7 +207,11 @@ const ContactForm: React.FC<ContactFormProps> = ({
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="E-mail"
-            className={`rounded-lg h-12 focus:shadow-md ${inputClassName}`}
+            className={cn(
+              'rounded-lg h-12 focus:shadow-md',
+              inputClassName,
+              invalidEmail && 'border-red-500 focus:border-red-500 focus:ring-red-500'
+            )}
             required
             aria-required="true"
           />
@@ -212,14 +227,18 @@ const ContactForm: React.FC<ContactFormProps> = ({
             value={telefone}
             onChange={(e) => handlePhoneChange(e.target.value)}
             placeholder="Telefone (99) 99999-9999"
-            className={`rounded-lg h-12 focus:shadow-md ${inputClassName}`}
+            className={cn(
+              'rounded-lg h-12 focus:shadow-md',
+              inputClassName,
+              invalidTelefone && 'border-red-500 focus:border-red-500 focus:ring-red-500'
+            )}
             inputMode="numeric"
             required
             aria-required="true"
           />
         </div>
         
-        <fieldset className="space-y-2">
+        <fieldset className={cn('space-y-2', invalidImovelProprio && 'border border-red-500 rounded-md p-2')}>
           <legend id="tipo-imovel-label" className="text-sm text-white font-medium mb-1">
             O imóvel que será utilizado como garantia é:
           </legend>
@@ -261,7 +280,12 @@ const ContactForm: React.FC<ContactFormProps> = ({
           </div>
         </fieldset>
 
-        <div className="flex items-start gap-2 mt-4">
+        <div
+          className={cn(
+            'flex items-start gap-2 mt-4',
+            invalidAceite && 'border border-red-500 rounded-md p-2'
+          )}
+        >
           <Checkbox
             id="aceite-compact"
             checked={aceitePrivacidade}
@@ -364,6 +388,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 value={nome}
                 onChange={(e) => setNome(e.target.value)}
                 placeholder="Digite seu nome completo"
+                className={cn(invalidNome && 'border-red-500 focus:border-red-500 focus:ring-red-500')}
                 required
                 aria-required="true"
               />
@@ -379,6 +404,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="Digite seu e-mail"
+                className={cn(invalidEmail && 'border-red-500 focus:border-red-500 focus:ring-red-500')}
                 required
                 aria-required="true"
               />
@@ -395,12 +421,13 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 onChange={(e) => handlePhoneChange(e.target.value)}
                 placeholder="(99) 99999-9999"
                 inputMode="numeric"
+                className={cn(invalidTelefone && 'border-red-500 focus:border-red-500 focus:ring-red-500')}
                 required
                 aria-required="true"
               />
             </div>
 
-            <fieldset className="space-y-3">
+            <fieldset className={cn('space-y-3', invalidImovelProprio && 'border border-red-500 rounded-md p-2')}>
               <legend id="tipo-imovel-legend" className="text-sm font-medium text-libra-navy">
                 O imóvel que será utilizado como garantia é: *
                 <div className="text-xs text-gray-500 font-normal mt-1" title="A matrícula/escritura do imóvel está no seu nome próprio ou de um terceiro?">
@@ -448,7 +475,12 @@ const ContactForm: React.FC<ContactFormProps> = ({
               </div>
             </fieldset>
 
-            <div className="flex items-start gap-2 mt-2">
+            <div
+              className={cn(
+                'flex items-start gap-2 mt-2',
+                invalidAceite && 'border border-red-500 rounded-md p-2'
+              )}
+            >
               <Checkbox
                 id="aceite"
                 checked={aceitePrivacidade}

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -80,6 +80,11 @@ const SimulationForm: React.FC = () => {
   // Validações
   const validation = validateForm(emprestimo, garantia, parcelas, amortizacao, cidade);
 
+  const invalidCity = !cidade;
+  const invalidLoan = !emprestimo || validation.emprestimoForaRange;
+  const invalidGuarantee = !garantia || validation.emprestimoExcedeGarantia || norm(garantia) <= 0;
+  const invalidAmortization = !amortizacao;
+
   const handleEmprestimoChange = (value: string) => {
     // aceitar somente números e limitar a 7 dígitos
     const numeric = value.replace(/\D/g, '').slice(0, 7);
@@ -421,19 +426,32 @@ const SimulationForm: React.FC = () => {
           <CardContent className="p-3 md:p-4">
             <form onSubmit={handleSubmit} className="space-y-2">
               
-              <CityAutocomplete value={cidade} onCityChange={setCidade} />
+              <CityAutocomplete
+                value={cidade}
+                onCityChange={setCidade}
+                isInvalid={invalidCity}
+              />
 
-              <LoanAmountField value={emprestimo} onChange={handleEmprestimoChange} />
+              <LoanAmountField
+                value={emprestimo}
+                onChange={handleEmprestimoChange}
+                isInvalid={invalidLoan}
+              />
 
-              <GuaranteeAmountField 
-                value={garantia} 
+              <GuaranteeAmountField
+                value={garantia}
                 onChange={handleGarantiaChange}
                 showError={validation.emprestimoExcedeGarantia}
+                isInvalid={invalidGuarantee}
               />
 
               <InstallmentsField value={parcelas} onChange={setParcelas} />
 
-              <AmortizationField value={amortizacao} onChange={setAmortizacao} />
+              <AmortizationField
+                value={amortizacao}
+                onChange={setAmortizacao}
+                isInvalid={invalidAmortization}
+              />
 
               {/* Botões */}
               <div className="flex gap-2 pt-2">

--- a/src/components/form/AmortizationField.tsx
+++ b/src/components/form/AmortizationField.tsx
@@ -2,20 +2,22 @@
 import React from 'react';
 import Calculator from 'lucide-react/dist/esm/icons/calculator';
 import ResponsiveInfo from '@/components/ui/ResponsiveInfo';
+import { cn } from '@/lib/utils';
 
 interface AmortizationFieldProps {
   value: string;
   onChange: (value: string) => void;
+  isInvalid?: boolean;
 }
 
-const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange }) => {
+const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange, isInvalid = false }) => {
   return (
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
         Escolha a Amortização
         <ResponsiveInfo content="SAC: parcelas maiores no início e que vão diminuindo com o tempo. PRICE: parcelas fixas ao longo do contrato." />
       </label>
-      <div className="flex items-center gap-2">
+      <div className={cn('flex items-center gap-2', isInvalid && 'border border-red-500 rounded-md p-2')}>
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
           <Calculator className="w-4 h-4 text-green-500" />
         </div>

--- a/src/components/form/CityAutocomplete.tsx
+++ b/src/components/form/CityAutocomplete.tsx
@@ -3,9 +3,12 @@ import MapPin from 'lucide-react/dist/esm/icons/map-pin';
 import { searchCities } from '@/utils/cityLtvService';
 import scrollToTarget from '@/utils/scrollToTarget';
 
+import { cn } from '@/lib/utils';
+
 interface CityAutocompleteProps {
   value?: string;
   onCityChange?: (city: string) => void;
+  isInvalid?: boolean;
 }
 
 /**
@@ -13,7 +16,7 @@ interface CityAutocompleteProps {
  * Searches city suggestions from LTV_Cidades.json as user types 
  * and only allows selection of valid cities.
  */
-const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityChange }) => {
+const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityChange, isInvalid = false }) => {
   const [inputValue, setInputValue] = useState<string>(value);
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -154,7 +157,12 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
             placeholder={
               inputValue.length < 2 ? 'Digite 2 ou mais caracteres' : 'Busque a cidade'
             }
-            className="text-sm w-full px-3 py-2 rounded-md border-2 border-green-500 focus:outline-none focus:border-green-600 transition-colors scroll-mt-header"
+            className={cn(
+              'text-sm w-full px-3 py-2 rounded-md border-2 focus:outline-none transition-colors scroll-mt-header',
+              isInvalid
+                ? 'border-red-500 focus:border-red-500'
+                : 'border-green-500 focus:border-green-600'
+            )}
           />
 
           {/* Suggestion dropdown - Fixed positioning for mobile */}

--- a/src/components/form/GuaranteeAmountField.tsx
+++ b/src/components/form/GuaranteeAmountField.tsx
@@ -3,17 +3,20 @@ import React from 'react';
 import { Input } from '@/components/ui/input';
 import Home from 'lucide-react/dist/esm/icons/home';
 import ResponsiveInfo from '@/components/ui/ResponsiveInfo';
+import { cn } from '@/lib/utils';
 
 interface GuaranteeAmountFieldProps {
   value: string;
   onChange: (value: string) => void;
   showError: boolean;
+  isInvalid?: boolean;
 }
 
-const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({ 
-  value, 
-  onChange, 
-  showError 
+const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
+  value,
+  onChange,
+  showError,
+  isInvalid = false
 }) => {
   return (
     <div className="flex flex-col gap-1">
@@ -30,7 +33,7 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
             value={value}
             onChange={(e) => onChange(e.target.value)}
             placeholder="Mínimo 2x o valor do empréstimo"
-            className="text-sm"
+            className={cn('text-sm', isInvalid && 'border-red-500 focus:border-red-500 focus:ring-red-500')}
             inputMode="numeric"
           />
         </div>

--- a/src/components/form/LoanAmountField.tsx
+++ b/src/components/form/LoanAmountField.tsx
@@ -4,12 +4,15 @@ import { Input } from '@/components/ui/input';
 import DollarSign from 'lucide-react/dist/esm/icons/dollar-sign';
 import ResponsiveInfo from '@/components/ui/ResponsiveInfo';
 
+import { cn } from '@/lib/utils';
+
 interface LoanAmountFieldProps {
   value: string;
   onChange: (value: string) => void;
+  isInvalid?: boolean;
 }
 
-const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange }) => {
+const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange, isInvalid = false }) => {
   return (
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
@@ -25,7 +28,7 @@ const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange }) =>
             value={value}
             onChange={(e) => onChange(e.target.value)}
             placeholder="entre 75 mil e 5 milhões"
-            className="text-sm"
+            className={cn('text-sm', isInvalid && 'border-red-500 focus:border-red-500 focus:ring-red-500')}
             inputMode="numeric"
           />
         </div>


### PR DESCRIPTION
## Summary
- highlight empty name, email and phone fields in ContactForm
- outline radio group and privacy checkbox in red when not selected

## Testing
- `npm run lint` *(fails: 63 errors, 234 warnings)*
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d09ad74c8832dbfd863e09d08a7eb