### PR TITLE
Load base stylesheet early and style dynamic headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,9 @@
     <!-- Preload local Comfortaa font -->
     <link rel="preload" as="font" href="/fonts/Comfortaa.woff2" type="font/woff2" crossorigin>
 
-    <!-- Preload main stylesheet -->
-    <link rel="preload" href="/assets/css/index.css" as="style" onload="this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="/assets/css/index.css"></noscript>
+    <!-- Main stylesheet -->
+    <link rel="preload" href="/assets/css/index.css" as="style">
+    <link rel="stylesheet" href="/assets/css/index.css">
 
     <link rel="preload" as="image" href="/images/media/video-cgi-libra.webp" fetchpriority="high">
 
@@ -95,6 +95,7 @@
       #root { height: 100%; }
       h1, h2, h3, h4, h5, h6 { font-weight: 700; }
       p { font-weight: 300; }
+      h1 { font-size: 1.5rem; line-height: 2rem; }
       
       /* Header Critical */
       .header-fixed { 

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -85,7 +85,9 @@ const BlogPost: React.FC<BlogPostPageProps> = ({ initialPost }) => {
   const renderContent = (content: string) => {
     if (!content) return '';
     const parsed = marked.parse(content);
-    return DOMPurify.sanitize(parsed);
+    const sanitized = DOMPurify.sanitize(parsed);
+    // Garante tamanho de fonte adequado para headings dinâmicos
+    return sanitized.replace(/<h1(\s|>)/g, '<h1 class="text-2xl"$1');
   };
 
   const origin = typeof window !== 'undefined' ? window.location.origin : 'https://libracredito.com.br';


### PR DESCRIPTION
## Summary
- Ensure main stylesheet loads before dynamic content for consistent base styling
- Inject `text-2xl` class into dynamic markdown headings

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, console statements)*
- `npm run build` *(errors fetching default posts but assets generated)*
- `npx lighthouse http://localhost:4173 --only-categories=accessibility` *(failed: Chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_e_6893a575a22c832da61ee04cb7dfc51f