### PR TITLE
feat: add image placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,6 +402,14 @@
                 <div class="relative w-full h-full overflow-hidden w-full h-full">
                   <button class="w-full h-full cursor-pointer relative bg-black flex items-center justify-center hero-video group" type="button" aria-label="Reproduzir vídeo: Vídeo institucional Libra Crédito">
                     <!-- OPTIMIZED LCP: Direct image load for immediate LCP -->
+                    <img class="video-thumbnail-placeholder" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 480 360'%3E%3Crect width='480' height='360' fill='%23e2e8f0'/%3E%3C/svg%3E" alt="" aria-hidden="true" width="480" height="360" style="
+                      position: absolute;
+                      inset: 0;
+                      width: 100%;
+                      height: 100%;
+                      object-fit: cover;
+                      display: block;
+                    ">
                     <img src="/images/optimized/video-thumbnail.webp" alt="Miniatura do Vídeo institucional Libra Crédito" width="480" height="360" style="
                       position: absolute;
                       inset: 0;
@@ -409,7 +417,7 @@
                       height: 100%;
                       object-fit: cover;
                       display: block;
-                    " loading="lazy">
+                    " loading="lazy" onload="this.previousElementSibling.style.display='none'">
                     <div class="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition-colors duration-200">
                       <div class="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-lg group-hover:bg-red-700 transition-all duration-200 group-hover:scale-105">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play w-8 h-8 md:w-10 md:h-10 text-white ml-1">

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -1,5 +1,5 @@
 import Play from 'lucide-react/dist/esm/icons/play';
-import type { FC, MouseEvent } from 'react';
+import { type FC, type MouseEvent, useRef } from 'react';
 
 interface OptimizedYouTubeProps {
   videoId: string;
@@ -17,6 +17,9 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
   thumbnailSrc,
 }) => {
   const thumbnailImage = thumbnailSrc || '/images/optimized/video-thumbnail.webp';
+  const placeholderRef = useRef<HTMLImageElement | null>(null);
+  const placeholderSrc =
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 480 360'%3E%3Crect width='480' height='360' fill='%23e2e8f0'/%3E%3C/svg%3E";
 
   const loadVideo = (e: MouseEvent<HTMLButtonElement>) => {
     const container = e.currentTarget.parentElement as HTMLElement | null;
@@ -45,6 +48,22 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
         type="button"
       >
         <img
+          ref={placeholderRef}
+          src={placeholderSrc}
+          alt=""
+          aria-hidden="true"
+          width="480"
+          height="360"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            display: 'block',
+          }}
+        />
+        <img
           src={thumbnailImage}
           alt={`Miniatura do ${title}`}
           width="480"
@@ -58,6 +77,11 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
             display: 'block',
           }}
           loading={priority ? 'eager' : 'lazy'}
+          onLoad={() => {
+            if (placeholderRef.current) {
+              placeholderRef.current.style.display = 'none';
+            }
+          }}
         />
         <div className="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition-colors duration-200">
           <div className="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-lg group-hover:bg-red-700 transition-all duration-200 group-hover:scale-105">


### PR DESCRIPTION
## Summary
- add inline SVG placeholder for OptimizedYouTube thumbnails
- ensure placeholder is hidden once real image loads
- include placeholder in static HTML markup

## Testing
- `npm test`
- `npm run lint` *(fails: 'e' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68909dd3a4a8832db226c1934e8e01ae