### PR TITLE
Reduce padding on desktop new simulation button

### DIFF
--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -231,7 +231,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
         <Button
           onClick={onNewSimulation}
           variant="outline"
-          className="bg-white/10 border-white/30 text-white hover:bg-white/20 text-xs px-3 py-2"
+          className="bg-white/10 border-white/30 text-white hover:bg-white/20 text-xs px-2 py-1"
           size="sm"
         >
           <Calculator className="w-3 h-3 mr-1 text-white" />


### PR DESCRIPTION
## Summary
- tighten padding on "Nova Simulação" button in desktop results to shrink its footprint

## Testing
- `npm run lint` *(fails: Unexpected console statements and unused variable in other files)*
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d79208fa8832db6bb96b9565cca43