### PR TITLE
Use logo-azul icon for site favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,9 +321,8 @@
     <!-- Main stylesheet will be injected by Vite -->
     
     <!-- Favicon - Libra Crédito -->
-    <link rel="icon" href="/favicon.png" type="image/png" />
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="icon" href="/logo-azul.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="/logo-azul.ico" />
     
     <!-- Apple Touch Icons -->
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,9 +8,9 @@
   "background_color": "#ffffff",
   "icons": [
     {
-      "src": "/favicon.png",
+      "src": "/logo-azul.ico",
       "sizes": "any",
-      "type": "image/png",
+      "type": "image/x-icon",
       "purpose": "any maskable"
     },
     {

--- a/public/sw.js
+++ b/public/sw.js
@@ -11,7 +11,7 @@ const STATIC_ASSETS = [
   '/images/logos/logo-azul.png',
   '/images/logos/libra-icon.png',
 
-  '/favicon.ico',
+  '/logo-azul.ico',
   '/manifest.json'
 ];
 
@@ -227,7 +227,7 @@ function isStaticAsset(url) {
     url.pathname.endsWith('.js') ||
     url.pathname.endsWith('.woff2') ||
     url.pathname.endsWith('.woff') ||
-    url.pathname.includes('/favicon')
+    url.pathname.endsWith('.ico')
   );
 }
 


### PR DESCRIPTION
## Summary
- replace previous favicon references with `logo-azul.ico`
- update PWA manifest and service worker to include new icon and handle `.ico` caching

## Testing
- `npm run lint` *(fails: 53 errors)*
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890d37df0b0832dbf6f05c8a75a025b