### PR TITLE
fix: stabilize trust bar counters

### DIFF
--- a/src/components/TrustBarMinimal.tsx
+++ b/src/components/TrustBarMinimal.tsx
@@ -118,8 +118,10 @@ const TrustBarMinimal: React.FC = () => {
                 {/* Valor e label em linha */}
                 <div className="text-center md:text-left">
                   <div className="text-[0.9rem] md:text-[1.2rem] font-bold text-white leading-none">
-                    {stat.value}
-                    <span className="text-white font-bold text-[0.75rem] md:text-[1rem]">
+                    <span className="tabular-nums inline-block min-w-[4ch]">
+                      {stat.value}
+                    </span>
+                    <span className="text-white font-bold text-[0.75rem] md:text-[1rem] tabular-nums inline-block min-w-[3ch]">
                       {stat.suffix}
                     </span>
                   </div>


### PR DESCRIPTION
## Summary
- avoid layout shift in trust bar counters by using tabular numerals and min-widths

## Testing
- `npm test` *(fails: LogoBand.test.tsx)*
- `npm run lint` *(fails: 52 errors, 244 warnings)*
- `npm run build` *(fails: multiple fetch errors, but build proceeds)*

------
https://chatgpt.com/codex/tasks/task_e_6893b80d0adc832d97f572dff5faf686