### PR TITLE
Fix CLS by adding dimensions to logo image

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -150,6 +150,8 @@ const Index: React.FC = () => {
             <img
               src="/images/logos/logo-branco.svg"
               alt="Libra Crédito"
+              width={64}
+              height={64}
               className="h-12 sm:h-16 w-auto flex-shrink-0"
             />
             <span className="ml-3 sm:ml-4 text-white text-sm sm:text-base font-semibold leading-tight text-center flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- specify width and height on logo image inside mobile call-to-action section to avoid layout shift

## Testing
- `npm test`
- `npm run lint` (fails: 53 errors)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68927596a5bc832d9253a4317ac6e936