### PR TITLE
refactor: reuse LogoBand component

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -1,22 +1,74 @@
 import React from 'react';
 import ImageOptimizer from '@/components/ImageOptimizer';
 
-const LogoBand: React.FC = () => {
+interface LogoBandProps {
+  /**
+   * Optional click handler to transform the band into a clickable element.
+   */
+  onClick?: () => void;
+  /**
+   * Visual variant controlling paddings and sizes.
+   * - `desktop`: larger logo and tighter padding (default)
+   * - `mobile`: smaller logo with bigger vertical padding
+   */
+  size?: 'desktop' | 'mobile';
+}
+
+const LogoBand: React.FC<LogoBandProps> = ({ onClick, size = 'desktop' }) => {
+  const isClickable = typeof onClick === 'function';
+
+  const config =
+    size === 'mobile'
+      ? {
+          padding: 'py-8',
+          imgSize: 64,
+          imgClass: 'h-12 sm:h-16 flex-shrink-0',
+          textClass:
+            'ml-3 sm:ml-4 text-white text-sm sm:text-base font-semibold leading-tight text-center flex-1 min-w-0',
+        }
+      : {
+          padding: 'py-4',
+          imgSize: 80,
+          imgClass: 'h-20 w-20 flex-shrink-0',
+          textClass: 'ml-4 text-white text-lg font-semibold whitespace-nowrap',
+        };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!onClick) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
   return (
-    <div className="w-full bg-[#003399] flex justify-center py-4">
-      <div className="flex items-center">
+    <div
+      className={`w-full bg-[#003399] flex justify-center ${config.padding} ${
+        isClickable ? 'cursor-pointer hover:bg-[#002277] transition-colors' : ''
+      }`}
+      onClick={onClick}
+      role={isClickable ? 'button' : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      onKeyDown={handleKeyDown}
+      aria-label={
+        isClickable
+          ? 'Clique para conhecer mais sobre a Libra Crédito'
+          : undefined
+      }
+    >
+      <div className="flex items-center px-4 max-w-full">
         <ImageOptimizer
           src="/images/logos/logo-branco.svg"
           alt="Libra Crédito"
-          className="h-20 w-20"
+          className={config.imgClass}
           aspectRatio={1}
           priority={false}
-          width={80}
-          height={80}
-          widths={[80, 160]}
-          sizes="80px"
+          width={config.imgSize}
+          height={config.imgSize}
+          widths={[config.imgSize, config.imgSize * 2]}
+          sizes={`${config.imgSize}px`}
         />
-        <span className="ml-4 text-white text-lg font-semibold whitespace-nowrap">
+        <span className={config.textClass}>
           Crédito justo, equilibrado e consciente!
         </span>
       </div>

--- a/src/components/__tests__/LogoBand.test.tsx
+++ b/src/components/__tests__/LogoBand.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import LogoBand from '../LogoBand';
@@ -22,6 +22,22 @@ describe('LogoBand', () => {
     expect(img).toHaveAttribute('height', '80');
     expect(img.getAttribute('srcset')).toContain('width=80');
     expect(img).toHaveAttribute('sizes', '80px');
+  });
+
+  it('allows mobile sizing and clickable behaviour', () => {
+    const handleClick = vi.fn();
+    const { container } = render(<LogoBand size="mobile" onClick={handleClick} />);
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass('py-8');
+    expect(wrapper).toHaveClass('cursor-pointer');
+
+    wrapper.click();
+    expect(handleClick).toHaveBeenCalled();
+
+    const img = screen.getByAltText('Libra Crédito') as HTMLImageElement;
+    const imgContainer = img.parentElement as HTMLElement;
+    expect(imgContainer).toHaveClass('h-12');
   });
 });
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,7 +7,6 @@ import { useIsMobile } from '@/hooks/useMobileContext';
 import HeroPremium from '@/components/HeroPremium';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 import Header from '@/components/Header';
-import ImageOptimizer from '@/components/ImageOptimizer';
 
 // Lazy loading dos componentes pesados - com threshold otimizado
 const FAQ = lazy(() => import('@/components/FAQ'));
@@ -115,14 +114,14 @@ const Index: React.FC = () => {
       
       {/* Botão Conheça a Libra - Desktop / Faixa azul clicável - Mobile */}
       {!isMobile ? (
-        <section 
+        <section
           className="py-8"
           style={{ backgroundColor: '#003399' }}
           aria-label="Conheça mais sobre a Libra Crédito"
         >
           <div className="container mx-auto px-4">
             <div className="flex justify-center items-center">
-              <Button 
+              <Button
                 onClick={goToQuemSomos}
                 className="min-h-[48px] min-w-[200px] bg-white text-[#003399] hover:bg-gray-50 border-0"
                 size="xl"
@@ -134,35 +133,15 @@ const Index: React.FC = () => {
           </div>
         </section>
       ) : (
-        <section 
-          className="w-full bg-[#003399] flex justify-center py-8 cursor-pointer hover:bg-[#002277] transition-colors"
-          onClick={goToQuemSomos}
-          aria-label="Clique para conhecer mais sobre a Libra Crédito"
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              goToQuemSomos();
-            }
-          }}
-        >
-          <div className="flex items-center px-4 max-w-full">
-            <ImageOptimizer
-              src="/images/logos/logo-branco.svg"
-              alt="Libra Crédito"
-              width={64}
-              height={64}
-              aspectRatio={1}
-              className="h-12 sm:h-16 flex-shrink-0"
-              widths={[64, 128]}
-              sizes="64px"
-            />
-            <span className="ml-3 sm:ml-4 text-white text-sm sm:text-base font-semibold leading-tight text-center flex-1 min-w-0">
-              Crédito justo, equilibrado e consciente!
-            </span>
-          </div>
-        </section>
+        <LazySection
+          load={() =>
+            import('@/components/LogoBand').then(({ default: LogoBand }) => ({
+              default: () => (
+                <LogoBand onClick={goToQuemSomos} size="mobile" />
+              ),
+            }))
+          }
+        />
       )}
       
       <WaveSeparator variant="hero" height="md" inverted />


### PR DESCRIPTION
## Summary
- make `LogoBand` configurable with optional click handler and desktop/mobile variants
- reuse `LogoBand` in `Index` for mobile CTA, removing duplicated markup
- extend tests for `LogoBand` mobile sizing and click support

## Testing
- `npm test`
- `npm run lint` *(fails: 52 errors, 244 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893ad902040832db84dff81714004a9