### PR TITLE
Maintain header offset when banner closed

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -39,6 +39,8 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
   const location = useLocation();
   const _navigate = useNavigate();
   const [showBanner, setShowBanner] = useState(true);
+  const bannerRef = useRef<HTMLDivElement | null>(null);
+  const [bannerHeight, setBannerHeight] = useState(0);
   const headerRef = useRef<HTMLElement | null>(null);
   const headerHeightRef = useRef(0);
 
@@ -82,8 +84,8 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
         ref={headerRef}
       >
       {/* Faixa superior informativa */}
-      {showBanner && (
-        <div className="w-full bg-libra-navy">
+      {showBanner ? (
+        <div ref={bannerRef} className="w-full bg-libra-navy overflow-hidden">
           <div className="container mx-auto px-4">
             <div className="relative flex items-center justify-center py-2">
               <div className="flex items-center text-white text-sm font-semibold">
@@ -92,7 +94,12 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
               </div>
               <button
                 className="absolute right-0 top-1/2 -translate-y-1/2 text-white hover:text-gray-200"
-                onClick={() => setShowBanner(false)}
+                onClick={() => {
+                  if (bannerRef.current) {
+                    setBannerHeight(bannerRef.current.offsetHeight);
+                  }
+                  setShowBanner(false);
+                }}
                 aria-label="Fechar aviso"
               >
                 <X className="w-4 h-4" />
@@ -100,6 +107,12 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
             </div>
           </div>
         </div>
+      ) : (
+        <div
+          aria-hidden="true"
+          style={{ height: bannerHeight }}
+          className="w-full overflow-hidden"
+        />
       )}
 
         {/* Faixa principal */}

--- a/src/components/__tests__/DesktopHeader.test.tsx
+++ b/src/components/__tests__/DesktopHeader.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import DesktopHeader from '../DesktopHeader';
+
+describe('DesktopHeader', () => {
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 103,
+    });
+
+    // Simple mock for ResizeObserver
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).ResizeObserver = class {
+      observe() {}
+      disconnect() {}
+    };
+  });
+
+  afterAll(() => {
+    delete (HTMLElement.prototype as any).offsetHeight;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (global as any).ResizeObserver;
+  });
+
+  it('keeps header offset after closing the banner', async () => {
+    render(
+      <MemoryRouter>
+        <DesktopHeader onPortalClientes={() => {}} onSimulateNow={() => {}} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue('--header-offset-desktop')
+      ).toBe('103px');
+    });
+
+    const closeButton = screen.getByLabelText('Fechar aviso');
+    fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue('--header-offset-desktop')
+      ).toBe('103px');
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- Preserve desktop header height when info banner closes
- Add unit test ensuring `--header-offset-desktop` remains stable

## Testing
- `npm run lint` *(fails: 53 errors, 241 warnings)*
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893615e0194832da15765298804b70e