### PR TITLE
Update video thumbnail path

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <!-- CRITICAL LCP Strategy: Remove image preload to eliminate render blocking -->
     <!-- Video thumbnail now uses instant SVG placeholder for LCP -->
     <link rel="preload" href="/images/logos/libra-logo.png" as="image" fetchpriority="high">
-    <link rel="preload" href="/images/optimized/video-thumbnail.webp" as="image" fetchpriority="high">
+    <link rel="preload" href="/images/media/video-cgi-libra.webp" as="image" fetchpriority="high">
     
       <!-- RADICAL LCP: Force immediate DOM/CSS render -->
       <!--

--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -91,7 +91,7 @@ const HeroPremium: React.FC = () => {
                 title="Vídeo institucional Libra Crédito"
                 priority
                 className="w-full h-full"
-                thumbnailSrc="/images/optimized/video-thumbnail.webp"
+                thumbnailSrc="/images/media/video-cgi-libra.webp"
               />
             </div>
             {/* Texto abaixo do vídeo em telas mobile */}

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -29,7 +29,8 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
   decoding = 'async',
   thumbnailSrc,
 }) => {
-  const thumbnailImage = thumbnailSrc || '/images/optimized/video-thumbnail.webp';
+  const thumbnailImage =
+    thumbnailSrc || '/images/media/video-cgi-libra.webp';
   const placeholderRef = useRef<HTMLImageElement | null>(null);
   const placeholderSrc =
     "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 480 360'%3E%3Crect width='480' height='360' fill='%23e2e8f0'/%3E%3C/svg%3E";


### PR DESCRIPTION
## Summary
- replace `/images/optimized/video-thumbnail.webp` with `/images/media/video-cgi-libra.webp`
- update hero and preload references to new thumbnail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890c620d10c832daea8b833559a5155