### PR TITLE
feat: add async decoding to OptimizedYouTube

### DIFF
--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -7,6 +7,7 @@ interface OptimizedYouTubeProps {
   className?: string;
   priority?: boolean;
   fetchPriority?: 'high' | 'low' | 'auto';
+  decoding?: 'sync' | 'async' | 'auto';
   thumbnailSrc?: string;
 }
 
@@ -16,6 +17,7 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
   className = '',
   priority = false,
   fetchPriority,
+  decoding = 'async',
   thumbnailSrc,
 }) => {
   const thumbnailImage = thumbnailSrc || '/images/optimized/video-thumbnail.webp';
@@ -79,8 +81,8 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
             display: 'block',
           }}
           loading={priority ? 'eager' : 'lazy'}
-          fetchPriority={priority ? 'high' : undefined}
-
+          fetchPriority={fetchPriority ?? (priority ? 'high' : undefined)}
+          decoding={decoding}
         />
         <div className="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition-colors duration-200">
           <div className="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-lg group-hover:bg-red-700 transition-all duration-200 group-hover:scale-105">


### PR DESCRIPTION
## Summary
- propagate `fetchPriority` and expose `decoding` in `OptimizedYouTube`

## Testing
- `npm run lint` *(fails: no-console, @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any)*
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6890a9399d30832dba83eed9a2b65dd4