### PR TITLE
Use high quality white logo in home band

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -6,7 +6,7 @@ const LogoBand: React.FC = () => {
     <div className="w-full bg-[#003399] flex justify-center py-4">
       <div className="flex items-center">
         <ImageOptimizer
-          src="/images/logos/logo-azul.png"
+          src="/images/logos/logo-branco.svg"
           alt="Libra Crédito"
           className="h-20 w-20"
           aspectRatio={1}

--- a/src/components/__tests__/LogoBand.test.tsx
+++ b/src/components/__tests__/LogoBand.test.tsx
@@ -15,6 +15,7 @@ describe('LogoBand', () => {
     expect(img).toHaveClass('w-20');
     expect(img).not.toHaveClass('h-24');
     expect(img).not.toHaveClass('w-auto');
+    expect(img.getAttribute('src')).toBe('/images/logos/logo-branco.svg');
     expect(img).toHaveAttribute('width', '80');
     expect(img).toHaveAttribute('height', '80');
   });

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -125,7 +125,7 @@ const Index: React.FC = () => {
         >
           <div className="flex items-center px-4 max-w-full">
             <img
-              src="/images/logos/logo-azul.png"
+              src="/images/logos/logo-branco.svg"
               alt="Libra Crédito"
               className="h-12 sm:h-16 w-auto flex-shrink-0"
             />


### PR DESCRIPTION
## Summary
- swap low-res blue logo for white SVG in LogoBand
- use same white logo in mobile CTA
- update LogoBand unit test for new asset

## Testing
- `npm test`
- `npm run lint` *(fails: 53 errors, 237 warnings)*
- `npx eslint src/components/LogoBand.tsx src/pages/Index.tsx src/components/__tests__/LogoBand.test.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6890cfc2dc54832da91b40d969f64173