### PR TITLE
feat: simplify media section layout on mobile

### DIFF
--- a/src/components/MediaSection.tsx
+++ b/src/components/MediaSection.tsx
@@ -45,18 +45,18 @@ const MediaSection: React.FC = () => {
           </p>
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-md md:max-w-6xl mx-auto">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-md md:max-w-6xl mx-auto place-items-center">
           {mediaLinks.map((media) => (
             <div
               key={media.name}
-              className="bg-white rounded-lg shadow-sm p-6 flex flex-col items-center text-center"
+              className="flex flex-col items-center text-center p-0 md:p-6 md:bg-white md:rounded-lg md:shadow-sm"
             >
               <a
                 href={media.url}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`Ver matéria da ${media.name}`}
-                className={`w-full flex items-center justify-center mb-4 ${media.name === 'G1 Globo' ? 'h-14 md:h-20' : 'h-12 md:h-20'}`}
+                className={`w-full flex items-center justify-center ${media.name === 'G1 Globo' ? 'h-14 md:h-20' : 'h-12 md:h-20'} md:mb-4`}
               >
                 <img
                   src={media.logo}


### PR DESCRIPTION
## Summary
- center logos in media section
- remove card styling and text spacing on mobile

## Testing
- `npm test`
- `npm run lint` *(fails: 52 errors)*
- `npx eslint src/components/MediaSection.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6890ea7ae1b4832daa5850e2816414d7