### PR TITLE
feat: use meta blog fields for SEO

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -144,7 +144,7 @@ const BlogSection: React.FC = () => {
                   <div className="aspect-video overflow-hidden rounded-t-lg bg-white">
                     <img
                       src={post.imageUrl}
-                      alt={post.title}
+                      alt={post.metaTitle ?? post.title}
                       className="w-full h-full object-cover object-center group-hover:scale-105 transition-transform duration-300"
                       width={1280}
                       height={720}
@@ -164,13 +164,13 @@ const BlogSection: React.FC = () => {
                       {post.readTime} min
                     </div>
                     <CardTitle className={`${isMobile ? 'text-base' : 'text-lg'} leading-tight text-[#003399] group-hover:text-[#0044aa] transition-colors`}>
-                      {post.title}
+                      {post.metaTitle ?? post.title}
                     </CardTitle>
                   </CardHeader>
                   
                   <CardContent>
                     <p className={`text-gray-600 ${isMobile ? 'text-sm' : 'text-sm'} leading-relaxed mb-4 line-clamp-2`}>
-                      {post.description}
+                      {post.metaDescription ?? post.description}
                     </p>
                     <div className="flex items-center text-[#003399] group-hover:text-[#0044aa] transition-colors">
                       <span className="text-sm font-medium">Ler mais</span>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -234,7 +234,7 @@ const Blog = () => {
                       <div className="aspect-video overflow-hidden rounded-t-xl bg-white">
                         <img
                           src={post.imageUrl}
-                          alt={post.title}
+                          alt={post.metaTitle ?? post.title}
                           className="w-full h-full object-cover object-center group-hover:scale-105 transition-transform duration-300"
                           width={1280}
                           height={720}
@@ -250,10 +250,10 @@ const Blog = () => {
                           {CATEGORIES.find(cat => cat.id === post.category)?.name}
                         </span>
                         <h3 className="text-lg font-bold text-libra-navy mt-2 mb-2 group-hover:text-libra-blue transition-colors">
-                          {post.title}
+                          {post.metaTitle ?? post.title}
                         </h3>
                         <p className="text-gray-600 text-sm mb-3 line-clamp-2">
-                          {post.description}
+                          {post.metaDescription ?? post.description}
                         </p>
                       <div className="flex items-center justify-between text-sm text-gray-500">
                         <span>{new Date(post.createdAt || '').toLocaleDateString('pt-BR')}</span>

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -116,13 +116,13 @@ const BlogPost = () => {
     <MobileLayout>
       {post && (
         <Seo
-          title={`${post.title} | Blog Libra Crédito`}
-          description={post.description}
+          title={`${post.metaTitle ?? post.title} | Blog Libra Crédito`}
+          description={post.metaDescription ?? post.description}
           jsonLd={{
             '@context': 'https://schema.org',
             '@type': 'Article',
-            headline: post.title,
-            description: post.description,
+            headline: post.metaTitle ?? post.title,
+            description: post.metaDescription ?? post.description,
             author: {
               '@type': 'Organization',
               name: 'Libra Crédito'


### PR DESCRIPTION
## Summary
- Prefer meta title/description when available for blog post SEO.
- Show meta titles and descriptions in blog listings.

## Testing
- `npm test`
- `npm run lint` *(fails: 53 errors, 241 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689369f2b95c832d8912409c1ad0fb2d