### PR TITLE
feat: capture utm data on contact form

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -34,7 +34,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
   buttonClassName = '',
   compact = false
 }) => {
-  const { sessionId } = useUserJourney();
+  const { sessionId, getJourneyData } = useUserJourney();
   const navigate = useNavigate();
   const [nome, setNome] = useState('');
   const [email, setEmail] = useState('');
@@ -134,7 +134,9 @@ const ContactForm: React.FC<ContactFormProps> = ({
         imovelProprio,
         imovelProprioTexto: imovelProprio === 'proprio' ? 'Imóvel Próprio' : 'Imóvel de Terceiro'
       });
-      
+
+      const journey = getJourneyData();
+
       // Usar o serviço local com dados da simulação
       await LocalSimulationService.processContact({
         simulationId: simulationResult.id,
@@ -150,7 +152,13 @@ const ContactForm: React.FC<ContactFormProps> = ({
         valorParcelaCalculada: simulationResult.valor,
         tipoAmortizacao: simulationResult.amortizacao,
         quantidadeParcelas: simulationResult.parcelas,
-        aceitaPolitica: aceitePrivacidade
+        aceitaPolitica: aceitePrivacidade,
+        utm_source: journey?.utm_source,
+        utm_medium: journey?.utm_medium,
+        utm_campaign: journey?.utm_campaign,
+        utm_term: journey?.utm_term,
+        utm_content: journey?.utm_content,
+        landing_page: journey?.landing_page
       });
       
       // Redirecionar diretamente para a página de confirmação

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+
+vi.mock('@/services/localSimulationService', () => ({
+  LocalSimulationService: {
+    processContact: vi.fn().mockResolvedValue({ success: true, message: 'ok' })
+  }
+}));
+
+const mockGetJourneyData = vi.fn();
+vi.mock('@/hooks/useUserJourney', () => ({
+  useUserJourney: () => ({
+    sessionId: 'session123',
+    getJourneyData: mockGetJourneyData
+  })
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    Link: ({ to, children }: { to: string; children: React.ReactNode }) => React.createElement('a', { href: to }, children)
+  };
+});
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ContactForm from '../ContactForm';
+import { LocalSimulationService } from '@/services/localSimulationService';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ContactForm', () => {
+  const simulationResult = {
+    id: 'sim1',
+    valor: 1000,
+    amortizacao: 'PRICE',
+    parcelas: 12,
+    valorEmprestimo: 50000,
+    valorImovel: 100000
+  } as any;
+
+  it('forwards journey UTM params to LocalSimulationService.processContact', async () => {
+    mockGetJourneyData.mockReturnValue({
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'camp',
+      utm_term: 'term',
+      utm_content: 'content',
+      landing_page: 'https://example.com'
+    });
+
+    render(<ContactForm simulationResult={simulationResult} />);
+
+    fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'John Doe' } });
+    fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'john@example.com' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '11999999999' } });
+    fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Solicitar análise agora/i }));
+
+    await waitFor(() => {
+      expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
+        expect.objectContaining({
+          utm_source: 'google',
+          utm_medium: 'cpc',
+          utm_campaign: 'camp',
+          utm_term: 'term',
+          utm_content: 'content',
+          landing_page: 'https://example.com'
+        })
+      );
+    });
+  });
+
+  it('handles missing journey data and submits with undefined UTM fields', async () => {
+    mockGetJourneyData.mockReturnValue(undefined);
+
+    render(<ContactForm simulationResult={simulationResult} />);
+
+    fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'Jane Doe' } });
+    fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'jane@example.com' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '11988888888' } });
+    fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Solicitar análise agora/i }));
+
+    await waitFor(() => {
+      expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
+        expect.objectContaining({
+          utm_source: undefined,
+          utm_medium: undefined,
+          utm_campaign: undefined,
+          utm_term: undefined,
+          utm_content: undefined,
+          landing_page: undefined
+        })
+      );
+    });
+  });
+});
+

--- a/src/services/__tests__/ploomesService.test.ts
+++ b/src/services/__tests__/ploomesService.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import PloomesService from '../ploomesService';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // @ts-ignore
+  delete global.fetch;
+});
+
+describe('PloomesService', () => {
+  it('sends UTM params in payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: true, msg: '', retorno: { nomeCompleto: '', email: '' } })
+    });
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    await PloomesService.cadastrarProposta({
+      cidade: 'São Paulo',
+      valorEmprestimo: 10000,
+      valorImovel: 20000,
+      parcelas: 36,
+      tipoAmortizacao: 'PRICE',
+      valorParcela: 500,
+      nomeCompleto: 'John Doe',
+      email: 'john@example.com',
+      telefone: '11999999999',
+      imovelProprio: 'proprio',
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'camp',
+      utm_term: 'term',
+      utm_content: 'content',
+      landing_page: 'https://example.com'
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse((options as any).body);
+    expect(body).toMatchObject({
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'camp',
+      utm_term: 'term',
+      utm_content: 'content',
+      landing_page: 'https://example.com'
+    });
+  });
+});
+

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -54,6 +54,12 @@ export interface ContactFormInput {
   telefone: string;
   imovelProprio: 'proprio' | 'terceiro';
   observacoes?: string;
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+  utm_term?: string | null;
+  utm_content?: string | null;
+  landing_page?: string | null;
 }
 
 // Classe principal do serviço local
@@ -319,7 +325,13 @@ export class LocalSimulationService {
         email: input.email.trim().toLowerCase(),
         telefone: input.telefone.replace(/\D/g, ''), // Remove all non-digits
         imovelProprio: input.imovelProprio === 'proprio' ? 'Imóvel próprio' : 'Imóvel de terceiro',
-        aceitaPolitica: Boolean(input.aceitaPolitica)
+        aceitaPolitica: Boolean(input.aceitaPolitica),
+        utm_source: input.utm_source || null,
+        utm_medium: input.utm_medium || null,
+        utm_campaign: input.utm_campaign || null,
+        utm_term: input.utm_term || null,
+        utm_content: input.utm_content || null,
+        landing_page: input.landing_page || null
       };
 
       // Validar campos obrigatórios

--- a/src/services/ploomesService.ts
+++ b/src/services/ploomesService.ts
@@ -31,6 +31,12 @@ export interface PloomesPayload {
   telefone: string;
   imovelProprio: 'Imóvel próprio' | 'Imóvel de terceiro';
   aceitaPolitica: boolean;
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+  utm_term?: string | null;
+  utm_content?: string | null;
+  landing_page?: string | null;
 }
 
 // Interface para resposta do Ploomes
@@ -73,6 +79,12 @@ export class PloomesService {
     email: string;
     telefone: string;
     imovelProprio: 'proprio' | 'terceiro';
+    utm_source?: string | null;
+    utm_medium?: string | null;
+    utm_campaign?: string | null;
+    utm_term?: string | null;
+    utm_content?: string | null;
+    landing_page?: string | null;
   }): Promise<PloomesResponse> {
     try {
       console.log('🚀 Iniciando cadastro no Ploomes:', data);
@@ -89,7 +101,13 @@ export class PloomesService {
         email: data.email.toLowerCase().trim(),
         telefone: this.limparTelefone(data.telefone),
         imovelProprio: IMOVEL_MAP[data.imovelProprio],
-        aceitaPolitica: true // Sempre true pois já foi validado antes
+        aceitaPolitica: true, // Sempre true pois já foi validado antes
+        utm_source: data.utm_source || null,
+        utm_medium: data.utm_medium || null,
+        utm_campaign: data.utm_campaign || null,
+        utm_term: data.utm_term || null,
+        utm_content: data.utm_content || null,
+        landing_page: data.landing_page || null
       };
       
       console.log('📤 Payload formatado para Ploomes:', payload);


### PR DESCRIPTION
## Summary
- capture journey UTM params in contact form
- forward UTM data through local simulation service to Ploomes CRM
- add tests verifying UTM and landing-page forwarding
- ensure contact form submits even when journey data missing

## Testing
- `npm test`
- `npm run lint` (fails: @typescript-eslint/no-unused-vars and others)
- `npm run typecheck`
- `curl -X POST https://api-ploomes.vercel.app/cadastro/online/env -H 'Content-Type: application/json' -d '{}' -i` *(403 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68909e569dbc832da9332445b4e85f77