### PR TITLE
chore: preload landing hero image

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
     <link rel="preload" href="/assets/css/index.css" as="style" onload="this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="/assets/css/index.css"></noscript>
 
+    <link rel="preload" as="image" href="/images/media/video-cgi-libra.webp" fetchpriority="high">
+
     <!-- Early hints for critical resources -->
     <link rel="dns-prefetch" href="https://img.youtube.com">
     <link rel="dns-prefetch" href="https://api-calculos.vercel.app">


### PR DESCRIPTION
## Summary
- preload landing hero image for faster loading

## Testing
- `npm run lint` *(fails: 52 errors, 238 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6892471cca44832d8d91cecf16e9c743