### PR TITLE
Use high resolution team image on Quem Somos page

### DIFF
--- a/src/pages/QuemSomos.tsx
+++ b/src/pages/QuemSomos.tsx
@@ -141,12 +141,12 @@ const QuemSomos = () => {
               {/* Imagem Institucional */}
               <div className="relative">
                 <ImageOptimizer
-                  src="/images/optimized/timelibra2.webp"
+                  src="/images/timelibra2.webp"
                   alt="Libra Crédito - Quem Somos"
                   className="rounded-xl shadow-lg w-full"
-                  aspectRatio={16/9}
-                  width={480}
-                  height={320}
+                  aspectRatio={1600/1066}
+                  width={1600}
+                  height={1066}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace low-res institutional photo with 1600x1066 high resolution version on Quem Somos page

## Testing
- `npm run lint` *(fails: 'trackPageVisit' is assigned a value but never used, etc.)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6890aa205044832db0d2c2f6142fb094