### PR TITLE
Fix logo dimensions to reduce layout shift

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,6 +7,7 @@ import { useIsMobile } from '@/hooks/useMobileContext';
 import HeroPremium from '@/components/HeroPremium';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 import Header from '@/components/Header';
+import ImageOptimizer from '@/components/ImageOptimizer';
 
 // Lazy loading dos componentes pesados - com threshold otimizado
 const FAQ = lazy(() => import('@/components/FAQ'));
@@ -147,14 +148,13 @@ const Index: React.FC = () => {
           }}
         >
           <div className="flex items-center px-4 max-w-full">
-            <img
+            <ImageOptimizer
               src="/images/logos/logo-branco.svg"
               alt="Libra Crédito"
               width={64}
               height={64}
-              className="h-12 sm:h-16 w-auto flex-shrink-0"
-              width={2048}
-              height={2047}
+              aspectRatio={1}
+              className="h-12 sm:h-16 flex-shrink-0"
             />
             <span className="ml-3 sm:ml-4 text-white text-sm sm:text-base font-semibold leading-tight text-center flex-1 min-w-0">
               Crédito justo, equilibrado e consciente!


### PR DESCRIPTION
## Summary
- replace mobile logo `<img>` with `ImageOptimizer` and fixed 64×64 dimensions

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: 53 errors)*
- `npm run build`
- `lighthouse http://localhost:8080` *(CLS ≈0.112)*

------
https://chatgpt.com/codex/tasks/task_e_6893615c9138832d9e620251b29306fa