### PR TITLE
refactor: load YouTube via API

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -22,14 +22,14 @@ const LogoBand: React.FC<LogoBandProps> = ({ onClick, size = 'desktop' }) => {
       ? {
           padding: 'py-8',
           imgSize: 64,
-          imgClass: 'h-12 sm:h-16 flex-shrink-0',
+          imgClass: 'h-12 sm:h-16 flex-shrink-0 w-auto',
           textClass:
             'ml-3 sm:ml-4 text-white text-sm sm:text-base font-semibold leading-tight text-center flex-1 min-w-0',
         }
       : {
           padding: 'py-4',
           imgSize: 80,
-          imgClass: 'h-20 w-20 flex-shrink-0',
+          imgClass: 'h-20 w-auto flex-shrink-0',
           textClass: 'ml-4 text-white text-lg font-semibold whitespace-nowrap',
         };
 
@@ -60,11 +60,9 @@ const LogoBand: React.FC<LogoBandProps> = ({ onClick, size = 'desktop' }) => {
         <ImageOptimizer
           src="/images/logos/logo-branco.svg"
           alt="Libra Crédito"
-          className="h-20 w-20"
+          className={config.imgClass}
           objectFit="contain"
-
           aspectRatio={1}
-
           priority={false}
           width={config.imgSize}
           height={config.imgSize}

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -1,6 +1,28 @@
 import Play from 'lucide-react/dist/esm/icons/play';
 import { type FC, type MouseEvent } from 'react';
 
+let youtubeApiPromise: Promise<void> | null = null;
+
+const loadYouTubeApi = (): Promise<void> => {
+  const w = window as any;
+
+  if (w.YT && w.YT.Player) {
+    return Promise.resolve();
+  }
+
+  if (!youtubeApiPromise) {
+    youtubeApiPromise = new Promise((resolve) => {
+      const tag = document.createElement('script');
+      tag.src = 'https://www.youtube.com/iframe_api';
+      const firstScriptTag = document.getElementsByTagName('script')[0];
+      firstScriptTag?.parentNode?.insertBefore(tag, firstScriptTag);
+      w.onYouTubeIframeAPIReady = () => resolve();
+    });
+  }
+
+  return youtubeApiPromise;
+};
+
 interface OptimizedYouTubeProps {
   videoId: string;
   title: string;
@@ -32,23 +54,28 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
   const thumbnailImage = thumbnailSrc || '/images/media/video-cgi-libra.webp';
   const fetchPriorityAttr = fetchPriority ?? (priority ? 'high' : undefined);
 
-  const loadVideo = (e: MouseEvent<HTMLButtonElement>) => {
+  const loadVideo = async (e: MouseEvent<HTMLButtonElement>) => {
     const container = e.currentTarget.parentElement as HTMLElement | null;
     if (!container) return;
 
-    const iframe = document.createElement('iframe');
-
-    iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&playsinline=1&modestbranding=1&rel=0&enablejsapi=1`;
-    iframe.title = title;
-    iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
-    iframe.allowFullscreen = true;
-    iframe.style.position = 'absolute';
-    iframe.style.inset = '0';
-    iframe.style.width = '100%';
-    iframe.style.height = '100%';
+    await loadYouTubeApi();
+    const w = window as any;
 
     container.innerHTML = '';
-    container.appendChild(iframe);
+    const div = document.createElement('div');
+    container.appendChild(div);
+
+    new w.YT.Player(div, {
+      videoId,
+      playerVars: { autoplay: 1, playsinline: 1, modestbranding: 1, rel: 0 },
+      events: {
+        onReady: (event: any) => {
+          event.target.unMute();
+          event.target.setVolume(100);
+          event.target.playVideo();
+        },
+      },
+    });
   };
 
   return (

--- a/src/components/__tests__/OptimizedYouTube.test.tsx
+++ b/src/components/__tests__/OptimizedYouTube.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import OptimizedYouTube from '../OptimizedYouTube';
@@ -16,42 +16,31 @@ describe('OptimizedYouTube', () => {
     expect(placeholder).toBeNull();
   });
 
-  it('loads video iframe on click', () => {
-    const { container } = render(
-      <OptimizedYouTube videoId="abc123" title="Test Video" />
-    );
+  it('calls player methods on click', async () => {
+    const unMute = vi.fn();
+    const setVolume = vi.fn();
+    const playVideo = vi.fn();
 
-    const button = container.querySelector('button') as HTMLButtonElement;
-    fireEvent.click(button);
-
-    const iframe = container.querySelector('iframe');
-    expect(iframe).toBeInTheDocument();
-    expect(iframe?.getAttribute('src')).toContain('abc123');
-  });
-
-  it('não renderiza botão de unmute', () => {
-    const { container } = render(
-      <OptimizedYouTube videoId="abc123" title="Test Video" />
-    );
-
-    const button = container.querySelector('button') as HTMLButtonElement;
-    fireEvent.click(button);
-
-    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
-    expect(iframe).toBeInTheDocument();
-    expect(iframe.getAttribute('src')).not.toContain('mute=1');
-
-    const postMessage = vi.fn();
-    Object.defineProperty(iframe, 'contentWindow', {
-      value: { postMessage },
+    const PlayerMock = vi.fn().mockImplementation((element, options) => {
+      options.events.onReady({ target: { unMute, setVolume, playVideo } });
+      return {};
     });
 
-    const messageData = JSON.stringify({ event: 'onReady' });
-    window.dispatchEvent(
-      new MessageEvent('message', { source: iframe.contentWindow, data: messageData })
+    (window as any).YT = { Player: PlayerMock };
+
+    const { container } = render(
+      <OptimizedYouTube videoId="abc123" title="Test Video" />
     );
 
-    expect(postMessage).not.toHaveBeenCalled();
+    const button = container.querySelector('button') as HTMLButtonElement;
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(PlayerMock).toHaveBeenCalled();
+      expect(unMute).toHaveBeenCalled();
+      expect(setVolume).toHaveBeenCalledWith(100);
+      expect(playVideo).toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- load YouTube iframe API before instantiating players
- use `YT.Player` to inject videos with autoplay and volume controls
- mock `YT.Player` in tests and verify unMute/setVolume/playVideo
- ensure `LogoBand` respects configured image sizing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b4d72277c832d9484052d09c960d0