### PR TITLE
Fix mobile header height

### DIFF
--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -34,16 +34,16 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
       data-mobile="true"
       className={`fixed top-0 left-0 right-0 z-[9999] bg-white border-b border-gray-200 shadow-sm ${hasNotch ? 'pt-safe-top' : ''}`}
     >
-      <div className="h-[52px] px-4 flex items-center justify-between">
+      <div className="h-[64px] px-4 flex items-center justify-between">
         {/* Logo */}
         <Link to="/" className="flex items-center tap-transparent" aria-label="Ir para página inicial da Libra Crédito">
-          <div className="h-[52px] overflow-hidden flex items-center">
+          <div className="h-[64px] overflow-hidden flex items-center">
             <img
               src="/images/optimized/logo-header.webp"
               alt="Libra Crédito - Simulação de crédito com garantia de imóvel"
-              className="header-logo"
-              width="120"
-              height="120"
+              className="header-logo h-[48px]"
+              width="90"
+              height="90"
             />
           </div>
         </Link>


### PR DESCRIPTION
## Summary
- bump mobile header height to 64px so the header aligns with wave separators
- shrink the mobile logo 25% within the header so it doesn't dominate the space

## Testing
- `npm run lint` *(fails: 63 errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688d10f56674832dadb3cd1c23de7fa4