### PR TITLE
chore: tree-shake lucide icons

### DIFF
--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { ChevronRight, MoreHorizontal } from "lucide-react"
+import ChevronRight from "lucide-react/dist/esm/icons/chevron-right"
+import MoreHorizontal from "lucide-react/dist/esm/icons/more-horizontal"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -2,7 +2,8 @@ import * as React from "react"
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
 } from "embla-carousel-react"
-import { ArrowLeft, ArrowRight } from "lucide-react"
+import ArrowLeft from "lucide-react/dist/esm/icons/arrow-left"
+import ArrowRight from "lucide-react/dist/esm/icons/arrow-right"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Check } from "lucide-react";
+import Check from "lucide-react/dist/esm/icons/check";
 import { cn } from "@/lib/utils";
 
 interface CheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { type DialogProps } from "@radix-ui/react-dialog"
 import { Command as CommandPrimitive } from "cmdk"
-import { Search } from "lucide-react"
+import Search from "lucide-react/dist/esm/icons/search"
 
 import { cn } from "@/lib/utils"
 import { Dialog, DialogContent } from "@/components/ui/dialog"

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
-import { Check, ChevronRight, Circle } from "lucide-react"
+import Check from "lucide-react/dist/esm/icons/check"
+import ChevronRight from "lucide-react/dist/esm/icons/chevron-right"
+import Circle from "lucide-react/dist/esm/icons/circle"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import X from "lucide-react/dist/esm/icons/x"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { Check, ChevronRight, Circle } from "lucide-react"
+import Check from "lucide-react/dist/esm/icons/check"
+import ChevronRight from "lucide-react/dist/esm/icons/chevron-right"
+import Circle from "lucide-react/dist/esm/icons/circle"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { OTPInput, OTPInputContext } from "input-otp"
-import { Dot } from "lucide-react"
+import Dot from "lucide-react/dist/esm/icons/dot"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as MenubarPrimitive from "@radix-ui/react-menubar"
-import { Check, ChevronRight, Circle } from "lucide-react"
+import Check from "lucide-react/dist/esm/icons/check"
+import ChevronRight from "lucide-react/dist/esm/icons/chevron-right"
+import Circle from "lucide-react/dist/esm/icons/circle"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
 import { cva } from "class-variance-authority"
-import { ChevronDown } from "lucide-react"
+import ChevronDown from "lucide-react/dist/esm/icons/chevron-down"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
-import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+import ChevronLeft from "lucide-react/dist/esm/icons/chevron-left"
+import ChevronRight from "lucide-react/dist/esm/icons/chevron-right"
+import MoreHorizontal from "lucide-react/dist/esm/icons/more-horizontal"
 
 import { cn } from "@/lib/utils"
 import { ButtonProps, buttonVariants } from "@/components/ui/button"

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
-import { Circle } from "lucide-react"
+import Circle from "lucide-react/dist/esm/icons/circle"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,4 +1,4 @@
-import { GripVertical } from "lucide-react"
+import GripVertical from "lucide-react/dist/esm/icons/grip-vertical"
 import * as ResizablePrimitive from "react-resizable-panels"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,7 +1,9 @@
 
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import { Check, ChevronDown, ChevronUp } from "lucide-react"
+import Check from "lucide-react/dist/esm/icons/check"
+import ChevronDown from "lucide-react/dist/esm/icons/chevron-down"
+import ChevronUp from "lucide-react/dist/esm/icons/chevron-up"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,6 +1,6 @@
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import X from "lucide-react/dist/esm/icons/x"
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
-import { PanelLeft } from "lucide-react"
+import PanelLeft from "lucide-react/dist/esm/icons/panel-left"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"


### PR DESCRIPTION
## Summary
- import lucide icons directly to enable tree-shaking

## Testing
- `npm test`
- `npm run build:stats`


------
https://chatgpt.com/codex/tasks/task_e_6890fea78af4832dbe6108b20e2f56bd