### PR TITLE
fix: ensure blog images retain aspect ratio

### DIFF
--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -152,7 +152,7 @@ const BlogPost = () => {
               <img
                 src={post.imageUrl}
                 alt={post.title}
-                className="w-full h-64 md:h-96 object-cover transition-transform duration-300 hover:scale-105"
+                className="w-full h-auto max-h-screen object-contain transition-transform duration-300 hover:scale-105"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent"></div>
             </div>


### PR DESCRIPTION
## Summary
- ensure blog post images maintain aspect ratio and fit within viewport

## Testing
- `npm run lint` (fails: 52 errors)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892491d4bd8832d99395dc9b89693c8