### PR TITLE
feat: style admin markdown preview

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -55,9 +55,35 @@ import DOMPurify from 'dompurify';
 
 export const renderMarkdownPreview = (content: string) => {
   if (!content) return '';
+
+  // Primeiro converte para HTML e sanitiza o conteúdo
   const parsed = marked.parse(content);
   const sanitized = DOMPurify.sanitize(parsed);
-  return sanitized.replace(/<h1(\s|>)/g, '<h1 class="text-2xl"$1');
+
+  // Em seguida, aplica classes Tailwind nos elementos permitidos
+  const div = document.createElement('div');
+  div.innerHTML = sanitized;
+
+  const addClass = (selector: string, classes: string) => {
+    div.querySelectorAll(selector).forEach(el => {
+      el.classList.add(...classes.split(' '));
+    });
+  };
+
+  addClass('h1', 'text-3xl font-bold text-gray-900 mt-12 mb-8 border-l-4 border-blue-500 pl-4');
+  addClass('h2', 'text-2xl font-bold text-gray-900 mt-10 mb-6 border-l-4 border-blue-500 pl-4');
+  addClass('h3', 'text-xl font-semibold text-gray-900 mt-8 mb-4 border-l-4 border-blue-500 pl-4');
+  addClass('p', 'mb-6 text-gray-700 leading-relaxed');
+  addClass('a', 'text-blue-600 hover:text-blue-800 underline');
+  addClass('strong', 'font-semibold text-gray-900');
+  addClass('em', 'italic text-gray-700');
+  addClass('blockquote', 'border-l-4 border-blue-500 bg-gray-50 p-4 my-6 italic text-gray-700');
+  addClass('code', 'bg-gray-100 text-gray-900 px-2 py-1 rounded font-mono text-sm');
+  addClass('ul', 'list-disc list-inside space-y-2 my-6 ml-4');
+  addClass('ol', 'list-decimal list-inside space-y-2 my-6 ml-4');
+  addClass('li', 'mb-2 text-gray-700');
+
+  return div.innerHTML;
 };
 
 const AdminDashboard: React.FC = () => {

--- a/src/pages/__tests__/MarkdownPreview.test.ts
+++ b/src/pages/__tests__/MarkdownPreview.test.ts
@@ -2,19 +2,24 @@
 
 import { describe, expect, it } from 'vitest';
 import { renderMarkdownPreview } from '../AdminDashboard';
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
 
 describe('renderMarkdownPreview', () => {
-  it('matches blog rendering for titles, lists, links and images', () => {
-    const markdown = '# Título\n\nLista:\n\n- Item 1\n- Item 2\n\n[Link](https://example.com)\n\n![Alt](https://example.com/img.png)';
-    const previewHtml = renderMarkdownPreview(markdown);
-    const blogHtml = DOMPurify.sanitize(marked.parse(markdown)).replace(/<h1(\s|>)/g, '<h1 class="text-2xl"$1');
+  it('applies styling classes to markdown elements', () => {
+    const markdown = '# Título\n\n## Subtítulo\n\n### Seção\n\nParágrafo com [link](https://example.com) **negrito** *itálico* `código`.\n\n> Citação\n\n- Item 1\n- Item 2\n\n1. Primeiro\n2. Segundo';
+    const html = renderMarkdownPreview(markdown);
+    const doc = new DOMParser().parseFromString(html, 'text/html');
 
-    expect(previewHtml).toBe(blogHtml);
-    expect(previewHtml).toContain('<h1 class="text-2xl">Título</h1>');
-    expect(previewHtml).toContain('<ul>');
-    expect(previewHtml).toContain('<a href="https://example.com"');
-    expect(previewHtml).toContain('<img src="https://example.com/img.png"');
+    expect(doc.querySelector('h1')?.className).toBe('text-3xl font-bold text-gray-900 mt-12 mb-8 border-l-4 border-blue-500 pl-4');
+    expect(doc.querySelector('h2')?.className).toBe('text-2xl font-bold text-gray-900 mt-10 mb-6 border-l-4 border-blue-500 pl-4');
+    expect(doc.querySelector('h3')?.className).toBe('text-xl font-semibold text-gray-900 mt-8 mb-4 border-l-4 border-blue-500 pl-4');
+    expect(doc.querySelector('p')?.className).toBe('mb-6 text-gray-700 leading-relaxed');
+    expect(doc.querySelector('a')?.className).toBe('text-blue-600 hover:text-blue-800 underline');
+    expect(doc.querySelector('strong')?.className).toBe('font-semibold text-gray-900');
+    expect(doc.querySelector('em')?.className).toBe('italic text-gray-700');
+    expect(doc.querySelector('blockquote')?.className).toBe('border-l-4 border-blue-500 bg-gray-50 p-4 my-6 italic text-gray-700');
+    expect(doc.querySelector('code')?.className).toBe('bg-gray-100 text-gray-900 px-2 py-1 rounded font-mono text-sm');
+    expect(doc.querySelector('ul')?.className).toBe('list-disc list-inside space-y-2 my-6 ml-4');
+    expect(doc.querySelector('ol')?.className).toBe('list-decimal list-inside space-y-2 my-6 ml-4');
+    expect(doc.querySelector('li')?.className).toBe('mb-2 text-gray-700');
   });
 });


### PR DESCRIPTION
## Summary
- inject legacy Tailwind classes into sanitized markdown preview so admin retains prior styling
- test that markdown preview applies expected classes across headings, text and lists

## Testing
- `npm test` *(fails: LogoBand.test.tsx > renders container with py-4 padding and optimized image; LogoBand.test.tsx > allows mobile sizing and clickable behaviour)*
- `npx vitest run src/pages/__tests__/MarkdownPreview.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6899f119f01c832d8f475b801c905a18