### PR TITLE
fix: align mobile header width with page layout

### DIFF
--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -49,10 +49,10 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
   ];
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-[9999] bg-white shadow-md" role="banner" style={{ position: 'fixed !important' }}>
+    <header className="fixed top-0 left-0 right-0 z-[9999] bg-white shadow-md" role="banner">
       {/* Barra superior compacta */}
       <div className="bg-libra-navy border-b border-blue-800">
-        <div className="container mx-auto px-4 py-2">
+        <div className="w-full px-4 py-2">
           <div className="flex items-center justify-center">
             <div className="flex items-center text-white text-xs font-semibold">
               <Info className="w-3 h-3 mr-1 text-white" />
@@ -63,7 +63,7 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
       </div>
 
       {/* Header principal */}
-      <div className="container mx-auto px-4">
+      <div className="w-full px-4">
         <div className="flex items-center justify-between h-[52px]">
           <div className="flex items-center">
             <Link to="/" aria-label="Página inicial da Libra Crédito" className="tap-transparent">


### PR DESCRIPTION
## Summary
- remove inline fixed style from mobile header
- replace container wrappers with full-width utilities for better mobile alignment

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: 296 problems, 52 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893a9033dec832d988ec36cf7edd075