### PR TITLE
feat: scroll to simulation card on desktop

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -43,7 +43,6 @@
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { validateForm } from '@/utils/validations';
 import { LocalSimulationService, SimulationResult } from '@/services/localSimulationService';
 import { useUserJourney } from '@/hooks/useUserJourney';
@@ -53,12 +52,10 @@ import LoanAmountField from './form/LoanAmountField';
 import GuaranteeAmountField from './form/GuaranteeAmountField';
 import InstallmentsField from './form/InstallmentsField';
 import AmortizationField from './form/AmortizationField';
-import ResultCard from './ResultCard';
-import ContactForm from './ContactForm';
 import ApiMessageDisplay from './ApiMessageDisplay';
 import SmartApiMessage from './messages/SmartApiMessage';
 import SimulationResultDisplay from './SimulationResultDisplay';
-import { analyzeApiMessage, ApiMessageAnalysis } from '@/utils/apiMessageAnalyzer';
+import { ApiMessageAnalysis } from '@/utils/apiMessageAnalyzer';
 import { analyzeLocalMessage } from '@/utils/localMessageAnalyzer';
 import { formatBRL, norm } from '@/utils/formatters';
 import { toast } from '@/components/ui/use-toast';
@@ -75,7 +72,7 @@ const SimulationForm: React.FC = () => {
   const [resultado, setResultado] = useState<SimulationResult | null>(null);
   const [erro, setErro] = useState('');
   const [apiMessage, setApiMessage] = useState<ApiMessageAnalysis | null>(null);
-  const [isRuralProperty, setIsRuralProperty] = useState(false);
+  const [_isRuralProperty, setIsRuralProperty] = useState(false);
 
   // Validações
   const validation = validateForm(emprestimo, garantia, parcelas, amortizacao, cidade);
@@ -434,8 +431,8 @@ const SimulationForm: React.FC = () => {
     >
       <div className={`${showSideComplement ? 'grid grid-cols-1 lg:grid-cols-2 gap-6' : ''}`}>
         {/* Formulário de Simulação */}
-        <Card className="shadow-lg">
-          <CardHeader className="text-center pb-2">
+        <Card className="shadow-lg" id="simulation-card">
+          <CardHeader data-sim-card-header="true" className="text-center pb-2">
             <CardTitle className="text-lg md:text-xl font-bold text-green-700 mb-1">
               Sua simulação em um clique!
             </CardTitle>

--- a/src/pages/Simulacao.tsx
+++ b/src/pages/Simulacao.tsx
@@ -4,6 +4,7 @@ import MobileLayout from '@/components/MobileLayout';
 import SimulationForm from '@/components/SimulationForm';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 import { useIsMobile } from '@/hooks/use-mobile';
+import scrollToTarget from '@/utils/scrollToTarget';
 
 const Simulacao = () => {
   const isMobile = useIsMobile();
@@ -18,6 +19,20 @@ const Simulacao = () => {
       metaDescription.setAttribute('content', 'Simulação gratuita de crédito com garantia de imóvel. Taxa mínima 1,19% a.m. Descubra sua parcela em segundos com nossa calculadora online.');
     }
   }, []);
+
+  useEffect(() => {
+    if (!isMobile) {
+      const frame = requestAnimationFrame(() => {
+        const card = document.getElementById('simulation-card');
+        const headerHeight = document.querySelector('header')?.offsetHeight ?? 0;
+        const cardHeader = card?.querySelector('[data-sim-card-header="true"]') as HTMLElement | null;
+        if (cardHeader) {
+          scrollToTarget(cardHeader, -headerHeight);
+        }
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+  }, [isMobile]);
 
   return (
     <MobileLayout>


### PR DESCRIPTION
## Summary
- add identifier to simulation form card and header
- scroll desktop users directly to simulation card using header height
- remove unused imports and state to satisfy lint

## Testing
- `npm test`
- `npm run typecheck`
- `npx eslint src/components/SimulationForm.tsx src/pages/Simulacao.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688d6d2b8fa4832d92c634d1ca72ff57