### PR TITLE
Remove pre-rendered hero from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,76 +372,7 @@
   </head>
 
   <body>
-    <div id="root">
-      <section class="min-h-[50vh] md:min-h-[55vh] lg:min-h-[60vh] xl:min-h-[calc(100vh-280px)] pb-0 bg-white relative flex flex-col justify-center" aria-labelledby="hero-heading" role="banner">
-        <div class="container mx-auto px-4 relative z-10 flex-grow flex flex-col justify-center">
-          <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8 items-center">
-            <div class="text-[#003399] space-y-4 md:space-y-5 text-center flex flex-col items-center animate-fade-in-up">
-              <div>
-                <h1 id="hero-heading" class="text-xl md:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight">
-                  <span class="block whitespace-nowrap">Crédito com Garantia de Imóvel</span>
-                  <span class="block text-green-700">é mais simples na Libra!</span>
-                </h1>
-                <ul class="mt-2 space-y-1 text-sm md:text-base lg:text-lg text-[#003399] font-medium">
-                  <li class="flex items-center justify-center gap-2 bg-green-50 rounded-md py-1 px-2">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-shield w-4 h-4 md:w-5 md:h-5 flex-shrink-0" aria-hidden="true">
-                      <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
-                    </svg>
-                    <span class="text-center">Atendimento Personalizado, Segurança e Transparência</span>
-                  </li>
-                  <li>
-                    Taxas a partir de <span class="font-bold text-green-700">1,19% a.m.</span> • Até 180 meses • 100% online
-                  </li>
-                </ul>
-              </div>
-              <div class="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full max-w-sm mx-auto pt-3 sm:pt-4">
-                <button class="w-full cta-button px-6 py-3 text-sm sm:px-8 sm:py-4 sm:text-base font-bold bg-gradient-to-r from-[#003399] to-[#0055CC] text-white" type="button">Simular Agora</button>
-              </div>
-            </div>
-            <div class="w-full max-w-xl lg:max-w-lg xl:max-w-none mx-auto">
-              <div class="hero-video aspect-video" style="contain-intrinsic-size:480px 360px; contain:strict;">
-                <div class="relative w-full h-full overflow-hidden w-full h-full">
-                  <button class="w-full h-full cursor-pointer relative bg-black flex items-center justify-center hero-video group" type="button" aria-label="Reproduzir vídeo: Vídeo institucional Libra Crédito">
-                    <!-- OPTIMIZED LCP: Direct image load for immediate LCP -->
-                    <img class="video-thumbnail-placeholder" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 480 360'%3E%3Crect width='480' height='360' fill='%23e2e8f0'/%3E%3C/svg%3E" alt="" aria-hidden="true" width="480" height="360" style="
-                      position: absolute;
-                      inset: 0;
-                      width: 100%;
-                      height: 100%;
-                      object-fit: cover;
-                      display: block;
-                    ">
-                    <img src="/images/optimized/video-thumbnail.webp" alt="Miniatura do Vídeo institucional Libra Crédito" width="480" height="360" style="
-                      position: absolute;
-                      inset: 0;
-                      width: 100%;
-                      height: 100%;
-                      object-fit: cover;
-                      display: block;
-                    " loading="eager" fetchpriority="high">
-
-                    <div class="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition-colors duration-200">
-                      <div class="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-lg group-hover:bg-red-700 transition-all duration-200 group-hover:scale-105">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play w-8 h-8 md:w-10 md:h-10 text-white ml-1">
-                          <polygon points="6 3 20 12 6 21 6 3"></polygon>
-                        </svg>
-                      </div>
-                    </div>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="flex justify-center mt-2 md:mt-3 lg:mt-2">
-            <button class="text-[#003399] flex flex-col items-center opacity-90 hover:opacity-100 transition-opacity" aria-label="Rolar para benefícios" type="button">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down w-5 h-5 md:w-5 md:h-5 lg:w-4 lg:h-4 animate-bounce">
-                <path d="m6 9 6 6 6-6"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-      </section>
-    </div>
+    <div id="root"></div>
     
     
     <script type="module" src="/src/main.tsx" defer></script>


### PR DESCRIPTION
## Summary
- remove stale hero markup from `index.html` so React renders HeroPremium without hydration mismatch

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected console statement, no-unused-vars, no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_6890a9249070832dadd2b46070b196bd