### PR TITLE
Resize LogoBand logo to 80px

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -8,7 +8,7 @@ const LogoBand: React.FC = () => {
         <ImageOptimizer
           src="/images/logos/libra-logo.png"
           alt="Libra Crédito"
-          className="h-24 w-auto"
+          className="h-20 w-20"
           aspectRatio={1}
           priority={false}
           width={80}


### PR DESCRIPTION
## Summary
- constrain LogoBand logo dimensions to 80x80px to avoid oversized rendering

## Testing
- `npm test`
- `npm run lint` *(fails: 'e' is defined but never used, 53 errors overall)*

------
https://chatgpt.com/codex/tasks/task_e_6890aeb86fa8832d8192a7080243e692