### PR TITLE
fix: stabilize hero video aspect ratio

### DIFF
--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -85,7 +85,7 @@ const HeroPremium: React.FC = () => {
 
           {/* Vídeo reduzido para exibir as ondas seguintes na dobra inicial */}
           <div className="w-full max-w-md lg:w-[85%] lg:max-w-lg mx-auto">
-            <div className="hero-video aspect-video">
+            <div className="hero-video aspect-video" style={{ aspectRatio: '16 / 9' }}>
               <OptimizedYouTube
                 videoId="E9lwL6R2l1s"
                 title="Vídeo institucional Libra Crédito"


### PR DESCRIPTION
## Summary
- ensure hero video container reserves space with 16:9 aspect ratio to avoid layout shift

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892759977c4832da73641df8815485a