### PR TITLE
feat: add Vercel web analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-tooltip": "^1.1.4",
         "@supabase/supabase-js": "^2.45.4",
         "@tanstack/react-query": "^5.59.0",
+        "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
         "axios": "^1.9.0",
         "class-variance-authority": "^0.7.1",
@@ -3177,6 +3178,44 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vercel/speed-insights": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@supabase/supabase-js": "^2.45.4",
     "@tanstack/react-query": "^5.59.0",
+    "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
@@ -68,11 +69,11 @@
     "postcss": "^8.4.47",
     "rollup-plugin-visualizer": "^5.12.0",
     "tailwindcss": "^3.4.11",
+    "tsx": "^4.15.7",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.0.1",
     "vite": "^4.5.3",
     "vite-plugin-compression": "^0.5.1",
-    "vitest": "^3.2.4",
-    "tsx": "^4.15.7"
+    "vitest": "^3.2.4"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import ScrollToTop from '@/components/ScrollToTop';
 import { MobileProvider } from '@/hooks/useMobileContext';
+import { Analytics } from '@vercel/analytics/react';
 
 // Lazy load TooltipProvider para LCP
 const TooltipProvider = lazy(() => import('@/components/ui/tooltip').then(m => ({ default: m.TooltipProvider })));
@@ -101,6 +102,7 @@ const App = () => {
           </Suspense>
         </BrowserRouter>
         <Toaster />
+        <Analytics />
       </MobileProvider>
     </QueryClientProvider>
   );

--- a/src/AppServer.tsx
+++ b/src/AppServer.tsx
@@ -5,6 +5,7 @@ import { Routes, Route } from "react-router-dom";
 import ScrollToTop from '@/components/ScrollToTop';
 import { MobileProvider } from '@/hooks/useMobileContext';
 import { Toaster } from '@/components/ui/toast';
+import { Analytics } from '@vercel/analytics/react';
 
 const TooltipProvider = lazy(() => import('@/components/ui/tooltip').then(m => ({ default: m.TooltipProvider })));
 
@@ -100,6 +101,7 @@ const AppServer = () => {
           </Suspense>
         </StaticRouter>
         <Toaster />
+        <Analytics />
       </MobileProvider>
     </QueryClientProvider>
   );


### PR DESCRIPTION
## Summary
- install `@vercel/analytics`
- render `<Analytics />` in client and server app roots

## Testing
- `npm test`
- `npm run lint` *(fails: 52 errors, 238 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_6890f5744864832d8d6dda54634476f1