### PR TITLE
Fix mobile CTA text line break

### DIFF
--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -204,7 +204,9 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
         {/* CTA e Formulário compacto */}
         <div className="bg-libra-blue text-white rounded-lg p-4 mb-4 lg:mb-3 flex items-center justify-center gap-2">
           <Headphones className="w-5 h-5 text-[#003399]" />
-          <p className="text-lg font-bold">Gostou? Solicite uma consultoria gratuita!</p>
+        <p className="text-lg font-bold">
+          Gostou? <span className="block sm:inline">Solicite uma consultoria gratuita!</span>
+        </p>
         </div>
         
         <ContactForm
@@ -314,7 +316,9 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
       {/* CTA e Formulário compacto */}
       <div className="bg-libra-blue text-white rounded-lg p-4 mb-4 lg:mb-3 flex items-center justify-center gap-2">
         <Headphones className="w-5 h-5 text-[#003399]" />
-        <p className="text-lg font-bold">Gostou? Solicite uma consultoria gratuita!</p>
+        <p className="text-lg font-bold">
+          Gostou? <span className="block sm:inline">Solicite uma consultoria gratuita!</span>
+        </p>
       </div>
       
       <ContactForm


### PR DESCRIPTION
## Summary
- adjust `SimulationResultDisplay` CTA text so the phrase breaks onto two lines on mobile

## Testing
- `npm run lint` *(fails: 63 errors, 238 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688d0e812bf0832d9ddadc86db642608