### PR TITLE
Embed hero markup in initial HTML and hydrate

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,7 +395,73 @@
       />
     </noscript>
     <!-- End Meta Pixel (noscript) -->
-    <div id="root"></div>
+    <div id="root">
+      <section class="min-h-[50vh] md:min-h-[55vh] lg:min-h-[60vh] xl:min-h-[calc(100vh-280px)] pb-0 bg-white relative flex flex-col justify-center" aria-labelledby="hero-heading" role="banner">
+      <div class="container mx-auto px-4 md:px-6 relative z-10 flex-grow flex flex-col justify-center">
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-8 items-center">
+      <div class="text-[#003399] max-w-lg mx-auto space-y-4 md:space-y-5 text-center flex flex-col items-center">
+      <div>
+      <h1 id="hero-heading" class="text-xl md:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight">
+      <span>Crédito com Garantia de Imóvel</span>
+      <span class="block text-green-700">é mais simples na Libra!</span>
+      </h1>
+      <ul class="mt-2 space-y-2 md:space-y-3 text-sm md:text-base lg:text-lg text-[#003399] font-medium">
+      <li class="mt-2 lg:mt-4 text-xs md:text-sm lg:text-lg">Taxas a partir de <span class="font-bold text-green-700">1,19% a.m.</span> • Até 180 meses • 100% online</li>
+      <li class="list-none">
+      <div class="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full max-w-sm mx-auto pt-2 sm:pt-3">
+      <button class="w-full cta-button px-6 py-3 text-sm sm:px-8 sm:py-4 sm:text-base font-bold bg-gradient-to-r from-[#003399] to-[#0055CC] text-white bg-red-600 hover:bg-red-700">Simular Agora</button>
+      </div>
+      </li>
+      <li class="text-lg md:text-xl lg:text-2xl">Crédito inteligente para quem construiu patrimônio!</li>
+      </ul>
+      </div>
+      </div>
+      <div class="w-full max-w-md lg:w-[85%] lg:max-w-lg mx-auto">
+      <div class="hero-video aspect-video">
+      <div class="hero-video relative w-full h-full overflow-hidden w-full h-full">
+      <button class="w-full h-full cursor-pointer relative bg-black flex items-center justify-center group" aria-label="Reproduzir vídeo: Vídeo institucional Libra Crédito" type="button">
+      <img src="data:image/svg+xml,%3Csvg xmlns=&#x27;http://www.w3.org/2000/svg&#x27; viewBox=&#x27;0 0 480 360&#x27;%3E%3Crect width=&#x27;480&#x27; height=&#x27;360&#x27; fill=&#x27;%23e2e8f0&#x27;/%3E%3C/svg%3E" alt="" aria-hidden="true" width="480" height="360" style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;display:block"/>
+      <picture style="position:absolute;inset:0;width:100%;height:100%;display:block">
+      <img src="/images/media/video-cgi-libra.webp" alt="Miniatura do Vídeo institucional Libra Crédito" width="480" height="360" style="width:100%;height:100%;object-fit:cover;display:block" loading="eager" fetchpriority="high" decoding="async"/>
+      </picture>
+      <div class="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition-colors duration-200">
+      <div class="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-lg group-hover:bg-red-700 transition-all duration-200 group-hover:scale-105">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play w-8 h-8 md:w-10 md:h-10 text-white ml-1">
+      <polygon points="6 3 20 12 6 21 6 3">
+      </polygon>
+      </svg>
+      </div>
+      </div>
+      </button>
+      </div>
+      </div>
+      <div class="flex lg:hidden items-center justify-center gap-2 bg-green-50 rounded-md py-1 px-2 mt-2">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-shield w-4 h-4 md:w-5 md:h-5 flex-shrink-0 text-[#003399]" aria-hidden="true">
+      <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z">
+      </path>
+      </svg>
+      <span class="text-center text-[#003399]">Atendimento Premium, Segurança e Velocidade!</span>
+      </div>
+      <div class="hidden lg:flex items-center justify-center gap-2 bg-green-50 rounded-md py-1 px-2 mt-2">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-shield w-4 h-4 flex-shrink-0 text-[#003399]" aria-hidden="true">
+      <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z">
+      </path>
+      </svg>
+      <span class="text-center text-[#003399]">Atendimento Premium, Segurança e Velocidade!</span>
+      </div>
+      </div>
+      </div>
+      <div class="flex justify-center mt-2 md:mt-3">
+      <button class="text-[#003399] flex flex-col items-center opacity-90 hover:opacity-100 transition-opacity" aria-label="Rolar para benefícios">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down w-5 h-5 md:w-5 md:h-5 lg:w-4 lg:h-4 animate-bounce">
+      <path d="m6 9 6 6 6-6">
+      </path>
+      </svg>
+      </button>
+      </div>
+      </div>
+      </section>
+    </div>
     
     
     <script type="module" src="/src/main.tsx" defer></script>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { hydrateRoot } from 'react-dom/client';
+import { hydrateRoot, createRoot } from 'react-dom/client';
 import App from './App.tsx'
 import './index.css';
 import './styles/overflow-fix.css';
@@ -21,7 +21,11 @@ const renderApp = () => {
   
   const root = document.getElementById('root');
   if (root) {
-    hydrateRoot(root, <App />);
+    if (root.hasChildNodes()) {
+      hydrateRoot(root, <App />);
+    } else {
+      createRoot(root).render(<App />);
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- Embed Hero section markup in `index.html` so the thumbnail renders before JS
- Use `hydrateRoot` with a `createRoot` fallback to hydrate existing DOM

## Testing
- `npm test`
- `npm run lint` *(fails: 53 errors, 243 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893777b713c832dabd99f1cbbdc525b