### PR TITLE
feat: defer analytics scripts and preconnect

### DIFF
--- a/clear-localstorage.html
+++ b/clear-localstorage.html
@@ -1,18 +1,31 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <!-- Google Tag Manager -->
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+    <!-- Google Tag Manager (loaded after first paint or on user interaction) -->
     <script>
-        (function(w,d,s,l,i){
-            w[l]=w[l]||[];
-            w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
-            var f=d.getElementsByTagName(s)[0],
-                j=d.createElement(s),
-                dl=l!='dataLayer'?'&l='+l:'';
-            j.async=true;
-            j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
-            f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-M943GMK8');
+        function loadGTM(){
+            if (window.gtmLoaded) return;
+            window.gtmLoaded = true;
+            (function(w,d,s,l,i){
+                w[l]=w[l]||[];
+                w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
+                var f=d.getElementsByTagName(s)[0],
+                    j=d.createElement(s),
+                    dl=l!='dataLayer'?'&l='+l:'';
+                j.async=true;
+                j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+                f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','GTM-M943GMK8');
+        }
+        if (window.requestIdleCallback) {
+            requestIdleCallback(loadGTM);
+        } else {
+            setTimeout(loadGTM, 0);
+        }
+        ['scroll','mousemove','touchstart','keydown'].forEach(function(evt){
+            window.addEventListener(evt, loadGTM, { once: true });
+        });
     </script>
     <!-- End Google Tag Manager -->
     <title>Limpar LocalStorage</title>

--- a/index.html
+++ b/index.html
@@ -1,29 +1,26 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
   <head>
-    <!-- Google Tag Manager -->
+    <!-- Analytics Scripts (loaded after first paint or on user interaction) -->
     <script>
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-M943GMK8');
+      function loadAnalytics() {
+        if (window.analyticsLoaded) return;
+        window.analyticsLoaded = true;
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'? '&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-M943GMK8');
+        !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '763158836667720');
+        fbq('track', 'PageView');
+      }
+      if (window.requestIdleCallback) {
+        requestIdleCallback(loadAnalytics);
+      } else {
+        setTimeout(loadAnalytics, 0);
+      }
+      ['scroll','mousemove','touchstart','keydown'].forEach(function(evt){
+        window.addEventListener(evt, loadAnalytics, { once: true });
+      });
     </script>
-    <!-- End Google Tag Manager -->
-    <!-- Meta Pixel Code -->
-    <script>
-      !function(f,b,e,v,n,t,s)
-      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-      n.queue=[];t=b.createElement(e);t.async=!0;
-      t.src=v;s=b.getElementsByTagName(e)[0];
-      s.parentNode.insertBefore(t,s)}(window, document,'script',
-      'https://connect.facebook.net/en_US/fbevents.js');
-      fbq('init', '763158836667720');
-      fbq('track', 'PageView');
-    </script>
-    <!-- End Meta Pixel Code -->
+    <!-- End Analytics Scripts -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Libra Crédito | Empréstimo com Garantia de Imóvel</title>
@@ -61,6 +58,8 @@
     
     <!-- Early connection hints for critical resources -->
     <link rel="preconnect" href="https://www.youtube-nocookie.com" crossorigin>
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+    <link rel="preconnect" href="https://connect.facebook.net" crossorigin>
     <link rel="dns-prefetch" href="https://i.ytimg.com">
     
     <!-- Prefetch Important Pages -->


### PR DESCRIPTION
## Summary
- load Google Tag Manager and Facebook Pixel after first paint or user interaction
- add preconnect hints for tag manager and facebook domains

## Testing
- `npm test`
- `npm run lint` *(fails: 296 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68937e829ffc832d9e240836bf0d3722