### PR TITLE
refactor: centralize markdown rendering

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -50,41 +50,7 @@ import Trash2 from 'lucide-react/dist/esm/icons/trash-2';
 import Save from 'lucide-react/dist/esm/icons/save';
 import LogOut from 'lucide-react/dist/esm/icons/log-out';
 import { formatBRL } from '@/utils/formatters';
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
-
-export const renderMarkdownPreview = (content: string) => {
-  if (!content) return '';
-
-  // Primeiro converte para HTML e sanitiza o conteúdo
-  const parsed = marked.parse(content);
-  const sanitized = DOMPurify.sanitize(parsed);
-
-  // Em seguida, aplica classes Tailwind nos elementos permitidos
-  const div = document.createElement('div');
-  div.innerHTML = sanitized;
-
-  const addClass = (selector: string, classes: string) => {
-    div.querySelectorAll(selector).forEach(el => {
-      el.classList.add(...classes.split(' '));
-    });
-  };
-
-  addClass('h1', 'text-3xl font-bold text-gray-900 mt-12 mb-8 border-l-4 border-blue-500 pl-4');
-  addClass('h2', 'text-2xl font-bold text-gray-900 mt-10 mb-6 border-l-4 border-blue-500 pl-4');
-  addClass('h3', 'text-xl font-semibold text-gray-900 mt-8 mb-4 border-l-4 border-blue-500 pl-4');
-  addClass('p', 'mb-6 text-gray-700 leading-relaxed');
-  addClass('a', 'text-blue-600 hover:text-blue-800 underline');
-  addClass('strong', 'font-semibold text-gray-900');
-  addClass('em', 'italic text-gray-700');
-  addClass('blockquote', 'border-l-4 border-blue-500 bg-gray-50 p-4 my-6 italic text-gray-700');
-  addClass('code', 'bg-gray-100 text-gray-900 px-2 py-1 rounded font-mono text-sm');
-  addClass('ul', 'list-disc list-inside space-y-2 my-6 ml-4');
-  addClass('ol', 'list-decimal list-inside space-y-2 my-6 ml-4');
-  addClass('li', 'mb-2 text-gray-700');
-
-  return div.innerHTML;
-};
+import { renderMarkdown } from '@/utils/markdown';
 
 const AdminDashboard: React.FC = () => {
   // Estados de autenticação
@@ -1244,7 +1210,7 @@ Escreva seu conteúdo aqui...
                           <div 
                             className="p-4 prose prose-sm max-w-none"
                             dangerouslySetInnerHTML={{ 
-                              __html: renderMarkdownPreview(postForm.content || '') || '<p class="text-gray-400 italic">Nada para mostrar ainda. Digite algo no editor.</p>'
+                              __html: renderMarkdown(postForm.content || '') || '<p class="text-gray-400 italic">Nada para mostrar ainda. Digite algo no editor.</p>'
                             }}
                           />
                         </div>

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -9,8 +9,7 @@ import MobileLayout from '@/components/MobileLayout';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 import { BlogService, type BlogPost as BlogPostType } from '@/services/blogService';
 import Seo from '@/components/Seo';
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
+import { renderMarkdown } from '@/utils/markdown';
 
 type BlogPost = BlogPostType;
 
@@ -81,14 +80,8 @@ const BlogPost: React.FC<BlogPostPageProps> = ({ initialPost }) => {
     );
   }
 
-  // Função para renderizar Markdown como HTML usando biblioteca com sanitização
-  const renderContent = (content: string) => {
-    if (!content) return '';
-    const parsed = marked.parse(content);
-    const sanitized = DOMPurify.sanitize(parsed);
-    // Garante tamanho de fonte adequado para headings dinâmicos
-    return sanitized.replace(/<h1(\s|>)/g, '<h1 class="text-2xl"$1');
-  };
+  // Renderiza conteúdo Markdown com sanitização e estilos
+  const renderContent = (content: string) => renderMarkdown(content);
 
   const origin = typeof window !== 'undefined' ? window.location.origin : 'https://libracredito.com.br';
   const postUrl = post ? `${origin}/blog/${post.slug}` : '';

--- a/src/pages/__tests__/BlogPostMarkdown.test.tsx
+++ b/src/pages/__tests__/BlogPostMarkdown.test.tsx
@@ -1,13 +1,51 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it } from 'vitest';
-import { renderMarkdown } from '@/utils/markdown';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import BlogPost from '../BlogPost';
+import type { BlogPost as BlogPostType } from '@/services/blogService';
 
-describe('renderMarkdown', () => {
-  it('applies styling classes to markdown elements', () => {
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ slug: undefined }),
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => <a href={to}>{children}</a>,
+}));
+
+vi.mock('@/components/MobileLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/WaveSeparator', () => ({
+  default: () => <div />, 
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+vi.mock('@/components/Seo', () => ({
+  default: () => null,
+}));
+
+describe('BlogPost Markdown rendering', () => {
+  it('applies styling classes to rendered markdown', () => {
     const markdown = '# Título\n\n## Subtítulo\n\n### Seção\n\nParágrafo com [link](https://example.com) **negrito** *itálico* `código`.\n\n> Citação\n\n- Item 1\n- Item 2\n\n1. Primeiro\n2. Segundo';
-    const html = renderMarkdown(markdown);
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+
+    const post: BlogPostType = {
+      title: 'Teste',
+      description: 'Desc',
+      category: 'home-equity',
+      imageUrl: 'https://example.com/img.png',
+      slug: 'teste',
+      content: markdown,
+      readTime: 1,
+      published: true,
+      featuredPost: false,
+    };
+
+    const { container } = render(<BlogPost initialPost={post} />);
+    const contentDiv = container.querySelector('.mt-8 > div') as HTMLElement;
+    const doc = new DOMParser().parseFromString(contentDiv.innerHTML, 'text/html');
 
     expect(doc.querySelector('h1')?.className).toBe('text-3xl font-bold text-gray-900 mt-12 mb-8 border-l-4 border-blue-500 pl-4');
     expect(doc.querySelector('h2')?.className).toBe('text-2xl font-bold text-gray-900 mt-10 mb-6 border-l-4 border-blue-500 pl-4');

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,37 @@
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+export const renderMarkdown = (content: string): string => {
+  if (!content) return '';
+
+  // Parse markdown to HTML and sanitize
+  const parsed = marked.parse(content);
+  const sanitized = DOMPurify.sanitize(parsed);
+
+  // Inject Tailwind classes into allowed elements
+  const div = document.createElement('div');
+  div.innerHTML = sanitized;
+
+  const addClass = (selector: string, classes: string) => {
+    div.querySelectorAll(selector).forEach(el => {
+      el.classList.add(...classes.split(' '));
+    });
+  };
+
+  addClass('h1', 'text-3xl font-bold text-gray-900 mt-12 mb-8 border-l-4 border-blue-500 pl-4');
+  addClass('h2', 'text-2xl font-bold text-gray-900 mt-10 mb-6 border-l-4 border-blue-500 pl-4');
+  addClass('h3', 'text-xl font-semibold text-gray-900 mt-8 mb-4 border-l-4 border-blue-500 pl-4');
+  addClass('p', 'mb-6 text-gray-700 leading-relaxed');
+  addClass('a', 'text-blue-600 hover:text-blue-800 underline');
+  addClass('strong', 'font-semibold text-gray-900');
+  addClass('em', 'italic text-gray-700');
+  addClass('blockquote', 'border-l-4 border-blue-500 bg-gray-50 p-4 my-6 italic text-gray-700');
+  addClass('code', 'bg-gray-100 text-gray-900 px-2 py-1 rounded font-mono text-sm');
+  addClass('ul', 'list-disc list-inside space-y-2 my-6 ml-4');
+  addClass('ol', 'list-decimal list-inside space-y-2 my-6 ml-4');
+  addClass('li', 'mb-2 text-gray-700');
+
+  return div.innerHTML;
+};
+
+export default renderMarkdown;


### PR DESCRIPTION
## Summary
- centralize markdown parsing and sanitization with Tailwind classes
- reuse markdown renderer in admin preview and blog posts
- verify markdown styling through unit tests

## Testing
- `npm test` *(fails: LogoBand tests)*
- `npx vitest run src/pages/__tests__/MarkdownPreview.test.ts`
- `npx vitest run src/pages/__tests__/BlogPostMarkdown.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6899f930f8a0832dbf35d9468c9787c3