### PR TITLE
feat: add responsive srcset support

### DIFF
--- a/src/components/ImageOptimizer.tsx
+++ b/src/components/ImageOptimizer.tsx
@@ -58,6 +58,8 @@ interface ImageOptimizerProps {
   priority?: boolean;
   width?: number;
   height?: number;
+  widths?: number[];
+  sizes?: string;
 }
 
 const ImageOptimizer: React.FC<ImageOptimizerProps> = ({
@@ -67,8 +69,12 @@ const ImageOptimizer: React.FC<ImageOptimizerProps> = ({
   aspectRatio = 16/9,
   priority = false,
   width,
-  height
+  height,
+  widths,
+  sizes
 }) => {
+  const srcSet = widths?.map((w) => `${src}?width=${w} ${w}w`).join(', ');
+
   const imageElement = (
     <img
       src={src}
@@ -78,6 +84,8 @@ const ImageOptimizer: React.FC<ImageOptimizerProps> = ({
       width={width}
       height={height}
       decoding="async"
+      srcSet={srcSet}
+      sizes={sizes}
     />
   );
   

--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -13,6 +13,8 @@ const LogoBand: React.FC = () => {
           priority={false}
           width={80}
           height={80}
+          widths={[80, 160]}
+          sizes="80px"
         />
         <span className="ml-4 text-white text-lg font-semibold whitespace-nowrap">
           Crédito justo, equilibrado e consciente!

--- a/src/components/__tests__/LogoBand.test.tsx
+++ b/src/components/__tests__/LogoBand.test.tsx
@@ -18,6 +18,8 @@ describe('LogoBand', () => {
     expect(img.getAttribute('src')).toBe('/images/logos/logo-branco.svg');
     expect(img).toHaveAttribute('width', '80');
     expect(img).toHaveAttribute('height', '80');
+    expect(img.getAttribute('srcset')).toContain('width=80');
+    expect(img).toHaveAttribute('sizes', '80px');
   });
 });
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -155,6 +155,8 @@ const Index: React.FC = () => {
               height={64}
               aspectRatio={1}
               className="h-12 sm:h-16 flex-shrink-0"
+              widths={[64, 128]}
+              sizes="64px"
             />
             <span className="ml-3 sm:ml-4 text-white text-sm sm:text-base font-semibold leading-tight text-center flex-1 min-w-0">
               Crédito justo, equilibrado e consciente!

--- a/src/pages/QuemSomos.tsx
+++ b/src/pages/QuemSomos.tsx
@@ -96,6 +96,8 @@ const QuemSomos = () => {
                     aspectRatio={16/9}
                     width={2048}
                     height={1106}
+                    widths={[480, 768, 1024, 1600, 2048]}
+                    sizes="(max-width: 768px) 100vw, 50vw"
                   />
               </div>
             </div>
@@ -147,6 +149,8 @@ const QuemSomos = () => {
                   aspectRatio={1600/1066}
                   width={1600}
                   height={1066}
+                  widths={[480, 768, 1024, 1600]}
+                  sizes="(max-width: 1024px) 100vw, 50vw"
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- extend ImageOptimizer to build srcset and accept sizes
- update pages to use responsive image widths
- adjust LogoBand test for new srcset

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and console warnings)*
- `npx eslint src/components/ImageOptimizer.tsx src/pages/Index.tsx src/pages/QuemSomos.tsx src/components/LogoBand.tsx src/components/__tests__/LogoBand.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68937e86112c832d8217d9a7998dce32