### PR TITLE
fix: stabilize typewriter text width

### DIFF
--- a/src/components/TypewriterText.tsx
+++ b/src/components/TypewriterText.tsx
@@ -1,13 +1,34 @@
 import { useEffect, useRef } from 'react';
+import type Typed from 'typed.js';
 
 export default function TypewriterText({ strings }: { strings: string[] }) {
   const el = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
-    let typed: any;
+    let typed: Typed | undefined;
     let isMounted = true;
 
+    const setMinWidth = () => {
+      if (!el.current) return;
+      const span = document.createElement('span');
+      const computed = window.getComputedStyle(el.current);
+      span.style.visibility = 'hidden';
+      span.style.position = 'absolute';
+      span.style.whiteSpace = 'pre';
+      span.style.font = computed.font;
+      document.body.appendChild(span);
+      let maxWidth = 0;
+      strings.forEach((str) => {
+        span.textContent = str;
+        maxWidth = Math.max(maxWidth, span.getBoundingClientRect().width);
+      });
+      document.body.removeChild(span);
+      el.current.style.display = 'inline-block';
+      el.current.style.minWidth = `${Math.ceil(maxWidth)}px`;
+    };
+
     const loadTyped = async () => {
+      setMinWidth();
       const { default: Typed } = await import('typed.js');
       if (!isMounted || !el.current) return;
 


### PR DESCRIPTION
## Summary
- pre-measure typewriter text and enforce min-width to prevent layout shift

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: 53 errors)*


------
https://chatgpt.com/codex/tasks/task_e_68937e89ce3c832dab260bc381264928