### PR TITLE
Update logo paths and service worker assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     
     <!-- CRITICAL LCP Strategy: Remove image preload to eliminate render blocking -->
     <!-- Video thumbnail now uses instant SVG placeholder for LCP -->
-    <link rel="preload" href="/images/logos/libra-logo.png" as="image" fetchpriority="high">
+    <link rel="preload" href="/images/logos/logo-azul.png" as="image" fetchpriority="high">
     <link rel="preload" href="/images/optimized/video-thumbnail.webp" as="image" fetchpriority="high">
     
       <!-- RADICAL LCP: Force immediate DOM/CSS render -->
@@ -356,7 +356,7 @@
       "name": "Libra Crédito",
       "description": "Empréstimo com garantia de imóvel com as melhores taxas do mercado",
       "url": "https://libracredito.com.br",
-      "logo": "https://libracredito.com.br/images/logos/libra-logo.png",
+      "logo": "https://libracredito.com.br/images/logos/logo-azul.png",
       "priceRange": "R$ 100.000 - R$ 5.000.000",
       "areaServed": {
         "@type": "Country",

--- a/public/sw.js
+++ b/public/sw.js
@@ -7,9 +7,9 @@ const DYNAMIC_CACHE_NAME = 'libra-dynamic-v1';
 const STATIC_ASSETS = [
   '/',
   '/index.html',
-  '/src/styles/critical.css',
-  '/images/logos/libra-logo.png',
-  '/images/logos/libra-icon.png',
+  '/assets/css/index.css',
+  '/images/logos/logo-azul.png',
+  '/icon-192.png',
   '/favicon.ico',
   '/manifest.json'
 ];
@@ -293,8 +293,8 @@ self.addEventListener('push', (event) => {
     const data = event.data.json();
     const options = {
       body: data.body,
-      icon: '/images/logos/libra-icon.png',
-      badge: '/images/logos/libra-icon.png',
+      icon: '/icon-192.png',
+      badge: '/icon-192.png',
       data: data.data
     };
     

--- a/src/components/AdminLogin.tsx
+++ b/src/components/AdminLogin.tsx
@@ -31,7 +31,7 @@ const AdminLogin: React.FC<AdminLoginProps> = ({ onLogin, loading, error }) => {
         <div className="text-center">
           <div className="mx-auto h-16 w-auto flex justify-center mb-6">
             <img
-              src="/images/logos/libra-logo.png"
+              src="/images/logos/logo-azul.png"
               alt="Libra Crédito"
               className="h-16 w-auto"
               loading="lazy"

--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -6,7 +6,7 @@ const LogoBand: React.FC = () => {
     <div className="w-full bg-[#003399] flex justify-center py-4">
       <div className="flex items-center">
         <ImageOptimizer
-          src="/images/logos/libra-logo.png"
+          src="/images/logos/logo-azul.png"
           alt="Libra Crédito"
           className="h-20 w-20"
           aspectRatio={1}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -125,7 +125,7 @@ const Index: React.FC = () => {
         >
           <div className="flex items-center px-4 max-w-full">
             <img
-              src="/images/logos/libra-logo.png"
+              src="/images/logos/logo-azul.png"
               alt="Libra Crédito"
               className="h-12 sm:h-16 w-auto flex-shrink-0"
             />


### PR DESCRIPTION
## Summary
- swap old logo references for `logo-azul.png`
- replace invalid service worker asset paths and notification icons
- adjust schema logo reference in index.html

## Testing
- `npm run build`
- `node -e "const fs=require('fs'),path=require('path');const a=['index.html','assets/css/index.css','images/logos/logo-azul.png','icon-192.png','favicon.ico','manifest.json'];const d=path.resolve('dist');for(const f of a){console.log(f,fs.existsSync(path.join(d,f))?'OK':'MISSING');}"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c632db34832d861ab591e43997f7