### PR TITLE
feat: apply institutional blue to limit message

### DIFF
--- a/src/components/messages/Limit30General.tsx
+++ b/src/components/messages/Limit30General.tsx
@@ -36,27 +36,27 @@ const Limit30General: React.FC<Limit30GeneralProps> = ({
   };
 
   return (
-    <div data-api-message="true" className={`bg-blue-50 border border-blue-200 rounded-lg ${isMobile ? 'p-3 mx-2' : 'p-4'} max-w-full overflow-hidden`}>
+    <div data-api-message="true" className={`bg-libra-blue/10 border border-libra-blue/20 rounded-lg ${isMobile ? 'p-3 mx-2' : 'p-4'} max-w-full overflow-hidden`}>
       <div className={`flex items-start ${isMobile ? 'gap-2' : 'gap-3'}`}>
-        <div className={`bg-blue-100 ${isMobile ? 'p-1.5' : 'p-2'} rounded-full flex-shrink-0`}>
-          <Info className={`${isMobile ? 'w-4 h-4' : 'w-5 h-5'} text-blue-600`} />
+        <div className={`bg-libra-blue/20 ${isMobile ? 'p-1.5' : 'p-2'} rounded-full flex-shrink-0`}>
+          <Info className={`${isMobile ? 'w-4 h-4' : 'w-5 h-5'} text-libra-blue`} />
         </div>
         
         <div className="flex-1 min-w-0">
-          <h3 className={`font-semibold text-blue-900 ${isMobile ? 'mb-1' : 'mb-2'} flex items-center gap-2 ${isMobile ? 'text-sm' : 'text-base'}`}>
-            <MapPin className={`${isMobile ? 'w-3 h-3' : 'w-4 h-4'} flex-shrink-0`} />
+          <h3 className={`font-semibold text-libra-navy ${isMobile ? 'mb-1' : 'mb-2'} flex items-center gap-2 ${isMobile ? 'text-sm' : 'text-base'}`}>
+            <MapPin className={`${isMobile ? 'w-3 h-3' : 'w-4 h-4'} flex-shrink-0 text-libra-blue`} />
             <span className="truncate">Limite Especial para {cidade}</span>
           </h3>
-          
-          <div className={`text-blue-800 ${isMobile ? 'text-xs' : 'text-sm'} mb-3`}>
+
+          <div className={`text-libra-blue ${isMobile ? 'text-xs' : 'text-sm'} mb-3`}>
             <p className={`${isMobile ? 'mb-1' : 'mb-2'} leading-relaxed`}>
-              Na cidade de <strong>{cidade}</strong>, o valor máximo de empréstimo 
+              Na cidade de <strong>{cidade}</strong>, o valor máximo de empréstimo
               é limitado a <strong>30% do valor do imóvel</strong>.
             </p>
-            
-            <div className={`bg-white rounded ${isMobile ? 'p-2' : 'p-3'} border border-blue-100`}>
+
+            <div className={`bg-white rounded ${isMobile ? 'p-2' : 'p-3'} border border-libra-blue/10`}>
               <div className={`flex items-center gap-2 ${isMobile ? 'mb-1' : 'mb-2'}`}>
-                <Calculator className={`${isMobile ? 'w-3 h-3' : 'w-4 h-4'} text-blue-600 flex-shrink-0`} />
+                <Calculator className={`${isMobile ? 'w-3 h-3' : 'w-4 h-4'} text-libra-blue flex-shrink-0`} />
                 <span className={`font-medium ${isMobile ? 'text-xs' : 'text-sm'}`}>Cálculo para seu imóvel:</span>
               </div>
               <div className={`${isMobile ? 'text-xs' : 'text-sm'} space-y-1`}>
@@ -65,11 +65,11 @@ const Limit30General: React.FC<Limit30GeneralProps> = ({
               </div>
             </div>
           </div>
-          
+
           <div className={`flex ${isMobile ? 'flex-col space-y-2' : 'gap-2'}`}>
             <Button
               onClick={handleAdjustClick}
-              className={`bg-blue-600 hover:bg-blue-700 text-white flex items-center justify-center gap-2 ${isMobile ? 'w-full text-xs' : ''}`}
+              className={`bg-libra-blue hover:bg-libra-navy text-white flex items-center justify-center gap-2 ${isMobile ? 'w-full text-xs' : ''}`}
               size={isMobile ? "sm" : "sm"}
             >
               <Calculator className={`${isMobile ? 'w-3 h-3' : 'w-4 h-4'} flex-shrink-0`} />
@@ -77,11 +77,11 @@ const Limit30General: React.FC<Limit30GeneralProps> = ({
                 {isMobile ? `Ajustar para R$ ${(valorMaximoEmprestimo / 1000).toFixed(0)}k` : `Ajustar para R$ ${valorMaximoEmprestimo.toLocaleString('pt-BR')}`}
               </span>
             </Button>
-            
+
             <Button
               onClick={onTryAgain}
               variant="outline"
-              className={`border-blue-300 text-blue-700 hover:bg-blue-50 ${isMobile ? 'w-full text-xs' : ''}`}
+              className={`border-libra-blue text-libra-blue hover:bg-libra-blue/10 ${isMobile ? 'w-full text-xs' : ''}`}
               size={isMobile ? "sm" : "sm"}
             >
               Tentar Outra Cidade


### PR DESCRIPTION
## Summary
- switch Limit30General message to institutional blues for backgrounds, text, borders and icons
- update primary and secondary buttons to use libra-blue and libra-navy shades

## Testing
- `npm run lint` (fails: 'e' is defined but never used)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d7706a608832d946ac804e357177e