### PR TITLE
refactor: streamline SW static cache

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -8,12 +8,9 @@ const STATIC_ASSETS = [
   '/',
   '/index.html',
   '/src/styles/critical.css',
-  '/images/logos/logo-azul.png',
-  '/images/logos/libra-icon.png',
-
-  '/logo-azul.ico',
   '/manifest.json'
 ];
+// Logos e ícones grandes serão armazenados no cache dinâmico após o primeiro uso
 
 // Precache desativado para reduzir requisições iniciais
 const PRECACHE_ASSETS = [];
@@ -222,12 +219,10 @@ function isStaticAsset(url) {
   return (
     url.pathname.includes('/static/') ||
     url.pathname.includes('/assets/') ||
-    url.pathname.includes('/images/') ||
     url.pathname.endsWith('.css') ||
     url.pathname.endsWith('.js') ||
     url.pathname.endsWith('.woff2') ||
-    url.pathname.endsWith('.woff') ||
-    url.pathname.endsWith('.ico')
+    url.pathname.endsWith('.woff')
   );
 }
 
@@ -246,7 +241,8 @@ function isImageRequest(url) {
     url.pathname.endsWith('.png') ||
     url.pathname.endsWith('.webp') ||
     url.pathname.endsWith('.avif') ||
-    url.pathname.endsWith('.svg')
+    url.pathname.endsWith('.svg') ||
+    url.pathname.endsWith('.ico')
   );
 }
 


### PR DESCRIPTION
## Summary
- slim down service worker static cache to avoid precaching large logos
- route logos and icons through dynamic caching after first access

## Testing
- `time npm run build`
- `npm run lint` *(fails: 52 errors, 238 warnings)*
- `npm test`
- `du -b index.html src/styles/critical.css public/manifest.json`
- `time node -e "const fs=require('fs'); const files=['index.html','src/styles/critical.css','public/manifest.json']; const start=Date.now(); files.forEach(f=>fs.readFileSync(f)); console.log('read', files.length, 'files');"`

------
https://chatgpt.com/codex/tasks/task_e_6892092f1c2c832d944a1af4447bb9c9