### PR TITLE
feat: improve grid layout stretching

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -429,9 +429,9 @@ const SimulationForm: React.FC = () => {
         isMobile ? 'py-2 pb-4' : 'py-2 min-h-[calc(100vh-4rem)]'
       } ${showSideComplement ? 'max-w-6xl' : 'max-w-xl'}`}
     >
-      <div className={`${showSideComplement ? 'grid grid-cols-1 lg:grid-cols-2 gap-6' : ''}`}>
+      <div className={`${showSideComplement ? 'grid grid-cols-1 lg:grid-cols-2 gap-6 items-stretch justify-center' : ''}`}> 
         {/* Formulário de Simulação */}
-        <Card className="shadow-lg" id="simulation-card">
+        <Card className="shadow-lg h-full" id="simulation-card">
           <CardHeader data-sim-card-header="true" className="text-center pb-2">
             <CardTitle className="text-lg md:text-xl font-bold text-green-700 mb-1">
               Sua simulação em um clique!
@@ -531,7 +531,10 @@ const SimulationForm: React.FC = () => {
 
         {/* Resultado ou Complemento */}
         {(resultado || (!isMobile && isLtvMessage && apiMessage)) && (
-          <div data-result-section="true" className={`${showSideComplement ? '' : 'mt-4'} scroll-mt-header`}>
+          <div
+            data-result-section="true"
+            className={`scroll-mt-header h-full ${showSideComplement ? '' : 'mt-4'}`}
+          >
             {resultado ? (
               <SimulationResultDisplay
                 resultado={resultado}

--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import Calculator from 'lucide-react/dist/esm/icons/calculator';
 import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
 import Users from 'lucide-react/dist/esm/icons/users';
-import Info from 'lucide-react/dist/esm/icons/info';
 import TrendingUp from 'lucide-react/dist/esm/icons/trending-up';
 import Headphones from 'lucide-react/dist/esm/icons/headphones';
 import { Button } from '@/components/ui/button';
@@ -106,14 +105,14 @@ const SwitchPriceTip: React.FC<{ onSwitchToPrice?: () => void }> = ({
  */
 const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
   resultado,
-  valorEmprestimo,
-  valorImovel,
-  cidade,
+  valorEmprestimo: _valorEmprestimo,
+  valorImovel: _valorImovel,
+  cidade: _cidade,
   onNewSimulation,
   onSwitchToPrice
 }) => {
   const isMobile = useIsMobile();
-  const { valor, amortizacao, parcelas, primeiraParcela, ultimaParcela } = resultado;
+  const { valor, amortizacao, parcelas: _parcelas, primeiraParcela, ultimaParcela } = resultado;
   
   // Cálculo da renda mínima familiar
   const calcularRendaMinima = () => {
@@ -129,7 +128,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
   if (isMobile) {
     // Layout Mobile - Sucinto e direto
     return (
-      <div className="bg-libra-green rounded-xl p-4 text-libra-navy shadow-xl">
+      <div className="flex flex-col h-full bg-libra-green rounded-xl p-4 text-libra-navy shadow-xl">
 
         {/* Header compacto */}
         <div className="flex items-center gap-2 mb-4">
@@ -221,7 +220,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
   
   // Layout Desktop - Adaptação do Mobile na Lateral
   return (
-    <div className="bg-libra-green rounded-xl p-4 text-libra-navy shadow-xl">
+    <div className="flex flex-col h-full bg-libra-green rounded-xl p-4 text-libra-navy shadow-xl">
 
       {/* Header compacto */}
       <div className="flex items-center justify-between mb-3">


### PR DESCRIPTION
## Summary
- ensure grid items stretch and center in simulation form
- expand form and result containers to fill grid height
- adjust result display root to flex column and h-full

## Testing
- `npm run lint` *(fails: 295 problems, 57 errors, 238 warnings)*
- `npx eslint src/components/SimulationForm.tsx src/components/SimulationResultDisplay.tsx` *(fails: 1 warning)*
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d73fb5820832d920ababd7b70064c