### PR TITLE
fix: avoid logo cropping

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -8,8 +8,9 @@ const LogoBand: React.FC = () => {
         <ImageOptimizer
           src="/images/logos/logo-branco.svg"
           alt="Libra Crédito"
-          className="h-20 w-20"
-          aspectRatio={1}
+          className="h-20 w-auto"
+          imgClassName="object-contain"
+          aspectRatio={0}
           priority={false}
           width={80}
           height={80}

--- a/src/components/__tests__/LogoBand.test.tsx
+++ b/src/components/__tests__/LogoBand.test.tsx
@@ -14,9 +14,10 @@ describe('LogoBand', () => {
     const imgContainer = img.parentElement as HTMLElement;
 
     expect(imgContainer).toHaveClass('h-20');
-    expect(imgContainer).toHaveClass('w-20');
+    expect(imgContainer).toHaveClass('w-auto');
     expect(img).not.toHaveClass('w-full');
     expect(img).not.toHaveClass('h-full');
+    expect(img).toHaveClass('object-contain');
     expect(img.getAttribute('src')).toBe('/images/logos/logo-branco.svg');
     expect(img).toHaveAttribute('width', '80');
     expect(img).toHaveAttribute('height', '80');


### PR DESCRIPTION
## Summary
- prevent logo band logo from being cropped by keeping natural width and object-contain fit
- update LogoBand tests for new image behaviour

## Testing
- `npm test`
- `npm run build` *(fails: fetch failed when generating blog posts)*

------
https://chatgpt.com/codex/tasks/task_e_6893ad8c7b30832db02cecb2ad34bac3