### PR TITLE
chore: lazy load heavy components

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "build:stats": "STATS=1 vite build",
+    "build:stats": "rm -f stats.html && STATS=1 vite build",
     "build:critical": "vite build && node scripts/async-css.mjs",
     "build:critters": "vite build && node scripts/extract-critical.mjs",
     "build:dev": "vite build --mode development",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,11 +5,8 @@ import { useIsMobile } from '@/hooks/useMobileContext';
 
 // Critical components - NOT lazy loaded for LCP
 import HeroPremium from '@/components/HeroPremium';
-import TrustBarMinimal from '@/components/TrustBarMinimal';
 import WaveSeparator from '@/components/ui/WaveSeparator';
-import LogoBand from '@/components/LogoBand';
 import Header from '@/components/Header';
-import Footer from '@/components/Footer';
 
 // Lazy loading dos componentes pesados - com threshold otimizado
 const Benefits = lazy(() => import('@/components/Benefits'));
@@ -17,6 +14,9 @@ const Testimonials = lazy(() => import('@/components/Testimonials'));
 const MediaSection = lazy(() => import('@/components/MediaSection'));
 const FAQ = lazy(() => import('@/components/FAQ'));
 const BlogSection = lazy(() => import('@/components/BlogSection'));
+const TrustBarMinimal = lazy(() => import('@/components/TrustBarMinimal'));
+const LogoBand = lazy(() => import('@/components/LogoBand'));
+const Footer = lazy(() => import('@/components/Footer'));
 
 
 const Index: React.FC = () => {
@@ -55,14 +55,20 @@ const Index: React.FC = () => {
       {/* Faixa Separadora com Ondas - Apenas adicionada, sem alterar o resto */}
       <WaveSeparator variant="hero" height="md" />
       
-      <TrustBarMinimal />
-      
+      <Suspense fallback={null}>
+        <TrustBarMinimal />
+      </Suspense>
+
       <Suspense fallback={null}>
         <Benefits />
       </Suspense>
 
       {/* Faixa azul com logo - apenas para desktop */}
-      {!isMobile && <LogoBand />}
+      {!isMobile && (
+        <Suspense fallback={null}>
+          <LogoBand />
+        </Suspense>
+      )}
 
       <Suspense fallback={null}>
         <Testimonials />
@@ -137,7 +143,9 @@ const Index: React.FC = () => {
       </Suspense>
       </main>
       
-      <Footer />
+      <Suspense fallback={null}>
+        <Footer />
+      </Suspense>
     </div>
   );
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,6 +69,7 @@ export default defineConfig(({ mode }) => ({
           'vendor-react': ['react', 'react-dom'],
           'vendor-router': ['react-router-dom'],
           'vendor-query': ['@tanstack/react-query'],
+          'vendor-supabase': ['@supabase/supabase-js'],
           'vendor-ui': [
             '@radix-ui/react-dialog',
             '@radix-ui/react-select'


### PR DESCRIPTION
## Summary
- separate Supabase into its own rollup chunk
- lazy load header extras and footer on home page
- cleanup previous stats before rebuilding

## Testing
- `npm run lint` *(fails: Unexpected console statements and unused vars in existing files)*
- `npx eslint src/pages/Index.tsx vite.config.ts --ext ts,tsx`
- `npm run typecheck`
- `npm test`
- `npm run build:stats`

------
https://chatgpt.com/codex/tasks/task_e_688fd7b90890832db9b43a39fddafa6d