### PR TITLE
fix: remove commission reports text from partner area

### DIFF
--- a/src/pages/Parceiros.tsx
+++ b/src/pages/Parceiros.tsx
@@ -572,7 +572,6 @@ const Parceiros = () => {
                 
                 <div className="text-xs text-libra-silver/80 space-y-2">
                   <p>✓ Material de divulgação</p>
-                  <p>✓ Relatórios de comissão</p>
                   <p>✓ Suporte especializado</p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- remove "Relatórios de comissão" entry from partner area list

## Testing
- `npm test`
- `npm run lint` *(fails: 52 errors, 234 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6890a97d7bcc832daf8201dd33fb5ba2