### PR TITLE
feat: lazy load simulation page

### DIFF
--- a/src/pages/Simulacao.tsx
+++ b/src/pages/Simulacao.tsx
@@ -1,18 +1,20 @@
-
-import React, { useEffect } from 'react';
+import React, { useEffect, lazy, Suspense } from 'react';
 import MobileLayout from '@/components/MobileLayout';
-import SimulationForm from '@/components/SimulationForm';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 import { useIsMobile } from '@/hooks/use-mobile';
 import scrollToTarget from '@/utils/scrollToTarget';
+import LazySection from '@/components/LazySection';
+
+const SimulationForm = lazy(() => import('@/components/SimulationForm'));
+const Footer = lazy(() => import('@/components/Footer'));
 
 const Simulacao = () => {
   const isMobile = useIsMobile();
 
   useEffect(() => {
     // Meta Title otimizado para simulação - 59 caracteres
-    document.title = "Simulação Home Equity | Libra Crédito Garantia Imóvel";
-    
+    document.title = 'Simulação Home Equity | Libra Crédito Garantia Imóvel';
+
     // Meta Description otimizada - 154 caracteres
     const metaDescription = document.querySelector('meta[name="description"]');
     if (metaDescription) {
@@ -28,7 +30,6 @@ const Simulacao = () => {
         const cardHeader = card?.querySelector('[data-sim-card-header="true"]') as HTMLElement | null;
         if (cardHeader) {
           scrollToTarget(cardHeader, -headerHeight);
-
         }
       });
       return () => cancelAnimationFrame(frame);
@@ -36,11 +37,20 @@ const Simulacao = () => {
   }, [isMobile]);
 
   return (
-    <MobileLayout>
+    <MobileLayout showFooter={false}>
       <WaveSeparator variant="hero" height="md" inverted />
-      <div className="bg-white lg:flex lg:justify-center">
-        <SimulationForm />
-      </div>
+      <LazySection load={() => import('@/components/SimulationForm')}>
+        <div className="bg-white lg:flex lg:justify-center">
+          <Suspense fallback={null}>
+            <SimulationForm />
+          </Suspense>
+        </div>
+      </LazySection>
+      <LazySection load={() => import('@/components/Footer')}>
+        <Suspense fallback={null}>
+          <Footer />
+        </Suspense>
+      </LazySection>
     </MobileLayout>
   );
 };

--- a/src/pages/__tests__/Simulacao.test.tsx
+++ b/src/pages/__tests__/Simulacao.test.tsx
@@ -14,6 +14,12 @@ vi.mock('@/components/SimulationForm', () => ({
     <div data-testid="simulation-form" className="container mx-auto max-w-6xl" />
   ),
 }));
+vi.mock('@/components/Footer', () => ({
+  default: () => <div />,
+}));
+vi.mock('@/components/LazySection', () => ({
+  default: ({ children }: { children: React.ReactNode; load: () => Promise<unknown> }) => <>{children}</>,
+}));
 vi.mock('@/hooks/use-mobile', () => ({
   useIsMobile: () => false,
 }));
@@ -23,26 +29,26 @@ vi.mock('@/utils/scrollToTarget', () => ({
 }));
 
 describe('Simulacao layout', () => {
-  it('centers SimulationForm on large screens using flex', () => {
+  it('centers SimulationForm on large screens using flex', async () => {
     render(<Simulacao />);
-    const form = screen.getByTestId('simulation-form');
+    const form = await screen.findByTestId('simulation-form');
     const wrapper = form.parentElement as HTMLElement;
     expect(wrapper).toHaveClass('bg-white');
     expect(wrapper).toHaveClass('lg:flex');
     expect(wrapper).toHaveClass('lg:justify-center');
   });
 
-  it('preserves mobile layout without flex utilities', () => {
+  it('preserves mobile layout without flex utilities', async () => {
     render(<Simulacao />);
-    const form = screen.getByTestId('simulation-form');
+    const form = await screen.findByTestId('simulation-form');
     const wrapper = form.parentElement as HTMLElement;
     expect(wrapper.classList.contains('flex')).toBe(false);
     expect(wrapper.classList.contains('justify-center')).toBe(false);
   });
 
-  it('SimulationForm remains centered with mx-auto and max width', () => {
+  it('SimulationForm remains centered with mx-auto and max width', async () => {
     render(<Simulacao />);
-    const form = screen.getByTestId('simulation-form');
+    const form = await screen.findByTestId('simulation-form');
     expect(form).toHaveClass('container');
     expect(form).toHaveClass('mx-auto');
     expect(form.className).toContain('max-w-6xl');


### PR DESCRIPTION
## Summary
- optimize SimulationForm and Footer with lazy loading and intersection-triggered rendering
- build shared LazySection component for on-demand imports
- adjust Simulacao tests for async component loading

## Testing
- `npm test` *(fails: LogoBand.test.tsx failures)*
- `npm run lint` *(fails: 52 errors, 244 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68944f1e4f38832dac550df047ace6df