### PR TITLE
feat: allow configuring image object fit

### DIFF
--- a/src/components/ImageOptimizer.tsx
+++ b/src/components/ImageOptimizer.tsx
@@ -19,7 +19,8 @@
  * @param {boolean} [props.priority=false] - Se true, carrega a imagem com prioridade alta
  * @param {number} [props.width] - Largura da imagem em pixels
  * @param {number} [props.height] - Altura da imagem em pixels
- * 
+ * @param {string} [props.objectFit="cover"] - Valor do object-fit (ex: cover, contain)
+ *
  * @example
  * ```tsx
  * // Imagem normal com lazy loading
@@ -58,6 +59,14 @@ interface ImageOptimizerProps {
   className?: string;
   /** Classes aplicadas diretamente à imagem */
   imgClassName?: string;
+  /** Define o comportamento de object-fit da imagem */
+  objectFit?:
+    | 'contain'
+    | 'cover'
+    | 'fill'
+    | 'none'
+    | 'scale-down'
+    | (string & {});
   aspectRatio?: number;
   priority?: boolean;
   width?: number;
@@ -71,6 +80,7 @@ const ImageOptimizer: React.FC<ImageOptimizerProps> = ({
   alt,
   className = "",
   imgClassName = "",
+  objectFit = 'cover',
   aspectRatio = 16/9,
   priority = false,
   width,
@@ -89,7 +99,7 @@ const ImageOptimizer: React.FC<ImageOptimizerProps> = ({
       alt={alt}
       loading={priority ? "eager" : "lazy"}
       className={cn(
-        "object-cover",
+        `object-${objectFit}`,
         !hasWidthClass && "w-full",
         !hasHeightClass && "h-full",
         imgClassName

--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -9,6 +9,7 @@ const LogoBand: React.FC = () => {
           src="/images/logos/logo-branco.svg"
           alt="Libra Crédito"
           className="h-20 w-20"
+          objectFit="contain"
           aspectRatio={1}
           priority={false}
           width={80}

--- a/src/components/__tests__/ImageOptimizer.test.tsx
+++ b/src/components/__tests__/ImageOptimizer.test.tsx
@@ -4,11 +4,12 @@ import React from 'react';
 import ImageOptimizer from '../ImageOptimizer';
 
 describe('ImageOptimizer', () => {
-  it('applies w-full and h-full by default', () => {
+  it('applies w-full, h-full and object-cover by default', () => {
     render(<ImageOptimizer src="/test.jpg" alt="default" />);
     const img = screen.getByAltText('default');
     expect(img).toHaveClass('w-full');
     expect(img).toHaveClass('h-full');
+    expect(img).toHaveClass('object-cover');
   });
 
   it('avoids w-full and h-full when size classes provided', () => {
@@ -19,5 +20,11 @@ describe('ImageOptimizer', () => {
     expect(container).toHaveClass('h-10');
     expect(img).not.toHaveClass('w-full');
     expect(img).not.toHaveClass('h-full');
+  });
+
+  it('supports custom object-fit', () => {
+    render(<ImageOptimizer src="/test.jpg" alt="contain" objectFit="contain" />);
+    const img = screen.getByAltText('contain');
+    expect(img).toHaveClass('object-contain');
   });
 });

--- a/src/components/__tests__/LogoBand.test.tsx
+++ b/src/components/__tests__/LogoBand.test.tsx
@@ -17,6 +17,7 @@ describe('LogoBand', () => {
     expect(imgContainer).toHaveClass('w-20');
     expect(img).not.toHaveClass('w-full');
     expect(img).not.toHaveClass('h-full');
+    expect(img).toHaveClass('object-contain');
     expect(img.getAttribute('src')).toBe('/images/logos/logo-branco.svg');
     expect(img).toHaveAttribute('width', '80');
     expect(img).toHaveAttribute('height', '80');

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -155,6 +155,7 @@ const Index: React.FC = () => {
               height={64}
               aspectRatio={1}
               className="h-12 sm:h-16 flex-shrink-0"
+              objectFit="contain"
               widths={[64, 128]}
               sizes="64px"
             />


### PR DESCRIPTION
## Summary
- add `objectFit` prop to `ImageOptimizer` and apply `object-${objectFit}` class
- use `objectFit="contain"` for logo images in `LogoBand` and home page
- expand tests for configurable object-fit and logo rendering

## Testing
- `npm test`
- `npm run lint` *(fails: 52 errors, 244 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893ad98b454832d97c4b86a91d35cd6