### PR TITLE
Auto-unmute YouTube player when ready

### DIFF
--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -37,6 +37,35 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
     if (!container) return;
 
     const iframe = document.createElement('iframe');
+
+    const sendUnmuteCommands = () => {
+      iframe.contentWindow?.postMessage(
+        JSON.stringify({ event: 'command', func: 'unMute', args: [] }),
+        '*',
+      );
+      iframe.contentWindow?.postMessage(
+        JSON.stringify({ event: 'command', func: 'setVolume', args: [100] }),
+        '*',
+      );
+    };
+
+    let fallbackTimer: ReturnType<typeof setTimeout>;
+
+    const handlePlayerReady = (event: MessageEvent) => {
+      if (event.source !== iframe.contentWindow) return;
+      try {
+        const data =
+          typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+        if (data?.event === 'onReady') {
+          clearTimeout(fallbackTimer);
+          sendUnmuteCommands();
+          window.removeEventListener('message', handlePlayerReady);
+        }
+      } catch {}
+    };
+
+    window.addEventListener('message', handlePlayerReady);
+
     iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&mute=1&playsinline=1&modestbranding=1&rel=0&enablejsapi=1`;
     iframe.title = title;
     iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
@@ -49,24 +78,7 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
     container.innerHTML = '';
     container.appendChild(iframe);
 
-    const unmuteBtn = document.createElement('button');
-    unmuteBtn.type = 'button';
-    unmuteBtn.textContent = 'Ativar som';
-    unmuteBtn.className =
-      'absolute bottom-4 right-4 bg-white/90 text-gray-900 px-3 py-1 rounded shadow';
-    unmuteBtn.addEventListener('click', () => {
-      iframe.contentWindow?.postMessage(
-        JSON.stringify({ event: 'command', func: 'unMute', args: [] }),
-        '*',
-      );
-      iframe.contentWindow?.postMessage(
-        JSON.stringify({ event: 'command', func: 'setVolume', args: [100] }),
-        '*',
-      );
-      unmuteBtn.remove();
-    });
-
-    container.appendChild(unmuteBtn);
+    fallbackTimer = setTimeout(sendUnmuteCommands, 1000);
   };
 
   return (

--- a/src/components/__tests__/OptimizedYouTube.test.tsx
+++ b/src/components/__tests__/OptimizedYouTube.test.tsx
@@ -29,19 +29,33 @@ describe('OptimizedYouTube', () => {
     expect(iframe?.getAttribute('src')).toContain('abc123');
   });
 
-  it('shows unmute button after loading video', () => {
-    const { container, getByText, queryByText } = render(
+  it('sends unmute commands when player is ready', () => {
+    const { container } = render(
       <OptimizedYouTube videoId="abc123" title="Test Video" />
     );
 
     const button = container.querySelector('button') as HTMLButtonElement;
     fireEvent.click(button);
 
-    const unmute = getByText('Ativar som');
-    expect(unmute).toBeInTheDocument();
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    const postMessage = vi.fn();
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: { postMessage },
+    });
 
-    fireEvent.click(unmute);
-    expect(queryByText('Ativar som')).toBeNull();
+    const messageData = JSON.stringify({ event: 'onReady' });
+    window.dispatchEvent(
+      new MessageEvent('message', { source: iframe.contentWindow, data: messageData })
+    );
+
+    expect(postMessage).toHaveBeenCalledWith(
+      JSON.stringify({ event: 'command', func: 'unMute', args: [] }),
+      '*'
+    );
+    expect(postMessage).toHaveBeenCalledWith(
+      JSON.stringify({ event: 'command', func: 'setVolume', args: [100] }),
+      '*'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- remove manual "Ativar som" button from OptimizedYouTube
- automatically unmute and set volume when the YouTube player signals readiness
- add fallback to ensure unmute executes even if ready event is missed
- update tests for new auto-unmute behavior

## Testing
- `npm test src/components/__tests__/OptimizedYouTube.test.tsx`
- `npm test` *(fails: LogoBand.test.tsx)*
- `npm run lint` *(fails: 54 errors, 244 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b2c522c80832dab7f4baa8a36048f