### PR TITLE
refactor: sanitize admin markdown preview

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -50,6 +50,15 @@ import Trash2 from 'lucide-react/dist/esm/icons/trash-2';
 import Save from 'lucide-react/dist/esm/icons/save';
 import LogOut from 'lucide-react/dist/esm/icons/log-out';
 import { formatBRL } from '@/utils/formatters';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+export const renderMarkdownPreview = (content: string) => {
+  if (!content) return '';
+  const parsed = marked.parse(content);
+  const sanitized = DOMPurify.sanitize(parsed);
+  return sanitized.replace(/<h1(\s|>)/g, '<h1 class="text-2xl"$1');
+};
 
 const AdminDashboard: React.FC = () => {
   // Estados de autenticação
@@ -203,39 +212,7 @@ const AdminDashboard: React.FC = () => {
     return text.trim().split(' ').filter(word => word.length > 0).length;
   };
 
-  // Função para renderizar preview do markdown
-  const renderMarkdownPreview = (content: string) => {
-    if (!content) return '';
-    
-    // Conversão aprimorada de Markdown para HTML (similar à do BlogPost)
-    const html = content
-      // Headers com classes para estilização
-      .replace(/^### (.*$)/gim, '<h3 class="text-xl font-semibold text-gray-900 mt-8 mb-4 border-l-4 border-blue-500 pl-4">$1</h3>')
-      .replace(/^## (.*$)/gim, '<h2 class="text-2xl font-bold text-gray-900 mt-10 mb-6 border-l-4 border-blue-500 pl-4">$1</h2>')
-      .replace(/^# (.*$)/gim, '<h1 class="text-3xl font-bold text-gray-900 mt-12 mb-8 border-l-4 border-blue-500 pl-4">$1</h1>')
-      // Bold e Italic
-      .replace(/\*\*(.*)\*\*/gim, '<strong class="font-semibold text-gray-900">$1</strong>')
-      .replace(/\*(.*)\*/gim, '<em class="italic text-gray-700">$1</em>')
-      // Links
-      .replace(/\[([^\]]*)\]\(([^)]*)\)/gim, '<a href="$2" class="text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer">$1</a>')
-      // Quotes
-      .replace(/^> (.*$)/gim, '<blockquote class="border-l-4 border-blue-500 bg-gray-50 p-4 my-6 italic text-gray-700">$1</blockquote>')
-      // Code blocks (inline)
-      .replace(/`([^`]+)`/gim, '<code class="bg-gray-100 text-gray-900 px-2 py-1 rounded font-mono text-sm">$1</code>')
-      // Line breaks
-      .replace(/\n\n/gim, '</p><p class="mb-6 text-gray-700 leading-relaxed">')
-      // Lists
-      .replace(/^\* (.*$)/gim, '<li class="mb-2 text-gray-700">$1</li>')
-      .replace(/^- (.*$)/gim, '<li class="mb-2 text-gray-700">$1</li>')
-      .replace(/(<li class="mb-2 text-gray-700">.*<\/li>)/s, '<ul class="list-disc list-inside space-y-2 my-6 ml-4">$1</ul>')
-      // Numbered lists
-      .replace(/^\d+\. (.*$)/gim, '<li class="mb-2 text-gray-700">$1</li>')
-      // Wrap in paragraphs
-      .replace(/^(?!<[hul])/gim, '<p class="mb-6 text-gray-700 leading-relaxed">')
-      .replace(/(?!<\/[hul]>)$/gim, '</p>');
-    
-    return html;
-  };
+
 
   // Função para inserir texto no editor
   const insertText = (before: string, after: string = '', placeholder: string = '') => {

--- a/src/pages/__tests__/MarkdownPreview.test.ts
+++ b/src/pages/__tests__/MarkdownPreview.test.ts
@@ -1,0 +1,20 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from 'vitest';
+import { renderMarkdownPreview } from '../AdminDashboard';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+describe('renderMarkdownPreview', () => {
+  it('matches blog rendering for titles, lists, links and images', () => {
+    const markdown = '# Título\n\nLista:\n\n- Item 1\n- Item 2\n\n[Link](https://example.com)\n\n![Alt](https://example.com/img.png)';
+    const previewHtml = renderMarkdownPreview(markdown);
+    const blogHtml = DOMPurify.sanitize(marked.parse(markdown)).replace(/<h1(\s|>)/g, '<h1 class="text-2xl"$1');
+
+    expect(previewHtml).toBe(blogHtml);
+    expect(previewHtml).toContain('<h1 class="text-2xl">Título</h1>');
+    expect(previewHtml).toContain('<ul>');
+    expect(previewHtml).toContain('<a href="https://example.com"');
+    expect(previewHtml).toContain('<img src="https://example.com/img.png"');
+  });
+});


### PR DESCRIPTION
## Summary
- use marked + DOMPurify to render markdown preview in admin dashboard
- add test ensuring admin preview matches blog rendering for various markdown features

## Testing
- `npm test` *(fails: LogoBand.test.tsx > LogoBand > renders container with py-4 padding and optimized image, LogoBand.test.tsx > LogoBand > allows mobile sizing and clickable behaviour)*
- `npx vitest run src/pages/__tests__/MarkdownPreview.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899ec37450c832dafd41ab40622e799