### PR TITLE
fix: serve image paths without SPA rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,10 @@
   "framework": "vite",
   "rewrites": [
     {
+      "source": "/images/(.*)",
+      "destination": "/images/$1"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary
- exclude /images/* from catch-all SPA rewrite in `vercel.json`

## Testing
- `npm test`
- `npm run lint` (fails: 53 errors, 240 warnings)
- `npm run build`
- `curl -I http://localhost:4173/images/media/video-cgi-libra.webp`
- `curl http://localhost:4173/ | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_68925fe64494832db4e8af3f628033af