### PR TITLE
Fix tooltip close buttons

### DIFF
--- a/src/components/ui/ResponsiveInfo.tsx
+++ b/src/components/ui/ResponsiveInfo.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import Info from 'lucide-react/dist/esm/icons/info';
+import X from 'lucide-react/dist/esm/icons/x';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import {
   Dialog,
   DialogTrigger,
   DialogContent,
+  DialogClose,
 } from '@/components/ui/dialog';
 import { useIsMobile } from '@/hooks/use-mobile';
 
@@ -21,8 +23,19 @@ const ResponsiveInfo: React.FC<ResponsiveInfoProps> = ({ content }) => {
         <DialogTrigger asChild>
           <Info className="w-3 h-3 text-gray-500 cursor-pointer" />
         </DialogTrigger>
-        <DialogContent className="p-4 text-sm max-w-xs mx-auto">
+        <DialogContent
+          hideCloseButton
+          className="p-4 text-sm max-w-xs mx-auto flex flex-col gap-4"
+        >
           {typeof content === 'string' ? <p>{content}</p> : content}
+          <div className="flex justify-end">
+            <DialogClose
+              aria-label="Fechar"
+              className="flex h-11 w-11 items-center justify-center rounded-full border bg-white text-gray-700 shadow"
+            >
+              <X className="h-4 w-4" />
+            </DialogClose>
+          </div>
         </DialogContent>
       </Dialog>
     );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -27,10 +27,15 @@ const DialogOverlay = React.forwardRef<
 ))
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  hideCloseButton?: boolean
+}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, children, hideCloseButton, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -42,10 +47,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!hideCloseButton && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Fechar</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ))


### PR DESCRIPTION
## Summary
- add `hideCloseButton` prop to dialog content to make default close button optional
- hide default dialog close icon in mobile tooltip implementation
- enlarge mobile tooltip close button for comfortable tap target

## Testing
- `npm run lint` *(fails: `lowerMessage` unused and forbidden `require()` import)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688cfbe20a4c832da4b110071df7c274