### PR TITLE
feat: add GTM and remove direct GA script

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
   <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-XXXXXXX');
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Libra Crédito | Empréstimo com Garantia de Imóvel</title>
@@ -359,6 +368,9 @@
   </head>
 
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     
     
@@ -386,25 +398,5 @@
       }
     </script>
 
-    <script>
-      function initGtag() {
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'G-4LXR55Y9HS');
-      }
-      function loadGtag() {
-        const gtagScript = document.createElement('script');
-        gtagScript.src = 'https://www.googletagmanager.com/gtag/js?id=G-4LXR55Y9HS';
-        gtagScript.async = true;
-        gtagScript.onload = initGtag;
-        document.head.appendChild(gtagScript);
-      }
-      if ('requestIdleCallback' in window) {
-        requestIdleCallback(loadGtag);
-      } else {
-        window.addEventListener('load', loadGtag);
-      }
-    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add Google Tag Manager snippet to the head
- include GTM noscript fallback after body tag
- remove direct gtag.js analytics script

## Testing
- `npm test`
- `npm run lint` *(fails: 290 problems, 52 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689210708504832d9c9221b399d2632d