### PR TITLE
Remove forced unmute from OptimizedYouTube embed

### DIFF
--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -38,35 +38,7 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
 
     const iframe = document.createElement('iframe');
 
-    const sendUnmuteCommands = () => {
-      iframe.contentWindow?.postMessage(
-        JSON.stringify({ event: 'command', func: 'unMute', args: [] }),
-        '*',
-      );
-      iframe.contentWindow?.postMessage(
-        JSON.stringify({ event: 'command', func: 'setVolume', args: [100] }),
-        '*',
-      );
-    };
-
-    let fallbackTimer: ReturnType<typeof setTimeout>;
-
-    const handlePlayerReady = (event: MessageEvent) => {
-      if (event.source !== iframe.contentWindow) return;
-      try {
-        const data =
-          typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
-        if (data?.event === 'onReady') {
-          clearTimeout(fallbackTimer);
-          sendUnmuteCommands();
-          window.removeEventListener('message', handlePlayerReady);
-        }
-      } catch {}
-    };
-
-    window.addEventListener('message', handlePlayerReady);
-
-    iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&mute=1&playsinline=1&modestbranding=1&rel=0&enablejsapi=1`;
+    iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&playsinline=1&modestbranding=1&rel=0&enablejsapi=1`;
     iframe.title = title;
     iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
     iframe.allowFullscreen = true;
@@ -77,9 +49,6 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
 
     container.innerHTML = '';
     container.appendChild(iframe);
-
-    fallbackTimer = setTimeout(sendUnmuteCommands, 1000);
-
   };
 
   return (

--- a/src/components/__tests__/OptimizedYouTube.test.tsx
+++ b/src/components/__tests__/OptimizedYouTube.test.tsx
@@ -1,5 +1,5 @@
 import { render, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import OptimizedYouTube from '../OptimizedYouTube';
 
@@ -29,7 +29,7 @@ describe('OptimizedYouTube', () => {
     expect(iframe?.getAttribute('src')).toContain('abc123');
   });
 
-  it('sends unmute commands when player is ready', () => {
+  it('não renderiza botão de unmute', () => {
     const { container } = render(
       <OptimizedYouTube videoId="abc123" title="Test Video" />
     );
@@ -38,6 +38,9 @@ describe('OptimizedYouTube', () => {
     fireEvent.click(button);
 
     const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe).toBeInTheDocument();
+    expect(iframe.getAttribute('src')).not.toContain('mute=1');
+
     const postMessage = vi.fn();
     Object.defineProperty(iframe, 'contentWindow', {
       value: { postMessage },
@@ -48,14 +51,7 @@ describe('OptimizedYouTube', () => {
       new MessageEvent('message', { source: iframe.contentWindow, data: messageData })
     );
 
-    expect(postMessage).toHaveBeenCalledWith(
-      JSON.stringify({ event: 'command', func: 'unMute', args: [] }),
-      '*'
-    );
-    expect(postMessage).toHaveBeenCalledWith(
-      JSON.stringify({ event: 'command', func: 'setVolume', args: [100] }),
-      '*'
-    );
+    expect(postMessage).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- remove mute parameter and unmute postMessage logic from OptimizedYouTube
- adjust tests to expect no mute parameter or audio postMessage

## Testing
- `npm test` *(fails: LogoBand.test.tsx expects different classes)*

------
https://chatgpt.com/codex/tasks/task_e_689b446987ec832dbb2f416e3cc57f4e