### PR TITLE
Ajusta tamanho do logo na seção mobile da home

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -153,7 +153,8 @@ const Index: React.FC = () => {
               width={64}
               height={64}
               aspectRatio={1}
-              className="h-12 sm:h-16 flex-shrink-0"
+              className="w-12 h-12 sm:w-16 sm:h-16 flex-shrink-0"
+              imgClassName="w-full h-full"
               objectFit="contain"
               widths={[64, 128]}
               sizes="64px"


### PR DESCRIPTION
## Summary
- corrige o tamanho do logo na faixa "Conheça a Libra" da versão mobile, mantendo-o proporcional ao texto

## Testing
- `npm test` *(falhou: 1 arquivo, 2 testes)*
- `npm run lint` *(falhou: 52 erros, 244 avisos)*

------
https://chatgpt.com/codex/tasks/task_e_6893b11e8758832da0dbc007019d1c0a