### PR TITLE
Resize LogoBand logo to 80px and reduce band padding

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -3,12 +3,12 @@ import ImageOptimizer from '@/components/ImageOptimizer';
 
 const LogoBand: React.FC = () => {
   return (
-    <div className="w-full bg-[#003399] flex justify-center py-8">
+    <div className="w-full bg-[#003399] flex justify-center py-4">
       <div className="flex items-center">
         <ImageOptimizer
           src="/images/logos/libra-logo.png"
           alt="Libra Crédito"
-          className="h-24 w-auto"
+          className="h-20 w-20"
           aspectRatio={1}
           priority={false}
           width={80}

--- a/src/components/__tests__/LogoBand.test.tsx
+++ b/src/components/__tests__/LogoBand.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import LogoBand from '../LogoBand';
+
+describe('LogoBand', () => {
+  it('renders container with py-4 padding and optimized image', () => {
+    const { container } = render(<LogoBand />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass('py-4');
+    expect(wrapper).not.toHaveClass('py-8');
+
+    const img = screen.getByAltText('Libra Crédito') as HTMLImageElement;
+    expect(img).toHaveClass('h-20');
+    expect(img).toHaveClass('w-20');
+    expect(img).not.toHaveClass('h-24');
+    expect(img).not.toHaveClass('w-auto');
+    expect(img).toHaveAttribute('width', '80');
+    expect(img).toHaveAttribute('height', '80');
+  });
+});
+


### PR DESCRIPTION
## Summary
- constrain LogoBand logo to 80×80 px
- halve vertical padding around the logo band to match smaller logo
- add regression test ensuring LogoBand renders with reduced padding and 80×80 logo

## Testing
- `npm test`
- `npm run lint` *(fails: 'e' is defined but never used, 53 errors overall)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6890aeb86fa8832d8192a7080243e692