### PR TITLE
feat: integrate GTM on local storage cleanup page

### DIFF
--- a/clear-localstorage.html
+++ b/clear-localstorage.html
@@ -1,18 +1,28 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4LXR55Y9HS"></script>
+    <!-- Google Tag Manager -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-4LXR55Y9HS');
+        (function(w,d,s,l,i){
+            w[l]=w[l]||[];
+            w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
+            var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),
+                dl=l!='dataLayer'?'&l='+l:'';
+            j.async=true;
+            j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+            f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-XXXXXXX');
     </script>
+    <!-- End Google Tag Manager -->
     <title>Limpar LocalStorage</title>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <h1>Limpando LocalStorage...</h1>
     <div id="status">Processando...</div>
     


### PR DESCRIPTION
## Summary
- add Google Tag Manager script to `clear-localstorage.html`
- remove direct gtag.js implementation

## Testing
- `npm test`
- `npm run lint` *(fails: 52 errors, 238 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68921072d4b4832d830d9bf29ed100fe