### PR TITLE
Split SAC/PRICE info into separate paragraphs

### DIFF
--- a/src/components/form/AmortizationField.tsx
+++ b/src/components/form/AmortizationField.tsx
@@ -15,7 +15,14 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange, 
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
         Escolha a Amortização
-        <ResponsiveInfo content="SAC: parcelas maiores no início e que vão diminuindo com o tempo. PRICE: parcelas fixas ao longo do contrato." />
+        <ResponsiveInfo
+          content={
+            <>
+              <p>SAC: parcelas maiores no início e que vão diminuindo com o tempo.</p>
+              <p>PRICE: parcelas fixas ao longo do contrato.</p>
+            </>
+          }
+        />
       </label>
       <div className={cn('flex items-center gap-2', isInvalid && 'border border-red-500 rounded-md p-2')}>
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">


### PR DESCRIPTION
## Summary
- update amortization field tooltip to show SAC and PRICE descriptions on separate lines

## Testing
- `npm test`
- `npm run lint` *(fails: `'e' is defined but never used` and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d1ce87ff4832daae7c565ac23e47f