### PR TITLE
feat: detect rural-only messages

### DIFF
--- a/src/utils/__tests__/localMessageAnalyzer.test.ts
+++ b/src/utils/__tests__/localMessageAnalyzer.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeLocalMessage } from '../localMessageAnalyzer';
+
+describe('analyzeLocalMessage', () => {
+  it('detects rural-only messages without 30% reference', () => {
+    const message = 'Para a cidade Teste, trabalhamos apenas com imóveis rurais.';
+    const analysis = analyzeLocalMessage(message);
+
+    expect(analysis.type).toBe('limit_30_rural');
+    expect(analysis.cidade).toBe('Teste');
+    expect(analysis.needsRuralConfirmation).toBe(true);
+    expect(analysis.shouldLimitTo30Percent).toBe(true);
+  });
+});

--- a/src/utils/localMessageAnalyzer.ts
+++ b/src/utils/localMessageAnalyzer.ts
@@ -32,15 +32,31 @@ export const analyzeLocalMessage = (message: string): ApiMessageAnalysis => {
   if (lowerMessage.includes('apenas com imóveis rurais') && lowerMessage.includes('30%')) {
     const cityMatch = message.match(/cidade\s+([^,]+)/i) || message.match(/em\s+([^,]+)/i);
     const valueMatch = message.match(/r\$?\s*([\d.,]+)/i);
-    
+
     const cidade = cityMatch ? cityMatch[1].trim() : undefined;
     const valorSugerido = valueMatch ? parseMonetaryValue(valueMatch[1]) : undefined;
-    
+
     return {
       type: 'limit_30_rural',
       originalMessage: message,
       cidade,
       valorSugerido,
+      shouldBlockSimulation: false,
+      needsRuralConfirmation: true,
+      shouldLimitTo30Percent: true
+    };
+  }
+
+  // Padrão 2.1: Apenas imóveis rurais sem menção ao limite de 30%
+  // "Para a cidade [cidade], trabalhamos apenas com imóveis rurais."
+  if (lowerMessage.includes('apenas com imóveis rurais') && !lowerMessage.includes('30%')) {
+    const cityMatch = message.match(/cidade\s+([^,]+)/i) || message.match(/em\s+([^,]+)/i);
+    const cidade = cityMatch ? cityMatch[1].trim() : undefined;
+
+    return {
+      type: 'limit_30_rural',
+      originalMessage: message,
+      cidade,
       shouldBlockSimulation: false,
       needsRuralConfirmation: true,
       shouldLimitTo30Percent: true


### PR DESCRIPTION
## Summary
- detect messages that mention only rural properties
- test rural-only message handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d7b63f99c832da899f7dbb073e232