### PR TITLE
feat: add guided simulation page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const Blog = lazy(() => import("./pages/Blog"));
 const BlogPost = lazy(() => import("./pages/BlogPost"));
 const Parceiros = lazy(() => import("./pages/Parceiros"));
 const Simulacao = lazy(() => import("./pages/Simulacao"));
+const SimulacaoGuiada = lazy(() => import("./pages/SimulacaoGuiada"));
 const PoliticaPrivacidade = lazy(() => import("./pages/PoliticaPrivacidade"));
 const PoliticaCookies = lazy(() => import("./pages/PoliticaCookies"));
 const AdminDashboard = lazy(() => import("./pages/AdminDashboard"));
@@ -102,6 +103,11 @@ const App = () => {
               <Route path="/simulacao" element={
                 <Suspense fallback={<Loading />}>
                   <TooltipProvider><Simulacao /></TooltipProvider>
+                </Suspense>
+              } />
+              <Route path="/simulacao-guiada" element={
+                <Suspense fallback={<Loading />}>
+                  <TooltipProvider><SimulacaoGuiada /></TooltipProvider>
                 </Suspense>
               } />
               <Route path="/simulacao/sapi" element={<SimulacaoSapi />} />

--- a/src/AppServer.tsx
+++ b/src/AppServer.tsx
@@ -20,6 +20,7 @@ import Blog from './pages/Blog';
 import BlogPost from './pages/BlogPost';
 const Parceiros = lazy(() => import("./pages/Parceiros"));
 const Simulacao = lazy(() => import("./pages/Simulacao"));
+const SimulacaoGuiada = lazy(() => import("./pages/SimulacaoGuiada"));
 const PoliticaPrivacidade = lazy(() => import("./pages/PoliticaPrivacidade"));
 const PoliticaCookies = lazy(() => import("./pages/PoliticaCookies"));
 const AdminDashboard = lazy(() => import("./pages/AdminDashboard"));
@@ -80,6 +81,11 @@ const AppServer: React.FC<AppServerProps> = ({ url, initialData = {} }) => {
               <Route path="/simulacao" element={
                 <Suspense fallback={<Loading />}>
                   <TooltipProvider><Simulacao /></TooltipProvider>
+                </Suspense>
+              } />
+              <Route path="/simulacao-guiada" element={
+                <Suspense fallback={<Loading />}>
+                  <TooltipProvider><SimulacaoGuiada /></TooltipProvider>
                 </Suspense>
               } />
               <Route path="/simulacao/sapi" element={<SimulacaoSapi />} />

--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -79,7 +79,7 @@ const Benefits: React.FC = () => {
   const navigate = useNavigate();
 
   const handleCardClick = () => {
-    navigate('/simulacao');
+    navigate('/simulacao-guiada');
   };
   
   return (

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -38,7 +38,7 @@ const BottomNavigation: React.FC = () => {
       id: 'simulate',
       label: 'Simular',
       icon: Calculator,
-      href: '/simulacao',
+      href: '/simulacao-guiada',
       isSpecial: true
     },
     {
@@ -187,7 +187,7 @@ const BottomNavigation: React.FC = () => {
               {/* CTA Button in Menu */}
               <div className="mt-6">
                 <Link
-                  to="/simulacao"
+                  to="/simulacao-guiada"
                   className="block w-full py-3 px-4 bg-libra-blue text-white text-center font-semibold rounded-lg"
                   onClick={() => setIsMenuOpen(false)}
                 >

--- a/src/components/CGISection.tsx
+++ b/src/components/CGISection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const CGISection: React.FC = () => {
   const benefits = [
@@ -24,6 +25,8 @@ const CGISection: React.FC = () => {
       iconBg: "bg-yellow-500"
     }
   ];
+
+  const navigate = useNavigate();
 
   return (
     <div className="bg-gray-50 py-16 px-4">
@@ -78,7 +81,10 @@ const CGISection: React.FC = () => {
               Com o CGI Libra, você tem a liberdade de usar o crédito como desejar, 
               sempre com as melhores condições do mercado.
             </p>
-            <button className="bg-red-600 hover:bg-red-700 text-white font-bold px-8 py-3 rounded-full transition-colors">
+            <button
+              onClick={() => navigate('/simulacao-guiada')}
+              className="bg-red-600 hover:bg-red-700 text-white font-bold px-8 py-3 rounded-full transition-colors"
+            >
               Simular Agora
             </button>
           </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -31,7 +31,7 @@ const Footer: React.FC = () => {
             <h3 className="text-sm md:text-xl font-bold mb-2 md:mb-4 text-white">Navegação</h3>
             <ul className="space-y-1 md:space-y-2">
               <li><Link to="/" className="text-white/80 hover:text-white transition-colors text-xs md:text-base">Início</Link></li>
-              <li><Link to="/simulacao" className="text-white/80 hover:text-white transition-colors text-xs md:text-base">Simulação</Link></li>
+              <li><Link to="/simulacao-guiada" className="text-white/80 hover:text-white transition-colors text-xs md:text-base">Simulação</Link></li>
               <li><Link to="/vantagens" className="text-white/80 hover:text-white transition-colors text-xs md:text-base">Vantagens</Link></li>
               <li><Link to="/quem-somos" className="text-white/80 hover:text-white transition-colors text-xs md:text-base">Quem Somos</Link></li>
               <li><Link to="/blog" className="text-white/80 hover:text-white transition-colors text-xs md:text-base">Blog</Link></li>

--- a/src/components/GlobalTracker.tsx
+++ b/src/components/GlobalTracker.tsx
@@ -38,6 +38,7 @@ const GlobalTracker: React.FC = () => {
     const pageEvents: Record<string, string> = {
       '/': 'homepage_view',
       '/simulacao': 'simulation_page_view',
+      '/simulacao-guiada': 'simulation_page_view',
       '/parceiros': 'partners_page_view',
       '/vantagens': 'benefits_page_view',
       '/quem-somos': 'about_page_view'

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -45,7 +45,7 @@ const Header: React.FC = () => {
   // Carrega o popup assim que o componente é montado
   useEffect(() => {
     const currentPath = location.pathname;
-    const allowedPaths = ['/', '/simulacao'];
+    const allowedPaths = ['/', '/simulacao-guiada'];
 
     if (allowedPaths.includes(currentPath)) {
       const storageKey = `popup_seen_${currentPath.replace('/', 'home')}`;
@@ -68,7 +68,7 @@ const Header: React.FC = () => {
   };
 
   const handleSimulateNow = () => {
-    navigate('/simulacao');
+    navigate('/simulacao-guiada');
   };
 
   const handlePortalClientes = () => {

--- a/src/components/HeroAnimated.tsx
+++ b/src/components/HeroAnimated.tsx
@@ -24,7 +24,7 @@ const HeroAnimated: React.FC = () => {
 
 
   const scrollToSimulator = () => {
-    navigate('/simulacao');
+    navigate('/simulacao-guiada');
   };
 
   const goToVantagens = () => {

--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -19,7 +19,7 @@ const HeroPremium: React.FC = () => {
   ];
 
   const scrollToSimulator = () => {
-    navigate('/simulacao');
+    navigate('/simulacao-guiada');
   };
 
   const scrollToBenefits = () => {

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -41,7 +41,7 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
 
   const navigationItems = [
     { name: 'Home', path: '/' },
-    { name: 'Simulação', path: '/simulacao', highlight: true },
+    { name: 'Simulação', path: '/simulacao-guiada', highlight: true },
     { name: 'Vantagens', path: '/vantagens' },
     { name: 'Quem Somos', path: '/quem-somos' },
     { name: 'Blog', path: '/blog' },

--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -17,7 +17,7 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
 
   const navigationItems = [
     { name: 'Home', path: '/' },
-    { name: 'Simulação', path: '/simulacao' },
+    { name: 'Simulação', path: '/simulacao-guiada' },
     { name: 'Vantagens', path: '/vantagens' },
     { name: 'Quem Somos', path: '/quem-somos' },
     { name: 'Blog', path: '/blog' },
@@ -25,7 +25,7 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
   ];
 
   const handleSimulate = () => {
-    navigate('/simulacao');
+    navigate('/simulacao-guiada');
     setIsMenuOpen(false);
   };
 

--- a/src/components/StepsSection.tsx
+++ b/src/components/StepsSection.tsx
@@ -40,7 +40,7 @@ const StepsSection: React.FC = () => {
   ];
 
   const handleSimulate = () => {
-    navigate('/simulacao');
+    navigate('/simulacao-guiada');
   };
 
   return (

--- a/src/components/TutorGuide/index.tsx
+++ b/src/components/TutorGuide/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import UserCircle from 'lucide-react/dist/esm/icons/user-circle';
+
+interface TutorGuideProps {
+  message: string;
+  onNext: () => void;
+  onBack?: () => void;
+}
+
+const TutorGuide: React.FC<TutorGuideProps> = ({ message, onNext, onBack }) => {
+  return (
+    <div className="flex items-end gap-3 p-4 bg-white rounded-xl shadow-lg border border-gray-100">
+      <UserCircle className="w-12 h-12 text-libra-blue flex-shrink-0" />
+      <div className="flex-1">
+        <p className="text-sm text-gray-700">{message}</p>
+        <div className="flex justify-end gap-2 mt-3">
+          {onBack && (
+            <button
+              onClick={onBack}
+              className="px-3 py-1 text-sm border border-libra-blue text-libra-blue rounded-lg"
+            >
+              Voltar
+            </button>
+          )}
+          <button
+            onClick={onNext}
+            className="px-3 py-1 text-sm bg-libra-blue text-white rounded-lg"
+          >
+            Avançar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TutorGuide;

--- a/src/hooks/useSwipeGesture.ts
+++ b/src/hooks/useSwipeGesture.ts
@@ -73,7 +73,7 @@ export const useSwipeGesture = (
 // Hook for page navigation with swipe
 export const useSwipeNavigation = () => {
   const bodyRef = useRef(document.body);
-  const pages = ['/', '/simulacao', '/vantagens', '/quem-somos'];
+  const pages = ['/', '/simulacao-guiada', '/vantagens', '/quem-somos'];
   
   const getCurrentPageIndex = () => {
     const currentPath = window.location.pathname;

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -116,7 +116,7 @@ const Blog: React.FC<BlogProps> = ({ initialPosts = [] }) => {
   }, [initialPosts]);
 
   const handleSimular = () => {
-    navigate('/simulacao');
+    navigate('/simulacao-guiada');
   };
 
   const filteredPosts = posts.filter(post => {

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -220,7 +220,7 @@ const BlogPost: React.FC<BlogPostPageProps> = ({ initialPost }) => {
                 <p className="text-lg md:text-xl mb-8 opacity-90 max-w-2xl mx-auto text-libra-navy">
                   Simule agora e descubra as melhores condições para você. Processo 100% digital e sem complicações.
                 </p>
-                <Link to="/simulacao">
+                <Link to="/simulacao-guiada">
                   <Button size="lg" className="bg-red-600 text-white hover:bg-red-700 font-semibold px-8 py-3 text-lg shadow-lg hover:shadow-xl transition-all duration-300">
                     Fazer Simulação Gratuita
                   </Button>

--- a/src/pages/QuemSomos.tsx
+++ b/src/pages/QuemSomos.tsx
@@ -25,7 +25,7 @@ const QuemSomos = () => {
   };
 
   const handleSimular = () => {
-    navigate('/simulacao');
+    navigate('/simulacao-guiada');
   };
 
   const valores = [
@@ -85,7 +85,7 @@ const QuemSomos = () => {
                   Clique aqui e entenda as <Link to="/vantagens" className="text-libra-blue hover:text-libra-navy transition-colors">vantagens</Link> que oferecemos para equiLIBRAr a sua vida financeira.
                 </p>
                 <p className="text-base md:text-lg text-gray-600">
-                  Faça uma <Link to="/simulacao" className="text-libra-blue hover:text-libra-navy transition-colors">simulação</Link> e fale com um consultor!
+                  Faça uma <Link to="/simulacao-guiada" className="text-libra-blue hover:text-libra-navy transition-colors">simulação</Link> e fale com um consultor!
                 </p>
               </div>
               <div className="relative">

--- a/src/pages/SimulacaoGuiada.tsx
+++ b/src/pages/SimulacaoGuiada.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { MobileWizard } from '@/components/MobileWizard';
+import { ValueStep, TermStep, ContactStep, SummaryStep } from '@/components/MobileWizard/steps';
+import TutorGuide from '@/components/TutorGuide';
+
+const validateValue = (data: any) => !!data.loanAmount;
+const validateTerm = (data: any) => !!data.loanTerm;
+const validateContact = (data: any) => !!(data.name && data.phone && data.phone.length >= 14);
+
+const tutorMessages: Record<string, string> = {
+  value: 'Escolha o valor que você precisa para começar a simulação.',
+  term: 'Agora selecione em quantos meses deseja pagar.',
+  contact: 'Precisamos de alguns dados para entrar em contato com você.',
+  summary: 'Confira se está tudo certo antes de finalizar.',
+};
+
+const withTutor = (
+  Component: React.ComponentType<any>,
+  id: string
+) => (props: any) => (
+  <div className="relative pb-32">
+    <Component {...props} />
+    <div className="absolute bottom-0 left-0 right-0 p-4">
+      <TutorGuide
+        message={tutorMessages[id]}
+        onNext={props.onNext}
+        onBack={props.onBack}
+      />
+    </div>
+  </div>
+);
+
+const steps = [
+  { id: 'value', title: 'Valor Necessário', component: withTutor(ValueStep, 'value'), validation: validateValue },
+  { id: 'term', title: 'Prazo de Pagamento', component: withTutor(TermStep, 'term'), validation: validateTerm },
+  { id: 'contact', title: 'Seus Dados', component: withTutor(ContactStep, 'contact'), validation: validateContact },
+  { id: 'summary', title: 'Resumo da Simulação', component: withTutor(SummaryStep, 'summary'), validation: () => true },
+];
+
+const SimulacaoGuiada = () => {
+  const navigate = useNavigate();
+  const [simulationResult, setSimulationResult] = useState<any>(null);
+
+  const handleComplete = (data: any) => {
+    setSimulationResult(data);
+    navigate('/confirmacao');
+  };
+
+  const handleClose = () => {
+    navigate(-1);
+  };
+
+  return (
+    <MobileWizard
+      steps={steps}
+      onComplete={handleComplete}
+      onClose={handleClose}
+      initialData={simulationResult || {}}
+      saveKey="simulacao-guiada"
+    />
+  );
+};
+
+export default SimulacaoGuiada;

--- a/src/pages/SimulacaoSapi.tsx
+++ b/src/pages/SimulacaoSapi.tsx
@@ -86,7 +86,7 @@ const SimulacaoSapi: React.FC = () => {
         {/* Breadcrumb */}
         <div className="mb-6">
           <Link 
-            to="/simulacao" 
+            to="/simulacao-guiada"
             className="inline-flex items-center text-libra-blue hover:text-libra-blue/80 transition-colors"
           >
             <ArrowLeft className="w-4 h-4 mr-2" />

--- a/src/pages/Vantagens.tsx
+++ b/src/pages/Vantagens.tsx
@@ -178,7 +178,7 @@ const Vantagens: React.FC = () => {
   ];
 
   const handleSimular = () => {
-    navigate('/simulacao');
+    navigate('/simulacao-guiada');
   };
 
   return (


### PR DESCRIPTION
## Summary
- add TutorGuide component with avatar guidance
- implement SimulacaoGuiada page using MobileWizard and TutorGuide
- wire new /simulacao-guiada route and update navigation links

## Testing
- `npm test` *(fails: LogoBand tests)*
- `npm run lint` *(fails: 52 errors, 251 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689a2d39a200832d977aa1336fc15d4e