### PR TITLE
feat: add fetch priority and async decoding

### DIFF
--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -6,6 +6,7 @@ interface OptimizedYouTubeProps {
   title: string;
   className?: string;
   priority?: boolean;
+  fetchPriority?: 'high' | 'low' | 'auto';
   thumbnailSrc?: string;
 }
 
@@ -14,6 +15,7 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
   title,
   className = '',
   priority = false,
+  fetchPriority,
   thumbnailSrc,
 }) => {
   const thumbnailImage = thumbnailSrc || '/images/optimized/video-thumbnail.webp';
@@ -58,6 +60,8 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
             display: 'block',
           }}
           loading={priority ? 'eager' : 'lazy'}
+          fetchPriority={fetchPriority ?? (priority ? 'high' : 'auto')}
+          decoding="async"
         />
         <div className="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition-colors duration-200">
           <div className="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-lg group-hover:bg-red-700 transition-all duration-200 group-hover:scale-105">


### PR DESCRIPTION
## Summary
- expose optional `fetchPriority` prop for `OptimizedYouTube`
- set thumbnail images to use async decoding and high fetch priority when needed

## Testing
- `npm test`
- `npm run lint` *(fails: 'e' is defined but never used in src/services/webhookService.ts, etc.)*
- `npx eslint src/components/OptimizedYouTube.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68909dd23c80832dbc6b0e0723c9c5df