### PR TITLE
track referrer through contact submission

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -165,7 +165,8 @@ const ContactForm: React.FC<ContactFormProps> = ({
         utm_campaign: journey?.utm_campaign ?? null,
         utm_term: journey?.utm_term ?? null,
         utm_content: journey?.utm_content ?? null,
-        landing_page: journey?.landing_page ?? null
+        landing_page: journey?.landing_page ?? null,
+        referrer: journey?.referrer ?? null
 
       });
       

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -49,7 +49,8 @@ describe('ContactForm', () => {
       utm_campaign: 'camp',
       utm_term: 'term',
       utm_content: 'content',
-      landing_page: 'https://example.com'
+      landing_page: 'https://example.com',
+      referrer: 'https://referrer.com'
     });
 
     render(<ContactForm simulationResult={simulationResult} />);
@@ -70,7 +71,8 @@ describe('ContactForm', () => {
           utm_campaign: 'camp',
           utm_term: 'term',
           utm_content: 'content',
-          landing_page: 'https://example.com'
+          landing_page: 'https://example.com',
+          referrer: 'https://referrer.com'
         })
       );
     });
@@ -97,7 +99,8 @@ describe('ContactForm', () => {
           utm_campaign: null,
           utm_term: null,
           utm_content: null,
-          landing_page: null
+          landing_page: null,
+          referrer: null
         })
       );
     });

--- a/src/services/__tests__/ploomesService.test.ts
+++ b/src/services/__tests__/ploomesService.test.ts
@@ -32,7 +32,8 @@ describe('PloomesService', () => {
       utm_campaign: 'camp',
       utm_term: 'term',
       utm_content: 'content',
-      landing_page: 'https://example.com'
+      landing_page: 'https://example.com',
+      referrer: 'https://referrer.com'
     });
 
     expect(fetchMock).toHaveBeenCalled();
@@ -44,7 +45,8 @@ describe('PloomesService', () => {
       utm_campaign: 'camp',
       utm_term: 'term',
       utm_content: 'content',
-      landing_page: 'https://example.com'
+      landing_page: 'https://example.com',
+      referrer: 'https://referrer.com'
     });
   });
 });

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -60,6 +60,7 @@ export interface ContactFormInput {
   utm_term?: string | null;
   utm_content?: string | null;
   landing_page?: string | null;
+  referrer?: string | null;
 }
 
 // Classe principal do serviço local
@@ -252,6 +253,7 @@ export class LocalSimulationService {
     tipoAmortizacao?: string;
     valorParcelaCalculada?: number;
     aceitaPolitica?: boolean;
+    referrer?: string | null;
   }): Promise<{success: boolean, message: string}> {
     try {
       console.log('📧 Processando contato com integração:', input);
@@ -331,7 +333,8 @@ export class LocalSimulationService {
         utm_campaign: input.utm_campaign || null,
         utm_term: input.utm_term || null,
         utm_content: input.utm_content || null,
-        landing_page: input.landing_page || null
+        landing_page: input.landing_page || null,
+        referrer: input.referrer || null
       };
 
       // Validar campos obrigatórios

--- a/src/services/ploomesService.ts
+++ b/src/services/ploomesService.ts
@@ -37,6 +37,7 @@ export interface PloomesPayload {
   utm_term?: string | null;
   utm_content?: string | null;
   landing_page?: string | null;
+  referrer?: string | null;
 }
 
 // Interface para resposta do Ploomes
@@ -85,6 +86,7 @@ export class PloomesService {
     utm_term?: string | null;
     utm_content?: string | null;
     landing_page?: string | null;
+    referrer?: string | null;
   }): Promise<PloomesResponse> {
     try {
       console.log('🚀 Iniciando cadastro no Ploomes:', data);
@@ -107,7 +109,8 @@ export class PloomesService {
         utm_campaign: data.utm_campaign || null,
         utm_term: data.utm_term || null,
         utm_content: data.utm_content || null,
-        landing_page: data.landing_page || null
+        landing_page: data.landing_page || null,
+        referrer: data.referrer || null
       };
       
       console.log('📤 Payload formatado para Ploomes:', payload);


### PR DESCRIPTION
## Summary
- forward referrer from user journey in ContactForm to contact processing
- extend localSimulationService and ploomesService to accept and send referrer
- cover referrer field in contact and ploomes service tests

## Testing
- `npm test` *(fails: LogoBand tests: renders container with py-4 padding and optimized image, allows mobile sizing and clickable behaviour)*
- `npm test src/components/__tests__/ContactForm.test.tsx src/services/__tests__/ploomesService.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899f72c2fbc832d8cb6450c4769407d