### PR TITLE
refactor: lazy load city data

### DIFF
--- a/src/components/LocalSimulationForm.tsx
+++ b/src/components/LocalSimulationForm.tsx
@@ -13,7 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { validateCity, validateLTV, searchCities, CityValidationResult } from '@/utils/cityLtvService';
+import type { CityValidationResult } from '@/utils/cityLtvService';
 import { formatBRL, norm } from '@/utils/formatters';
 import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
 import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
@@ -57,10 +57,12 @@ const LocalSimulationForm: React.FC = () => {
   // Buscar cidades conforme o usuário digita
   useEffect(() => {
     if (cidade.length >= 2) {
-      searchCities(cidade).then(suggestions => {
+      (async () => {
+        const { searchCities } = await import('@/utils/cityLtvService');
+        const suggestions = await searchCities(cidade);
         setCitySuggestions(suggestions);
         setShowSuggestions(suggestions.length > 0);
-      });
+      })();
     } else {
       setCitySuggestions([]);
       setShowSuggestions(false);
@@ -70,17 +72,21 @@ const LocalSimulationForm: React.FC = () => {
   // Validar cidade quando selecionada
   useEffect(() => {
     if (cidade) {
-      validateCity(cidade).then(validation => {
-        setCityValidation(validation);
-      }).catch(error => {
-        console.error('Erro ao validar cidade:', error);
-        setCityValidation({
-          found: false,
-          status: 'not_found',
-          message: 'Erro ao carregar dados da cidade',
-          allowCalculation: false
-        });
-      });
+      (async () => {
+        try {
+          const { validateCity } = await import('@/utils/cityLtvService');
+          const validation = await validateCity(cidade);
+          setCityValidation(validation);
+        } catch (error) {
+          console.error('Erro ao validar cidade:', error);
+          setCityValidation({
+            found: false,
+            status: 'not_found',
+            message: 'Erro ao carregar dados da cidade',
+            allowCalculation: false
+          });
+        }
+      })();
     } else {
       setCityValidation(null);
     }
@@ -97,13 +103,15 @@ const LocalSimulationForm: React.FC = () => {
       cidade &&
       cityValidation?.allowCalculation
     ) {
-      validateLTV(empValue, imValue, cidade).then(validation => {
+      (async () => {
+        const { validateLTV } = await import('@/utils/cityLtvService');
+        const validation = await validateLTV(empValue, imValue, cidade);
         setLtvValidation(validation);
-      });
+      })();
     } else {
       setLtvValidation(null);
     }
-  }, [valorEmprestimo, valorImovel, cityValidation]);
+  }, [valorEmprestimo, valorImovel, cidade, cityValidation]);
 
   const handleCitySelect = useCallback((selectedCity: string) => {
     setCidade(selectedCity);

--- a/src/components/form/CityAutocomplete.tsx
+++ b/src/components/form/CityAutocomplete.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
 import MapPin from 'lucide-react/dist/esm/icons/map-pin';
-import { searchCities } from '@/utils/cityLtvService';
 import scrollToTarget from '@/utils/scrollToTarget';
 
 import { cn } from '@/lib/utils';
@@ -50,6 +49,7 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
 
     fetchTimeout.current = setTimeout(async () => {
       try {
+        const { searchCities } = await import('@/utils/cityLtvService');
         const results = await searchCities(inputValue);
         setSuggestions(results);
         setIsLoading(false);

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -14,7 +14,6 @@
  * - Compatibilidade total com componentes existentes
  */
 
-import { validateCity, validateLTV } from '@/utils/cityLtvService';
 import { validateEmail, validatePhone, formatPhone } from '@/utils/validations';
 import { supabaseApi, SimulacaoData, supabase } from '@/lib/supabase';
 
@@ -72,6 +71,7 @@ export class LocalSimulationService {
       this.validateSimulationInput(input);
       
       // 2. Validar cidade e LTV
+      const { validateCity, validateLTV } = await import('@/utils/cityLtvService');
       const cityValidation = await validateCity(input.cidade);
       console.log('🏘️ Validação da cidade:', cityValidation);
       

--- a/src/utils/cityLtvService.ts
+++ b/src/utils/cityLtvService.ts
@@ -11,7 +11,7 @@
 let ltvCidades: CityLtvData[] | null = null;
 let loadingPromise: Promise<CityLtvData[]> | null = null;
 
-async function loadCityData(): Promise<CityLtvData[]> {
+export async function loadCityData(): Promise<CityLtvData[]> {
   // Se já está em cache, retorna imediatamente
   if (ltvCidades) {
     return ltvCidades;


### PR DESCRIPTION
## Summary
- export `loadCityData` for optional prefetching
- defer city lookup utilities in UI components until user interaction
- lazy import city validation inside `LocalSimulationService`

## Testing
- `npm test`
- `npm run lint` *(fails: 288 problems (51 errors, 237 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688fd7b60cbc832da0d4301443932c32