### PR TITLE
Fix media card sizing and mobile layout

### DIFF
--- a/src/components/MediaSection.tsx
+++ b/src/components/MediaSection.tsx
@@ -45,11 +45,11 @@ const MediaSection: React.FC = () => {
           </p>
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-md md:max-w-6xl mx-auto place-items-center">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-md md:max-w-6xl mx-auto place-items-center md:place-items-stretch">
           {mediaLinks.map((media) => (
             <div
               key={media.name}
-              className="aspect-square w-full flex items-center justify-center bg-white md:aspect-auto md:flex-col md:p-6 md:rounded-lg md:shadow-sm md:text-center"
+              className="aspect-square w-full flex items-center justify-center bg-white rounded-lg md:aspect-auto md:flex-col md:h-full md:p-6 md:shadow-sm md:text-center"
 
             >
               <a


### PR DESCRIPTION
## Summary
- ensure media cards stretch evenly on desktop
- keep rounded white cards without text on mobile

## Testing
- `npm test`
- `npm run lint` *(fails: 52 errors, 238 warnings)*
- `npx eslint src/components/MediaSection.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6890f3bc53a0832d9536cdcdae04964b