### PR TITLE
feat: sync decode for priority videos

### DIFF
--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -26,7 +26,7 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
   className = '',
   priority = false,
   fetchPriority,
-  decoding = 'async',
+  decoding = priority ? 'sync' : 'async',
   thumbnailSrc,
 }) => {
   const thumbnailImage = thumbnailSrc || '/images/media/video-cgi-libra.webp';
@@ -91,6 +91,7 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
             objectFit: 'cover',
             display: 'block',
           }}
+          decoding={decoding}
         />
         <picture
           style={{
@@ -115,7 +116,7 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
             }}
             loading={priority ? 'eager' : 'lazy'}
             {...(fetchPriorityAttr ? { fetchpriority: fetchPriorityAttr } : {})}
-            decoding={decoding}
+            decoding="sync"
             onLoad={handleThumbnailLoad}
           />
         </picture>


### PR DESCRIPTION
## Summary
- adjust OptimizedYouTube to default decoding to sync when priority is set
- always decode the thumbnail synchronously

## Testing
- `npm test`
- `npm run lint` *(fails: 53 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893777769ec832db547e4f9c7182323