### PR TITLE
chore: optimize analytics loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
   <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4LXR55Y9HS"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-4LXR55Y9HS');
-    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Libra Crédito | Empréstimo com Garantia de Imóvel</title>
@@ -29,10 +20,6 @@
     <link rel="dns-prefetch" href="https://www.youtube-nocookie.com">
     <link rel="dns-prefetch" href="https://vercel.app">
     
-    <!-- CRITICAL LCP Strategy: Remove image preload to eliminate render blocking -->
-    <!-- Video thumbnail now uses instant SVG placeholder for LCP -->
-    <link rel="preload" href="/images/logos/logo-azul.png" as="image" fetchpriority="high">
-    <link rel="preload" href="/images/media/video-cgi-libra.webp" as="image" fetchpriority="high">
 
     
       <!-- RADICAL LCP: Force immediate DOM/CSS render -->
@@ -396,6 +383,27 @@
         });
 
         window.addEventListener('load', () => setTimeout(registerSW, 5000));
+      }
+    </script>
+
+    <script>
+      function initGtag() {
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-4LXR55Y9HS');
+      }
+      function loadGtag() {
+        const gtagScript = document.createElement('script');
+        gtagScript.src = 'https://www.googletagmanager.com/gtag/js?id=G-4LXR55Y9HS';
+        gtagScript.async = true;
+        gtagScript.onload = initGtag;
+        document.head.appendChild(gtagScript);
+      }
+      if ('requestIdleCallback' in window) {
+        requestIdleCallback(loadGtag);
+      } else {
+        window.addEventListener('load', loadGtag);
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- load Google Analytics after initial load using `requestIdleCallback`
- drop non-critical image preloads

## Testing
- `npm run lint` *(fails: 52 errors, 238 warnings)*
- `npm run typecheck`
- `npm run build`
- `npm run build:stats`


------
https://chatgpt.com/codex/tasks/task_e_6890fea0c888832db330b45417a88e08