### PR TITLE
fix: reserve space for typed text

### DIFF
--- a/src/components/TypewriterText.tsx
+++ b/src/components/TypewriterText.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 
 export default function TypewriterText({ strings }: { strings: string[] }) {
   const el = useRef<HTMLSpanElement>(null);
+  const maxChars = Math.max(...strings.map((s) => s.length));
 
   useEffect(() => {
     let typed: any;
@@ -28,5 +29,12 @@ export default function TypewriterText({ strings }: { strings: string[] }) {
     };
   }, [strings]);
 
-  return <span ref={el}>{strings[0]}</span>;
+  return (
+    <span
+      ref={el}
+      style={{ display: 'inline-block', minWidth: `${maxChars}ch` }}
+    >
+      {strings[0]}
+    </span>
+  );
 }


### PR DESCRIPTION
## Summary
- prevent layout shift by reserving space for longest string in typewriter text

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: 293 problems (53 errors, 240 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6892759baa0c832d82e559a2dc84cab6