### PR TITLE
fix: update video thumbnail preload path

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <!-- CRITICAL LCP Strategy: Remove image preload to eliminate render blocking -->
     <!-- Video thumbnail now uses instant SVG placeholder for LCP -->
     <link rel="preload" href="/images/logos/logo-azul.png" as="image" fetchpriority="high">
-    <link rel="preload" href="/images/optimized/video-thumbnail.webp" as="image" fetchpriority="high">
+    <link rel="preload" href="/images/media/video-cgi-libra.webp" as="image" fetchpriority="high">
 
     
       <!-- RADICAL LCP: Force immediate DOM/CSS render -->


### PR DESCRIPTION
## Summary
- fix preload path for video thumbnail to `/images/media/video-cgi-libra.webp`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890daa14d7c832d8c4937f1665f10ac