### PR TITLE
feat: respect current loan on LTV messages

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -235,8 +235,11 @@ const SimulationForm: React.FC = () => {
 
   // Função para ajustar valores automaticamente (30%) e executar simulação
   const handleAdjustValues = async (novoEmprestimo: number, isRural: boolean = false) => {
+    const atual = norm(emprestimo);
+    const final = Math.min(novoEmprestimo, atual);
+
     // Ajustar os valores - usar valor completo com formatação
-    setEmprestimo(formatBRL(novoEmprestimo.toString()));
+    setEmprestimo(formatBRL(final.toString()));
     setIsRuralProperty(isRural);
     setApiMessage(null);
     setErro('');
@@ -250,7 +253,7 @@ const SimulationForm: React.FC = () => {
 
       // Recalcular validação com novos valores
       const newValidation = validateForm(
-        formatBRL(novoEmprestimo.toString()),
+        formatBRL(final.toString()),
         garantia,
         parcelas,
         amortizacao,
@@ -506,6 +509,7 @@ const SimulationForm: React.FC = () => {
                   <SmartApiMessage
                     analysis={apiMessage}
                     valorImovel={validation.garantiaValue}
+                    valorEmprestimoAtual={validation.emprestimoValue || norm(emprestimo)}
                     onAdjustValues={handleAdjustValues}
                     onTryAgain={handleTryAgain}
                   />
@@ -551,6 +555,7 @@ const SimulationForm: React.FC = () => {
               <SmartApiMessage
                 analysis={apiMessage as ApiMessageAnalysis}
                 valorImovel={validation.garantiaValue}
+                valorEmprestimoAtual={validation.emprestimoValue || norm(emprestimo)}
                 onAdjustValues={handleAdjustValues}
                 onTryAgain={handleTryAgain}
               />

--- a/src/components/messages/Limit30Rural.tsx
+++ b/src/components/messages/Limit30Rural.tsx
@@ -10,6 +10,7 @@ interface Limit30RuralProps {
   cidade: string;
   valorSugerido: number;
   valorImovel: number;
+  valorEmprestimoAtual: number;
   onAdjustValues: (novoEmprestimo: number, isRural: boolean) => void;
   onTryAgain: () => void;
 }
@@ -21,6 +22,7 @@ const Limit30Rural: React.FC<Limit30RuralProps> = ({
   cidade,
   valorSugerido,
   valorImovel,
+  valorEmprestimoAtual,
   onAdjustValues,
   onTryAgain
 }) => {
@@ -31,11 +33,12 @@ const Limit30Rural: React.FC<Limit30RuralProps> = ({
   const valor30PercentImovel = Math.floor(valorImovel * 0.3);
   // Usar o valor sugerido da API se disponível, senão usar o cálculo
   const valorMaximoEmprestimo = valorSugerido || valor30PercentImovel;
+  const valorAjustado = Math.min(valorMaximoEmprestimo, valorEmprestimoAtual);
 
   const handleAdjustClick = () => {
     if (isRuralConfirmed) {
-      // Ajustar o valor do EMPRÉSTIMO para o máximo permitido
-      onAdjustValues(valorMaximoEmprestimo, true);
+      // Ajustar o valor do EMPRÉSTIMO para o máximo permitido ou manter o valor atual
+      onAdjustValues(valorAjustado, true);
     }
   };
 
@@ -106,7 +109,9 @@ const Limit30Rural: React.FC<Limit30RuralProps> = ({
               {isRuralConfirmed && <CheckCircle className={`${isMobile ? 'w-3 h-3' : 'w-4 h-4'} flex-shrink-0`} />}
               <Calculator className={`${isMobile ? 'w-3 h-3' : 'w-4 h-4'} flex-shrink-0`} />
               <span className="truncate">
-                {isMobile ? `Continuar com R$ ${(valorMaximoEmprestimo / 1000).toFixed(0)}k` : `Continuar com R$ ${valorMaximoEmprestimo.toLocaleString('pt-BR')}`}
+                {isMobile
+                  ? `Continuar com R$ ${(valorAjustado / 1000).toFixed(0)}k`
+                  : `Continuar com R$ ${valorAjustado.toLocaleString('pt-BR')}`}
               </span>
             </Button>
 

--- a/src/components/messages/SmartApiMessage.tsx
+++ b/src/components/messages/SmartApiMessage.tsx
@@ -8,6 +8,7 @@ import ApiMessageDisplay from '../ApiMessageDisplay';
 interface SmartApiMessageProps {
   analysis: ApiMessageAnalysis;
   valorImovel: number;
+  valorEmprestimoAtual: number;
   onAdjustValues: (novoEmprestimo: number, isRural?: boolean) => void;
   onTryAgain: () => void;
 }
@@ -18,6 +19,7 @@ interface SmartApiMessageProps {
 const SmartApiMessage: React.FC<SmartApiMessageProps> = ({
   analysis,
   valorImovel,
+  valorEmprestimoAtual,
   onAdjustValues,
   onTryAgain
 }) => {
@@ -39,6 +41,7 @@ const SmartApiMessage: React.FC<SmartApiMessageProps> = ({
           cidade={analysis.cidade || 'cidade informada'}
           valorSugerido={analysis.valorSugerido || 0}
           valorImovel={valorImovel}
+          valorEmprestimoAtual={valorEmprestimoAtual}
           onAdjustValues={onAdjustValues}
           onTryAgain={onTryAgain}
         />


### PR DESCRIPTION
## Summary
- pass current loan amount through SmartApiMessage to Limit30Rural
- prevent automatic loan increases when adjusting to 30% LTV

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d90016c84832d93fbe1c76286c986