### PR TITLE
feat: expand Seo component

### DIFF
--- a/docs/SEO_COMPONENT_USAGE.md
+++ b/docs/SEO_COMPONENT_USAGE.md
@@ -1,0 +1,28 @@
+# SEO Component Usage
+
+The `Seo` component centralizes page-level metadata so it can be reused across
+routes.
+
+## Props
+
+- `title` – Sets the document title.
+- `description` – Updates the standard meta description tag.
+- `canonicalUrl` – Adds or updates a canonical link element.
+- `openGraph` – Object containing Open Graph values such as `title`,
+  `description` and `image`.
+- `twitter` – Object containing Twitter card values such as `card`, `title`,
+  `description` and `image`.
+- `jsonLd` – Structured data injected as JSON-LD.
+- `schemaId` – Optional ID for the JSON-LD script element.
+
+## Example
+
+```tsx
+<Seo
+  title="Home Equity"
+  description="Crédito com garantia de imóvel"
+  canonicalUrl="https://example.com"
+  openGraph={{ title: 'OG Title', description: 'OG Description', image: '/img.png' }}
+  twitter={{ card: 'summary_large_image', title: 'Twitter Title', image: '/img.png' }}
+/>
+```

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,13 +1,37 @@
 import React, { useEffect } from 'react';
 
+/**
+ * Props for the {@link Seo} component used to manage page-level metadata.
+ *
+ * - `title` – Sets the document title.
+ * - `description` – Updates the standard meta description tag.
+ * - `canonicalUrl` – Adds or updates a canonical link element.
+ * - `openGraph` – Key/value pairs for Open Graph meta tags (e.g. `title`,
+ *   `description`, `image`).
+ * - `twitter` – Key/value pairs for Twitter card meta tags (e.g. `card`,
+ *   `title`, `description`, `image`).
+ * - `jsonLd` – Structured data object injected as JSON-LD.
+ * - `schemaId` – Optional ID for the JSON-LD script element.
+ */
 interface SeoProps {
   title?: string;
   description?: string;
+  canonicalUrl?: string;
+  openGraph?: Record<string, string | undefined>;
+  twitter?: Record<string, string | undefined>;
   jsonLd?: Record<string, any>;
   schemaId?: string;
 }
 
-const Seo: React.FC<SeoProps> = ({ title, description, jsonLd, schemaId }) => {
+const Seo: React.FC<SeoProps> = ({
+  title,
+  description,
+  canonicalUrl,
+  openGraph,
+  twitter,
+  jsonLd,
+  schemaId,
+}) => {
   useEffect(() => {
     if (title) {
       document.title = title;
@@ -18,6 +42,50 @@ const Seo: React.FC<SeoProps> = ({ title, description, jsonLd, schemaId }) => {
       if (metaDescription) {
         metaDescription.setAttribute('content', description);
       }
+    }
+
+    if (canonicalUrl) {
+      let link = document.querySelector(
+        "link[rel='canonical']"
+      ) as HTMLLinkElement | null;
+      if (!link) {
+        link = document.createElement('link');
+        link.setAttribute('rel', 'canonical');
+        document.head.appendChild(link);
+      }
+      link.setAttribute('href', canonicalUrl);
+    }
+
+    if (openGraph) {
+      Object.entries(openGraph).forEach(([key, value]) => {
+        if (!value) return;
+        const property = `og:${key}`;
+        let meta = document.querySelector(
+          `meta[property='${property}']`
+        ) as HTMLMetaElement | null;
+        if (!meta) {
+          meta = document.createElement('meta');
+          meta.setAttribute('property', property);
+          document.head.appendChild(meta);
+        }
+        meta.setAttribute('content', value);
+      });
+    }
+
+    if (twitter) {
+      Object.entries(twitter).forEach(([key, value]) => {
+        if (!value) return;
+        const name = `twitter:${key}`;
+        let meta = document.querySelector(
+          `meta[name='${name}']`
+        ) as HTMLMetaElement | null;
+        if (!meta) {
+          meta = document.createElement('meta');
+          meta.setAttribute('name', name);
+          document.head.appendChild(meta);
+        }
+        meta.setAttribute('content', value);
+      });
     }
 
     let script: HTMLScriptElement | null = null;
@@ -41,7 +109,15 @@ const Seo: React.FC<SeoProps> = ({ title, description, jsonLd, schemaId }) => {
         existing.remove();
       }
     };
-  }, [title, description, jsonLd, schemaId]);
+  }, [
+    title,
+    description,
+    canonicalUrl,
+    openGraph,
+    twitter,
+    jsonLd,
+    schemaId,
+  ]);
 
   return null;
 };


### PR DESCRIPTION
## Summary
- add canonical URL, Open Graph and Twitter support to Seo component
- document Seo component props for reuse

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689369e044f0832d85ab401fe202d90c