### PR TITLE
chore: prioritize hero video thumbnail

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@
                       height: 100%;
                       object-fit: cover;
                       display: block;
-                    " loading="lazy">
+                    " loading="eager" fetchpriority="high">
                     <div class="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition-colors duration-200">
                       <div class="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-lg group-hover:bg-red-700 transition-all duration-200 group-hover:scale-105">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play w-8 h-8 md:w-10 md:h-10 text-white ml-1">

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -58,6 +58,7 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
             display: 'block',
           }}
           loading={priority ? 'eager' : 'lazy'}
+          fetchPriority={priority ? 'high' : undefined}
         />
         <div className="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition-colors duration-200">
           <div className="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-lg group-hover:bg-red-700 transition-all duration-200 group-hover:scale-105">


### PR DESCRIPTION
## Summary
- prioritize hero video thumbnail for faster rendering
- ensure YouTube thumbnail component can set fetch priority

## Testing
- `npm test`
- `npm run lint` *(fails: 51 errors, 233 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68909dcd7374832db00d8ab5ae3ca7b2