### PR TITLE
Fix h1 font size warning

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,18 @@
   }
 }
 
+@layer base {
+  h1 {
+    @apply text-2xl;
+  }
+  article h1,
+  aside h1,
+  nav h1,
+  section h1 {
+    @apply text-2xl;
+  }
+}
+
 @layer components {
   /* Mobile Performance Optimizations */
   @media (max-width: 767px) {


### PR DESCRIPTION
## Summary
- ensure h1 elements always have a font size

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688d1c6e6bd4832da44e7a6767c4acac