### PR TITLE
feat: confirm rural property before simulation

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -72,7 +72,7 @@ const SimulationForm: React.FC = () => {
   const [resultado, setResultado] = useState<SimulationResult | null>(null);
   const [erro, setErro] = useState('');
   const [apiMessage, setApiMessage] = useState<ApiMessageAnalysis | null>(null);
-  const [_isRuralProperty, setIsRuralProperty] = useState(false);
+  const [isRuralProperty, setIsRuralProperty] = useState(false);
 
   // Validações
   const validation = validateForm(emprestimo, garantia, parcelas, amortizacao, cidade);
@@ -162,7 +162,8 @@ const SimulationForm: React.FC = () => {
         parcelas: parcelas,
         tipoAmortizacao: amortizacao,
         userAgent: navigator.userAgent,
-        ipAddress: undefined
+        ipAddress: undefined,
+        isRuralProperty
       };
 
 
@@ -275,7 +276,8 @@ const SimulationForm: React.FC = () => {
           parcelas: parcelas,
           tipoAmortizacao: amortizacao,
           userAgent: navigator.userAgent,
-          ipAddress: undefined
+          ipAddress: undefined,
+          isRuralProperty: isRural
         };
 
 
@@ -370,7 +372,8 @@ const SimulationForm: React.FC = () => {
           parcelas: parcelas,
           tipoAmortizacao: 'PRICE',
           userAgent: navigator.userAgent,
-          ipAddress: undefined
+          ipAddress: undefined,
+          isRuralProperty
         };
 
 


### PR DESCRIPTION
## Summary
- require rural confirmation for rural-only cities, always showing 30% loan limit
- pass rural confirmation flag through simulation form to allow proceeding after confirmation

## Testing
- `npm run lint` (fails: 51 errors, 238 warnings)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d7b62c1bc832dacad325a4d4a9331