### PR TITLE
fix: ensure deterministic mobile hooks for ssr

### DIFF
--- a/src/hooks/useDevice.ts
+++ b/src/hooks/useDevice.ts
@@ -15,88 +15,24 @@ interface DeviceInfo {
 }
 
 export const useDevice = (): DeviceInfo => {
-  const [deviceInfo, setDeviceInfo] = useState<DeviceInfo>(() => {
-    if (typeof window === 'undefined') {
-      return {
-        isMobile: false,
-        isTablet: false,
-        isDesktop: true,
-        isPremiumDevice: false,
-        screenWidth: 1920,
-        screenHeight: 1080,
-        deviceType: 'desktop',
-        isIOS: false,
-        isAndroid: false,
-        hasNotch: false,
-        isTouchDevice: false,
-      };
-    }
-
-    const width = window.innerWidth;
-    const height = window.innerHeight;
-    const userAgent = navigator.userAgent;
-
-    // Detectar sistema operacional
-    const isIOS = /iPad|iPhone|iPod/.test(userAgent);
-    const isAndroid = /Android/.test(userAgent);
-
-    // Detectar dispositivo premium
-    const isPremiumDevice = 
-      (isIOS && (width >= 375 || height >= 812)) || // iPhone X e superiores
-      (isAndroid && width >= 360 && window.devicePixelRatio >= 3); // Android premium
-
-    // Detectar notch (iPhone X+)
-    const hasNotch = isIOS && (
-      (width === 375 && height === 812) || // iPhone X/XS/11 Pro
-      (width === 414 && height === 896) || // iPhone XR/XS Max/11/11 Pro Max
-      (width === 390 && height === 844) || // iPhone 12/13/14
-      (width === 393 && height === 852) || // iPhone 14 Pro
-      (width === 430 && height === 932)    // iPhone 14 Pro Max
-    );
-
-    // Detectar touch
-    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-
-    // Determinar tipo de dispositivo
-    let deviceType: DeviceInfo['deviceType'];
-    let isMobile = false;
-    let isTablet = false;
-    let isDesktop = false;
-
-    if (width < 768) {
-      isMobile = true;
-      if (width < 375) {
-        deviceType = 'mobile-sm';
-      } else if (width < 414) {
-        deviceType = 'mobile-md';
-      } else {
-        deviceType = 'mobile-lg';
-      }
-    } else if (width < 1024) {
-      isTablet = true;
-      deviceType = 'tablet';
-    } else {
-      isDesktop = true;
-      deviceType = 'desktop';
-    }
-
-    return {
-      isMobile,
-      isTablet,
-      isDesktop,
-      isPremiumDevice,
-      screenWidth: width,
-      screenHeight: height,
-      deviceType,
-      isIOS,
-      isAndroid,
-      hasNotch,
-      isTouchDevice,
-    };
+  const [deviceInfo, setDeviceInfo] = useState<DeviceInfo>({
+    isMobile: false,
+    isTablet: false,
+    isDesktop: true,
+    isPremiumDevice: false,
+    screenWidth: 0,
+    screenHeight: 0,
+    deviceType: 'desktop',
+    isIOS: false,
+    isAndroid: false,
+    hasNotch: false,
+    isTouchDevice: false,
   });
 
   useEffect(() => {
-    const handleResize = () => {
+    if (typeof window === 'undefined') return;
+
+    const calculate = () => {
       const width = window.innerWidth;
       const height = window.innerHeight;
       const userAgent = navigator.userAgent;
@@ -104,7 +40,7 @@ export const useDevice = (): DeviceInfo => {
       const isIOS = /iPad|iPhone|iPod/.test(userAgent);
       const isAndroid = /Android/.test(userAgent);
 
-      const isPremiumDevice = 
+      const isPremiumDevice =
         (isIOS && (width >= 375 || height >= 812)) ||
         (isAndroid && width >= 360 && window.devicePixelRatio >= 3);
 
@@ -155,8 +91,9 @@ export const useDevice = (): DeviceInfo => {
       });
     };
 
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    calculate();
+    window.addEventListener('resize', calculate);
+    return () => window.removeEventListener('resize', calculate);
   }, []);
 
   return deviceInfo;

--- a/src/hooks/useMobileContext.tsx
+++ b/src/hooks/useMobileContext.tsx
@@ -21,13 +21,8 @@ interface MobileProviderProps {
 }
 
 export const MobileProvider: React.FC<MobileProviderProps> = ({ children }) => {
-  // Valor inicial baseado no breakpoint padrão
-  const getInitialValue = (): boolean => {
-    if (typeof window === 'undefined') return false;
-    return window.innerWidth < MOBILE_BREAKPOINT;
-  };
-
-  const [isMobile, setIsMobile] = useState<boolean>(getInitialValue);
+  // Valor inicial determinístico para evitar mismatch
+  const [isMobile, setIsMobile] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -40,7 +35,7 @@ export const MobileProvider: React.FC<MobileProviderProps> = ({ children }) => {
       setIsMobile(e.matches);
     };
 
-    // Definir valor inicial correto
+    // Definir valor inicial correto após montar
     setIsMobile(mql.matches);
     setIsLoading(false);
     


### PR DESCRIPTION
## Summary
- avoid window access during initial render in useIsMobile
- initialize MobileProvider with deterministic defaults
- compute device info in useEffect to prevent hydration mismatches

## Testing
- `npm test`
- `npx tsx scripts/hydration-test.ts` (no output)


------
https://chatgpt.com/codex/tasks/task_e_6893a5773e78832db33fc6ff27de5ece