### PR TITLE
feat: scroll to simulation card on desktop

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -434,7 +434,7 @@ const SimulationForm: React.FC = () => {
     >
       <div className={`${showSideComplement ? 'grid grid-cols-1 lg:grid-cols-2 gap-6' : ''}`}>
         {/* Formulário de Simulação */}
-        <Card className="shadow-lg">
+        <Card className="shadow-lg" id="simulation-card">
           <CardHeader className="text-center pb-2">
             <CardTitle className="text-lg md:text-xl font-bold text-green-700 mb-1">
               Sua simulação em um clique!

--- a/src/pages/Simulacao.tsx
+++ b/src/pages/Simulacao.tsx
@@ -4,6 +4,7 @@ import MobileLayout from '@/components/MobileLayout';
 import SimulationForm from '@/components/SimulationForm';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 import { useIsMobile } from '@/hooks/use-mobile';
+import scrollToTarget from '@/utils/scrollToTarget';
 
 const Simulacao = () => {
   const isMobile = useIsMobile();
@@ -18,6 +19,18 @@ const Simulacao = () => {
       metaDescription.setAttribute('content', 'Simulação gratuita de crédito com garantia de imóvel. Taxa mínima 1,19% a.m. Descubra sua parcela em segundos com nossa calculadora online.');
     }
   }, []);
+
+  useEffect(() => {
+    if (!isMobile) {
+      const frame = requestAnimationFrame(() => {
+        const card = document.getElementById('simulation-card');
+        if (card) {
+          scrollToTarget(card, -64);
+        }
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+  }, [isMobile]);
 
   return (
     <MobileLayout>


### PR DESCRIPTION
## Summary
- add identifier to simulation form card
- scroll desktop users directly to simulation card on mount

## Testing
- `npm test`
- `npm run typecheck`
- `npx eslint src/components/SimulationForm.tsx src/pages/Simulacao.tsx` *(fails: 'Input' is defined but never used. Allowed unused vars must match /^_/u @typescript-eslint/no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_688d6d2b8fa4832d92c634d1ca72ff57