### PR TITLE
Fix scroll for limit messages on mobile

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -123,6 +123,18 @@ const SimulationForm: React.FC = () => {
     }
   };
 
+  // Rolagem para mensagens de limite (rural/ltv30) no mobile
+  const scrollToApiMessage = () => {
+    if (isMobile) {
+      setTimeout(() => {
+        const messageElement = document.querySelector('[data-api-message="true"]');
+        if (messageElement) {
+          (messageElement as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }, 300);
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -186,6 +198,9 @@ const SimulationForm: React.FC = () => {
           // É uma mensagem estruturada do serviço local
           setApiMessage(analysis);
           setErro(''); // Limpar erro genérico
+          if (analysis.type === 'limit_30_general' || analysis.type === 'limit_30_rural') {
+            scrollToApiMessage();
+          }
         } else {
           // É um erro genérico
           let errorMessage = 'Erro desconhecido ao realizar simulação';
@@ -293,6 +308,9 @@ const SimulationForm: React.FC = () => {
           if (analysis.type !== 'unknown_error') {
             setApiMessage(analysis);
             setErro('');
+            if (analysis.type === 'limit_30_general' || analysis.type === 'limit_30_rural') {
+              scrollToApiMessage();
+            }
           } else {
             let errorMessage = 'Erro ao processar simulação automática';
             
@@ -385,6 +403,9 @@ const SimulationForm: React.FC = () => {
           if (analysis.type !== 'unknown_error') {
             setApiMessage(analysis);
             setErro('');
+            if (analysis.type === 'limit_30_general' || analysis.type === 'limit_30_rural') {
+              scrollToApiMessage();
+            }
           } else {
             setErro('Erro ao refazer simulação com tabela PRICE');
             setApiMessage(null);

--- a/src/components/messages/Limit30General.tsx
+++ b/src/components/messages/Limit30General.tsx
@@ -36,7 +36,7 @@ const Limit30General: React.FC<Limit30GeneralProps> = ({
   };
 
   return (
-    <div className={`bg-blue-50 border border-blue-200 rounded-lg ${isMobile ? 'p-3 mx-2' : 'p-4'} max-w-full overflow-hidden`}>
+    <div data-api-message="true" className={`bg-blue-50 border border-blue-200 rounded-lg ${isMobile ? 'p-3 mx-2' : 'p-4'} max-w-full overflow-hidden`}>
       <div className={`flex items-start ${isMobile ? 'gap-2' : 'gap-3'}`}>
         <div className={`bg-blue-100 ${isMobile ? 'p-1.5' : 'p-2'} rounded-full flex-shrink-0`}>
           <Info className={`${isMobile ? 'w-4 h-4' : 'w-5 h-5'} text-blue-600`} />

--- a/src/components/messages/Limit30Rural.tsx
+++ b/src/components/messages/Limit30Rural.tsx
@@ -40,7 +40,7 @@ const Limit30Rural: React.FC<Limit30RuralProps> = ({
   };
 
   return (
-    <div className={`bg-green-50 border border-green-200 rounded-lg ${isMobile ? 'p-3 mx-2' : 'p-4'} max-w-full overflow-hidden`}>
+    <div data-api-message="true" className={`bg-green-50 border border-green-200 rounded-lg ${isMobile ? 'p-3 mx-2' : 'p-4'} max-w-full overflow-hidden`}>
       <div className={`flex items-start ${isMobile ? 'gap-2' : 'gap-3'}`}>
         <div className={`bg-green-100 ${isMobile ? 'p-1.5' : 'p-2'} rounded-full flex-shrink-0`}>
           <Wheat className={`${isMobile ? 'w-4 h-4' : 'w-5 h-5'} text-green-600`} />


### PR DESCRIPTION
## Summary
- enable mobile scroll-to-message for LTV 30 and rural scenarios
- add data attributes to limit message containers

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d5d9046f0832d8c8ce8f274762e44