### PR TITLE
fix: update hero video thumbnail

### DIFF
--- a/src/components/HeroAnimated.tsx
+++ b/src/components/HeroAnimated.tsx
@@ -120,7 +120,7 @@ const HeroAnimated: React.FC = () => {
                 title="Vídeo institucional Libra Crédito"
                 priority={true}
                 className="w-full h-full"
-                thumbnailSrc="/images/thumbnail-libra.webp"
+                thumbnailSrc="/images/media/video-cgi-libra.webp"
               />
             </div>
           </div>

--- a/src/components/__tests__/HeroVideos.test.tsx
+++ b/src/components/__tests__/HeroVideos.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import HeroAnimated from '../HeroAnimated';
+import Hero from '../../../temp-files/Hero';
+import HeroMinimal from '../../../temp-files/HeroMinimal';
+
+vi.mock('../TypewriterText', () => ({
+  default: () => <span>Typewriter</span>,
+}));
+
+describe('video thumbnails', () => {
+  it('HeroAnimated uses the updated thumbnail', () => {
+    render(
+      <MemoryRouter>
+        <HeroAnimated />
+      </MemoryRouter>
+    );
+    const thumbnail = screen.getByAltText('Miniatura do Vídeo institucional Libra Crédito') as HTMLImageElement;
+    expect(thumbnail.src).toContain('/images/media/video-cgi-libra.webp');
+  });
+
+  it('Hero uses the updated thumbnail', () => {
+    render(
+      <MemoryRouter>
+        <Hero />
+      </MemoryRouter>
+    );
+    const thumbnail = screen.getByAltText('Miniatura do Vídeo institucional Libra Crédito') as HTMLImageElement;
+    expect(thumbnail.src).toContain('/images/media/video-cgi-libra.webp');
+  });
+
+  it('HeroMinimal uses the updated thumbnail', () => {
+    render(
+      <MemoryRouter>
+        <HeroMinimal />
+      </MemoryRouter>
+    );
+    const thumbnail = screen.getByAltText('Miniatura do Vídeo institucional Libra Crédito') as HTMLImageElement;
+    expect(thumbnail.src).toContain('/images/media/video-cgi-libra.webp');
+  });
+});

--- a/temp-files/Hero.tsx
+++ b/temp-files/Hero.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import PremiumButton from '@/components/ui/PremiumButton';
 import { ChevronDown, Shield } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import OptimizedYouTube from './OptimizedYouTube';
+import OptimizedYouTube from '@/components/OptimizedYouTube';
 import { useIsMobile } from '@/hooks/use-mobile';
 
 const Hero: React.FC = () => {
@@ -109,7 +109,7 @@ const Hero: React.FC = () => {
                 title="Vídeo institucional Libra Crédito"
                 priority={true}
                 className="w-full h-full"
-                thumbnailSrc="/images/thumbnail-libra.webp"
+                thumbnailSrc="/images/media/video-cgi-libra.webp"
               />
             </div>
           </div>

--- a/temp-files/HeroMinimal.tsx
+++ b/temp-files/HeroMinimal.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import PremiumButton from '@/components/ui/PremiumButton';
 import { ChevronDown, Shield } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import OptimizedYouTube from './OptimizedYouTube';
+import OptimizedYouTube from '@/components/OptimizedYouTube';
 import { useIsMobile } from '@/hooks/use-mobile';
 
 const HeroMinimal: React.FC = () => {
@@ -135,7 +135,7 @@ const HeroMinimal: React.FC = () => {
                       title="Vídeo institucional Libra Crédito"
                       priority={true}
                       className="w-full aspect-video"
-                      thumbnailSrc="/images/thumbnail-libra.webp"
+                      thumbnailSrc="/images/media/video-cgi-libra.webp"
                     />
                   </div>
 


### PR DESCRIPTION
## Summary
- update hero components to use `/images/media/video-cgi-libra.webp` thumbnail
- add tests validating hero video thumbnails

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890c61b7b00832da1fcf9259627234d