### PR TITLE
feat: add structured data for key pages

### DIFF
--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect } from 'react';
+
+interface SeoProps {
+  title?: string;
+  description?: string;
+  jsonLd?: Record<string, any>;
+  schemaId?: string;
+}
+
+const Seo: React.FC<SeoProps> = ({ title, description, jsonLd, schemaId }) => {
+  useEffect(() => {
+    if (title) {
+      document.title = title;
+    }
+
+    if (description) {
+      const metaDescription = document.querySelector('meta[name="description"]');
+      if (metaDescription) {
+        metaDescription.setAttribute('content', description);
+      }
+    }
+
+    let script: HTMLScriptElement | null = null;
+    const id = schemaId || 'json-ld-schema';
+
+    if (jsonLd) {
+      const existing = document.getElementById(id);
+      if (existing) {
+        existing.remove();
+      }
+      script = document.createElement('script');
+      script.type = 'application/ld+json';
+      script.id = id;
+      script.textContent = JSON.stringify(jsonLd);
+      document.head.appendChild(script);
+    }
+
+    return () => {
+      const existing = document.getElementById(id);
+      if (existing) {
+        existing.remove();
+      }
+    };
+  }, [title, description, jsonLd, schemaId]);
+
+  return null;
+};
+
+export default Seo;

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import MobileLayout from '@/components/MobileLayout';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 import { BlogService, type BlogPost as BlogPostType } from '@/services/blogService';
+import Seo from '@/components/Seo';
 
 type BlogPost = BlogPostType;
 
@@ -27,12 +28,6 @@ const BlogPost = () => {
         const foundPost = await BlogService.getPostBySlug(slug);
         if (foundPost) {
           setPost(foundPost);
-          document.title = `${foundPost.title} | Blog Libra Crédito`;
-          
-          const metaDescription = document.querySelector('meta[name="description"]');
-          if (metaDescription) {
-            metaDescription.setAttribute('content', foundPost.description);
-          }
         }
       } catch (error) {
         console.error('Erro ao carregar post:', error);
@@ -119,6 +114,24 @@ const BlogPost = () => {
 
   return (
     <MobileLayout>
+      {post && (
+        <Seo
+          title={`${post.title} | Blog Libra Crédito`}
+          description={post.description}
+          jsonLd={{
+            '@context': 'https://schema.org',
+            '@type': 'Article',
+            headline: post.title,
+            description: post.description,
+            author: {
+              '@type': 'Organization',
+              name: 'Libra Crédito'
+            },
+            image: post.imageUrl
+          }}
+          schemaId="article-schema"
+        />
+      )}
       <WaveSeparator variant="hero" height="md" inverted />
       
       <div className="bg-white flex-1 pb-8 md:pb-12">

--- a/src/pages/QuemSomos.tsx
+++ b/src/pages/QuemSomos.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import MobileLayout from '@/components/MobileLayout';
 import ImageOptimizer from '@/components/ImageOptimizer';
 import WaveSeparator from '@/components/ui/WaveSeparator';
@@ -10,19 +10,19 @@ import Shield from 'lucide-react/dist/esm/icons/shield';
 import TrendingUp from 'lucide-react/dist/esm/icons/trending-up';
 import { Link, useNavigate } from 'react-router-dom';
 import { useIsMobile } from '@/hooks/use-mobile';
+import Seo from '@/components/Seo';
 
 const QuemSomos = () => {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
 
-  useEffect(() => {
-    document.title = "Quem Somos | Libra Crédito | Nossa História e Missão";
-    
-    const metaDescription = document.querySelector('meta[name="description"]');
-    if (metaDescription) {
-      metaDescription.setAttribute('content', 'Conheça a Libra Crédito: nossa história, missão e valores. Especialistas em empréstimo com garantia de imóvel.');
-    }
-  }, []);
+  const aboutJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'AboutPage',
+    name: 'Quem Somos - Libra Crédito',
+    description:
+      'Conheça a Libra Crédito: nossa história, missão e valores. Especialistas em empréstimo com garantia de imóvel.',
+  };
 
   const handleSimular = () => {
     navigate('/simulacao');
@@ -58,6 +58,12 @@ const QuemSomos = () => {
 
   return (
     <MobileLayout>
+      <Seo
+        title="Quem Somos | Libra Crédito | Nossa História e Missão"
+        description="Conheça a Libra Crédito: nossa história, missão e valores. Especialistas em empréstimo com garantia de imóvel."
+        jsonLd={aboutJsonLd}
+        schemaId="about-schema"
+      />
       <WaveSeparator variant="hero" height="md" inverted />
       <div className="bg-white">
         {/* Quem Somos e Nossa História lado a lado */}

--- a/src/pages/Vantagens.tsx
+++ b/src/pages/Vantagens.tsx
@@ -14,6 +14,7 @@ import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
 import CreditCard from 'lucide-react/dist/esm/icons/credit-card';
 import { useNavigate } from 'react-router-dom';
 import { useIsMobile } from '@/hooks/use-mobile';
+import Seo from '@/components/Seo';
 
 const Vantagens: React.FC = () => {
   const navigate = useNavigate();
@@ -53,16 +54,13 @@ const Vantagens: React.FC = () => {
   // Cálculo do valor máximo para animação das barras
   const maxTaxa = useMemo(() => Math.max(...taxasJuros.map(item => item.taxa)), [taxasJuros]);
 
-  useEffect(() => {
-    // Meta Title otimizado para vantagens - 57 caracteres
-    document.title = "Vantagens Home Equity | Libra Crédito 1,19% a.m.";
-    
-    // Meta Description otimizada - 153 caracteres
-    const metaDescription = document.querySelector('meta[name="description"]');
-    if (metaDescription) {
-      metaDescription.setAttribute('content', 'Vantagens do crédito com garantia de imóvel: taxa mínima 1,19% a.m., até 180 meses, valores até 50% do imóvel. Compare as taxas agora.');
-    }
-  }, []);
+  const vantJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'Vantagens do Crédito com Garantia de Imóvel',
+    description:
+      'Vantagens do crédito com garantia de imóvel: taxa mínima 1,19% a.m., até 180 meses, valores até 50% do imóvel. Compare as taxas agora.',
+  };
 
   // Animação das barras da tabela
   useEffect(() => {
@@ -185,6 +183,12 @@ const Vantagens: React.FC = () => {
 
   return (
     <MobileLayout>
+      <Seo
+        title="Vantagens Home Equity | Libra Crédito 1,19% a.m."
+        description="Vantagens do crédito com garantia de imóvel: taxa mínima 1,19% a.m., até 180 meses, valores até 50% do imóvel. Compare as taxas agora."
+        jsonLd={vantJsonLd}
+        schemaId="vantagens-schema"
+      />
       {/* Faixa Separadora Superior Invertida - Exatamente como na home */}
       <WaveSeparator variant="hero" height={isMobile ? "sm" : "md"} inverted />
       


### PR DESCRIPTION
## Summary
- add reusable Seo component to manage meta tags and JSON-LD
- attach Article schema to blog posts and page schemas to Vantagens and Quem Somos

## Testing
- `npm test`
- `npm run lint` *(fails: 'e' defined but never used in webhookService.ts)*
- `npx eslint src/pages/BlogPost.tsx src/pages/Vantagens.tsx src/pages/QuemSomos.tsx src/components/Seo.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68909e979a70832d8b2cb88ebac712a6