### PR TITLE
fix: hide horizontal overflow on root element

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -328,6 +328,7 @@
   html {
     /* Ensures minimum 12px fonts for accessibility */
     font-size: 100%;
+    overflow-x: hidden;
   }
 
   body {

--- a/src/styles/critical-inline.css
+++ b/src/styles/critical-inline.css
@@ -14,6 +14,10 @@ body {
   overflow-x: hidden;
 }
 
+html {
+  overflow-x: hidden;
+}
+
 :root {
   --libra-blue: #003399;
   --libra-navy: #001166;


### PR DESCRIPTION
## Summary
- prevent global horizontal scrolling by hiding overflow on html
- ensure root element is clipped across critical and global styles

## Testing
- `npm test`
- `npm run build` *(fails: TypeError: fetch failed during generate-sitemap)*

------
https://chatgpt.com/codex/tasks/task_e_6893a9036808832da82ef193821b201f