### PR TITLE
feat: lazy load YouTube thumbnails

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
     <!-- CRITICAL LCP Strategy: Remove image preload to eliminate render blocking -->
     <!-- Video thumbnail now uses instant SVG placeholder for LCP -->
     <link rel="preload" href="/images/logos/logo-azul.png" as="image" fetchpriority="high">
-    <link rel="preload" href="/images/media/video-cgi-libra.webp" as="image" fetchpriority="high">
 
     
       <!-- RADICAL LCP: Force immediate DOM/CSS render -->

--- a/src/components/__tests__/HeroVideos.test.tsx
+++ b/src/components/__tests__/HeroVideos.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import HeroAnimated from '../HeroAnimated';
@@ -9,34 +9,70 @@ vi.mock('../TypewriterText', () => ({
   default: () => <span>Typewriter</span>,
 }));
 
+const setup = () => {
+  // mock requestIdleCallback and Image loading
+  // @ts-expect-error requestIdleCallback is not in the DOM lib yet
+  vi.stubGlobal('requestIdleCallback', (cb: any) => cb());
+  const OriginalImage = global.Image;
+  class MockImage {
+    onload: (() => void) | null = null;
+    _src = '';
+    set src(value: string) {
+      this._src = value;
+      if (this.onload) this.onload();
+    }
+    get src() {
+      return this._src;
+    }
+    loading = '';
+    fetchPriority = '';
+    decoding = '';
+  }
+  // @ts-expect-error overriding global Image for test
+  global.Image = MockImage;
+  return OriginalImage;
+};
+
 describe('video thumbnails', () => {
-  it('HeroAnimated uses the updated thumbnail', () => {
-    render(
+  it('HeroAnimated uses the updated thumbnail', async () => {
+    const OriginalImage = setup();
+    const { container } = render(
       <MemoryRouter>
         <HeroAnimated />
       </MemoryRouter>
     );
-    const thumbnail = screen.getByAltText('Miniatura do Vídeo institucional Libra Crédito') as HTMLImageElement;
-    expect(thumbnail.src).toContain('/images/media/video-cgi-libra.webp');
+    const thumbnail = container.querySelector('img[aria-hidden="true"]') as HTMLImageElement;
+    await waitFor(() => {
+      expect(thumbnail.src).toContain('/images/media/video-cgi-libra.webp');
+    });
+    global.Image = OriginalImage;
   });
 
-  it('Hero uses the updated thumbnail', () => {
-    render(
+  it('Hero uses the updated thumbnail', async () => {
+    const OriginalImage = setup();
+    const { container } = render(
       <MemoryRouter>
         <Hero />
       </MemoryRouter>
     );
-    const thumbnail = screen.getByAltText('Miniatura do Vídeo institucional Libra Crédito') as HTMLImageElement;
-    expect(thumbnail.src).toContain('/images/media/video-cgi-libra.webp');
+    const thumbnail = container.querySelector('img[aria-hidden="true"]') as HTMLImageElement;
+    await waitFor(() => {
+      expect(thumbnail.src).toContain('/images/media/video-cgi-libra.webp');
+    });
+    global.Image = OriginalImage;
   });
 
-  it('HeroMinimal uses the updated thumbnail', () => {
-    render(
+  it('HeroMinimal uses the updated thumbnail', async () => {
+    const OriginalImage = setup();
+    const { container } = render(
       <MemoryRouter>
         <HeroMinimal />
       </MemoryRouter>
     );
-    const thumbnail = screen.getByAltText('Miniatura do Vídeo institucional Libra Crédito') as HTMLImageElement;
-    expect(thumbnail.src).toContain('/images/media/video-cgi-libra.webp');
+    const thumbnail = container.querySelector('img[aria-hidden="true"]') as HTMLImageElement;
+    await waitFor(() => {
+      expect(thumbnail.src).toContain('/images/media/video-cgi-libra.webp');
+    });
+    global.Image = OriginalImage;
   });
 });

--- a/src/components/__tests__/OptimizedYouTube.test.tsx
+++ b/src/components/__tests__/OptimizedYouTube.test.tsx
@@ -1,26 +1,42 @@
-import { render, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import OptimizedYouTube from '../OptimizedYouTube';
 
 describe('OptimizedYouTube', () => {
-  it('hides placeholder after thumbnail loads', () => {
-    const { container, getByAltText } = render(
+  it('replaces placeholder src with real thumbnail after idle', async () => {
+    // mock requestIdleCallback to run immediately
+    // @ts-expect-error requestIdleCallback is not in the DOM lib yet
+    vi.stubGlobal('requestIdleCallback', (cb: any) => cb());
+
+    const OriginalImage = global.Image;
+    class MockImage {
+      onload: (() => void) | null = null;
+      _src = '';
+      set src(value: string) {
+        this._src = value;
+        if (this.onload) this.onload();
+      }
+      get src() {
+        return this._src;
+      }
+      loading = '';
+      fetchPriority = '';
+      decoding = '';
+    }
+    // @ts-expect-error overriding global Image for test
+    global.Image = MockImage;
+
+    const { container } = render(
       <OptimizedYouTube videoId="abc123" title="Test Video" />
     );
 
-    const placeholder = container.querySelector('img[aria-hidden="true"]') as HTMLImageElement;
-    const thumbnail = getByAltText('Miniatura do Test Video') as HTMLImageElement;
+    const img = container.querySelector('img') as HTMLImageElement;
 
-    // placeholder initially in the DOM and visible
-    expect(placeholder).toBeInTheDocument();
-    expect(placeholder.style.display).toBe('block');
+    await waitFor(() => {
+      expect(img.src).toContain('/images/media/video-cgi-libra.webp');
+    });
 
-    // fire load event
-    fireEvent.load(thumbnail);
-
-    // placeholder should be hidden after thumbnail load
-    expect(placeholder.style.display).toBe('none');
+    global.Image = OriginalImage;
   });
 });
-


### PR DESCRIPTION
## Summary
- defer YouTube thumbnail loading using `requestIdleCallback`/`IntersectionObserver`
- remove thumbnail preload now that an inline SVG placeholder is used
- update tests for new lazy image behavior

## Testing
- `npm test`
- `npx eslint src/components/OptimizedYouTube.tsx src/components/__tests__/OptimizedYouTube.test.tsx src/components/__tests__/HeroVideos.test.tsx`
- `curl -s -o /tmp/wpt.json -w '%{http_code}' "https://www.webpagetest.org/runtest.php?url=https://libracredito.com.br&f=json"` *(fails: exit status 000)*

------
https://chatgpt.com/codex/tasks/task_e_6890fe9a1d9c832da002abf22ff64244