### PR TITLE
refactor: load typed.js dynamically

### DIFF
--- a/src/components/TypewriterText.tsx
+++ b/src/components/TypewriterText.tsx
@@ -1,19 +1,23 @@
 import { useEffect, useRef } from 'react';
-import Typed from 'typed.js';
 
 export default function TypewriterText({ strings }: { strings: string[] }) {
   const el = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
-    const typed = new Typed(el.current!, {
-      strings,
-      typeSpeed: 50,
-      backSpeed: 30,
-      backDelay: 1500,
-      loop: true,
+    let typed: any;
+
+    import('typed.js').then(({ default: Typed }) => {
+      typed = new Typed(el.current!, {
+        strings,
+        typeSpeed: 50,
+        backSpeed: 30,
+        backDelay: 1500,
+        loop: true,
+      });
     });
-    return () => typed.destroy();
+
+    return () => typed?.destroy();
   }, [strings]);
 
-  return <span ref={el} />;
+  return <span ref={el}>{strings[0]}</span>;
 }


### PR DESCRIPTION
## Summary
- load typed.js dynamically in TypewriterText to avoid blocking LCP
- show static text until the library is ready

## Testing
- `npm test`
- `npm run lint` *(fails: 52 errors, 235 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6890a92147d4832d8c9eafcae3f69184