### PR TITLE
Fix accessible contrast for green text

### DIFF
--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -90,11 +90,11 @@ const Benefits: React.FC = () => {
       <section id="benefits" className={`${isMobile ? 'pt-4 pb-6' : 'pt-6 md:pt-8 lg:pt-8 xl:pt-10 pb-6 md:pb-8 lg:pb-8 xl:pb-10'} bg-white scroll-mt-header`}>
         <div className="container mx-auto px-4">
           <div className="text-center mb-6 md:mb-8 lg:mb-8 xl:mb-10">
-            <p className={`${isMobile ? 'text-sm' : 'text-lg'} text-green-500 font-semibold uppercase tracking-wider mb-4`}>
+            <p className={`${isMobile ? 'text-sm' : 'text-lg'} text-green-700 font-semibold uppercase tracking-wider mb-4`}>
               Soluções para cada necessidade
             </p>
             <h2 className={`${isMobile ? 'text-2xl' : 'text-3xl md:text-4xl'} font-bold text-gray-800 mb-3`}>
-              Como usar o <span className="text-green-500">Crédito com Garantia de Imóvel</span>
+              Como usar o <span className="text-green-700">Crédito com Garantia de Imóvel</span>
             </h2>
           </div>
           
@@ -121,7 +121,7 @@ const Benefits: React.FC = () => {
               <Link to="/vantagens">
                 <Button
                   size="lg"
-                  className="bg-green-500 hover:bg-green-600 text-white px-8 py-3"
+                  className="bg-green-700 hover:bg-green-800 text-white px-8 py-3"
                 >
                   Conheça Mais Vantagens
                 </Button>
@@ -129,7 +129,7 @@ const Benefits: React.FC = () => {
               <Button
                 size="lg"
                 variant="outline"
-                className="border-green-500 text-green-500 hover:bg-green-500 hover:text-white px-8 py-3"
+                className="border-green-700 text-green-700 hover:bg-green-700 hover:text-white px-8 py-3"
                 onClick={() => {
                   const testimonialsSection = document.getElementById('testimonials');
                   if (testimonialsSection) {

--- a/src/components/CGISection.tsx
+++ b/src/components/CGISection.tsx
@@ -31,7 +31,7 @@ const CGISection: React.FC = () => {
         {/* Section Header */}
         <div className="text-center mb-12">
           <h2 className="text-2xl md:text-3xl font-bold text-gray-800 mb-4">
-            Como usar seu <span className="text-green-500">CGI Libra?</span>
+            Como usar seu <span className="text-green-700">CGI Libra?</span>
           </h2>
           <p className="text-gray-600 text-lg">
             Literalmente do jeito que quiser!

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -81,7 +81,7 @@ const FAQ: React.FC = () => {
       <div className="container mx-auto px-4">
         <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl md:text-4xl font-bold text-gray-800 mb-4">
-            Perguntas <span className="text-green-500">frequentes:</span>
+            Perguntas <span className="text-green-700">frequentes:</span>
           </h2>
           <p className={`${isMobile ? 'text-base px-2' : 'text-lg'} text-gray-600 max-w-2xl mx-auto`}>
             Esclarecemos as principais dúvidas sobre crédito com garantia de imóvel

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -415,7 +415,7 @@ const SimulationForm: React.FC = () => {
         {/* Formulário de Simulação */}
         <Card className="shadow-lg">
           <CardHeader className="text-center pb-2">
-            <CardTitle className="text-lg md:text-xl font-bold text-green-500 mb-1">
+            <CardTitle className="text-lg md:text-xl font-bold text-green-700 mb-1">
               Sua simulação em um clique!
             </CardTitle>
             <p className="text-gray-600 text-xs">

--- a/src/components/StepsSection.tsx
+++ b/src/components/StepsSection.tsx
@@ -14,12 +14,12 @@ const StepsSection: React.FC = () => {
       textColor: "text-blue-600"
     },
     {
-      number: "2", 
+      number: "2",
       title: "Análise de crédito",
       description: "Nossa equipe analisa seu perfil e documenta o processo",
       image: "/images/customer-testimonial.png",
       bgColor: "bg-green-50",
-      textColor: "text-green-600"
+      textColor: "text-green-700"
     },
     {
       number: "3",

--- a/src/components/TransparencySection.tsx
+++ b/src/components/TransparencySection.tsx
@@ -22,8 +22,8 @@ const TransparencySection: React.FC = () => {
             {/* Testimonial Content */}
             <div className="flex-1 text-center md:text-left">
               <h2 className="text-2xl md:text-3xl font-bold text-gray-800 mb-4">
-                Quem <span className="text-green-500">conhece</span>{' '}
-                <span className="text-green-500">confia</span>
+                Quem <span className="text-green-700">conhece</span>{' '}
+                <span className="text-green-700">confia</span>
               </h2>
               
               <div className="bg-white rounded-2xl p-6 shadow-sm">

--- a/src/components/ValidatedInput.tsx
+++ b/src/components/ValidatedInput.tsx
@@ -61,7 +61,7 @@ export const ValidatedInput: React.FC<ValidatedInputProps> = ({
             {hasError ? (
               <AlertCircle className="h-4 w-4 text-red-500" />
             ) : (
-              <CheckCircle className="h-4 w-4 text-green-500" />
+              <CheckCircle className="h-4 w-4 text-green-700" />
             )}
           </div>
         )}

--- a/src/components/ValidatedSelect.tsx
+++ b/src/components/ValidatedSelect.tsx
@@ -67,7 +67,7 @@ export const ValidatedSelect: React.FC<ValidatedSelectProps> = ({
                 {hasError ? (
                   <AlertCircle className="h-4 w-4 text-red-500" />
                 ) : (
-                  <CheckCircle className="h-4 w-4 text-green-500" />
+                  <CheckCircle className="h-4 w-4 text-green-700" />
                 )}
               </div>
             )}

--- a/src/components/form/AmortizationField.tsx
+++ b/src/components/form/AmortizationField.tsx
@@ -13,13 +13,13 @@ interface AmortizationFieldProps {
 const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange, isInvalid = false }) => {
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
+      <label className="text-xs font-medium text-green-700 mb-1 flex items-center gap-1">
         Escolha a Amortização
         <ResponsiveInfo content="SAC: parcelas maiores no início e que vão diminuindo com o tempo. PRICE: parcelas fixas ao longo do contrato." />
       </label>
       <div className={cn('flex items-center gap-2', isInvalid && 'border border-red-500 rounded-md p-2')}>
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-          <Calculator className="w-4 h-4 text-green-500" />
+          <Calculator className="w-4 h-4 text-green-700" />
         </div>
         <div className="flex-1">
           <div className="flex gap-4">
@@ -29,7 +29,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange, 
                 value="PRICE"
                 checked={value === 'PRICE'}
                 onChange={(e) => onChange(e.target.value)}
-                className="text-green-500"
+                className="text-green-700"
               />
               <span className="text-xs">PRICE</span>
             </label>
@@ -39,7 +39,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange, 
                 value="SAC"
                 checked={value === 'SAC'}
                 onChange={(e) => onChange(e.target.value)}
-                className="text-green-500"
+                className="text-green-700"
               />
               <span className="text-xs">SAC</span>
             </label>

--- a/src/components/form/CityAutocomplete.tsx
+++ b/src/components/form/CityAutocomplete.tsx
@@ -136,13 +136,13 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
 
   return (
     <div ref={containerRef} className="flex flex-col gap-1 relative">
-      <label className="text-xs font-medium text-green-500 mb-1">
+      <label className="text-xs font-medium text-green-700 mb-1">
         Selecione a cidade do imóvel a ser utilizado como garantia
       </label>
       <div className="flex items-center gap-2">
         {/* Icon */}
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-          <MapPin className="w-4 h-4 text-green-500" />
+          <MapPin className="w-4 h-4 text-green-700" />
         </div>
         <div className="flex-1 relative">
           {/* Input with green border */}
@@ -161,7 +161,7 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
               'text-sm w-full px-3 py-2 rounded-md border-2 focus:outline-none transition-colors scroll-mt-header',
               isInvalid
                 ? 'border-red-500 focus:border-red-500'
-                : 'border-green-500 focus:border-green-600'
+                : 'border-green-700 focus:border-green-800'
             )}
           />
 
@@ -201,7 +201,7 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
                       }`}
                     >
                       <div className="flex items-center gap-2">
-                        <MapPin className="w-3 h-3 text-green-500 flex-shrink-0" />
+                        <MapPin className="w-3 h-3 text-green-700 flex-shrink-0" />
                         <span className="truncate">{city}</span>
                       </div>
                     </li>

--- a/src/components/form/CityField.tsx
+++ b/src/components/form/CityField.tsx
@@ -16,7 +16,7 @@ const CityField: React.FC<CityFieldProps> = ({ value, onChange }) => {
       </label>
       <div className="flex items-center gap-2">
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-          <MapPin className="w-4 h-4 text-green-500" />
+          <MapPin className="w-4 h-4 text-green-700" />
         </div>
         <div className="flex-1">
           <Select value={value} onValueChange={onChange}>

--- a/src/components/form/GuaranteeAmountField.tsx
+++ b/src/components/form/GuaranteeAmountField.tsx
@@ -20,13 +20,13 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
 }) => {
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
+      <label className="text-xs font-medium text-green-700 mb-1 flex items-center gap-1">
         Digite o valor do Imóvel em Garantia
         <ResponsiveInfo content="Insira aqui o valor da garantia (valor do imóvel a ser considerado na operação)." />
       </label>
       <div className="flex items-center gap-2">
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-          <Home className="w-4 h-4 text-green-500" />
+          <Home className="w-4 h-4 text-green-700" />
         </div>
         <div className="flex-1">
           <Input

--- a/src/components/form/InstallmentsField.tsx
+++ b/src/components/form/InstallmentsField.tsx
@@ -11,7 +11,7 @@ const InstallmentsField: React.FC<InstallmentsFieldProps> = ({ value, onChange }
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between mb-1">
-        <label className="text-xs font-medium text-green-500">
+        <label className="text-xs font-medium text-green-700">
           Em quantas parcelas?
         </label>
         <span className="bg-libra-blue text-white px-2 py-0.5 rounded text-xs font-bold">
@@ -20,7 +20,7 @@ const InstallmentsField: React.FC<InstallmentsFieldProps> = ({ value, onChange }
       </div>
       <div className="flex items-center gap-2">
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-          <Calendar className="w-4 h-4 text-green-500" />
+          <Calendar className="w-4 h-4 text-green-700" />
         </div>
         <div className="flex-1">
           <input

--- a/src/components/form/LoanAmountField.tsx
+++ b/src/components/form/LoanAmountField.tsx
@@ -15,13 +15,13 @@ interface LoanAmountFieldProps {
 const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange, isInvalid = false }) => {
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-xs font-medium text-green-500 mb-1 flex items-center gap-1">
+      <label className="text-xs font-medium text-green-700 mb-1 flex items-center gap-1">
         Digite o valor desejado do Empréstimo
         <ResponsiveInfo content="Insira aqui o valor que você pretende pegar de empréstimo." />
       </label>
       <div className="flex items-center gap-2">
         <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-          <DollarSign className="w-4 h-4 text-green-500" />
+          <DollarSign className="w-4 h-4 text-green-700" />
         </div>
         <div className="flex-1">
           <Input

--- a/src/components/ui/PremiumLoading.tsx
+++ b/src/components/ui/PremiumLoading.tsx
@@ -25,7 +25,7 @@ const PremiumLoading: React.FC<PremiumLoadingProps> = ({
   const colorClasses = {
     blue: 'text-blue-500',
     purple: 'text-purple-500',
-    green: 'text-green-500',
+    green: 'text-green-700',
     yellow: 'text-yellow-500',
     white: 'text-white'
   };

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -112,7 +112,7 @@ const AccordionTrigger: React.FC<AccordionTriggerProps> = ({ children, className
       {children}
       <ChevronDown
         className={cn(
-          'w-5 h-5 transition-transform duration-200 text-green-500',
+          'w-5 h-5 transition-transform duration-200 text-green-700',
           isOpen && 'transform rotate-180'
         )}
       />


### PR DESCRIPTION
## Summary
- use darker green for better readability across headings and form labels
- adjust button colors for better contrast
- tweak icons and outlines to match new darker green

## Testing
- `npm run lint` *(fails: no-unused-vars and other warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688d1c8ea240832da8ad897636001db1