### PR TITLE
feat: integrate ElevenLabs voice assistant with Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,14 @@ VITE_GA_TRACKING_ID=your_google_analytics_id_here
 
 # Environment
 VITE_NODE_ENV=development
+
+# Feature Flags
+VITE_FEATURE_ASSISTANT=true
+
+# ElevenLabs Integration
+VITE_ELEVENLABS_AGENT_ID=
+ELEVENLABS_API_KEY=
+ELEVENLABS_WEBHOOK_SECRET=
+
+# Supabase Service Role (server only)
+SUPABASE_SERVICE_ROLE_KEY=

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ cp .env.example .env
 # - `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY`
 #   - **Sem valores válidos a aplicação não inicializa**
 # - `VITE_WEBHOOK_URL` (opcional - para webhook de simulações)
+# - `VITE_FEATURE_ASSISTANT` (habilita o assistente de voz)
+# - `VITE_ELEVENLABS_AGENT_ID` (ID do agente, exposto no cliente)
+# - `ELEVENLABS_API_KEY` (apenas funções serverless)
+# - `ELEVENLABS_WEBHOOK_SECRET` (apenas funções serverless)
+# - `SUPABASE_SERVICE_ROLE_KEY` (apenas funções serverless)
 # - Outras conforme necessário
 ```
 
@@ -328,6 +333,28 @@ Se o navegador exibir `QuotaExceededError`, o espaço do localStorage esgotou co
 Acesse `/clear-localstorage.html` para limpar os dados armazenados e liberar espaço.
 
 ---
+
+## 🗣️ Assistente de Voz (ElevenLabs)
+
+- Ative o assistente definindo `VITE_FEATURE_ASSISTANT=true`.
+- Configure `VITE_ELEVENLABS_AGENT_ID` com o Agent ID obtido no painel da ElevenLabs.
+- Nas funções serverless defina `ELEVENLABS_API_KEY`, `ELEVENLABS_WEBHOOK_SECRET` e `SUPABASE_SERVICE_ROLE_KEY`.
+- O botão **Falar com especialista** leva a `/assistente?sim_id=<id>` e inicia a sessão de voz.
+- Cadastre o webhook pós-chamada no painel ElevenLabs apontando para `/api/elevenlabs/webhook`.
+
+### Teste Local
+
+1. Execute `npm run dev` com as variáveis acima configuradas.
+2. Realize uma simulação e clique em **Falar com especialista**.
+3. Para testar o webhook localmente:
+   ```bash
+   curl -X POST http://localhost:3000/api/elevenlabs/webhook \
+     -H "elevenlabs-signature: t=0,v0=assinatura" \
+     -d '{"type":"post_call_transcription","data":{}}'
+   ```
+
+### Alternativa: Supabase Edge Functions
+Caso o deploy não suporte rotas Node em `/api`, utilize as funções em `supabase/functions` e publique com `supabase functions deploy`.
 
 ## 🔒 Segurança e LGPD
 

--- a/api/conversations/link.ts
+++ b/api/conversations/link.ts
@@ -1,0 +1,28 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient } from '@supabase/supabase-js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const { conversation_id, agent_id, simulation_id } = req.body ?? {};
+  if (!conversation_id || !simulation_id) {
+    return res.status(400).json({ error: 'missing parameters' });
+  }
+
+  const url = process.env.VITE_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    return res.status(500).json({ error: 'supabase not configured' });
+  }
+
+  const supabase = createClient(url, serviceKey);
+
+  await supabase.from('conversations').upsert({
+    conversation_id,
+    agent_id,
+    simulation_id,
+    started_at: new Date().toISOString()
+  });
+
+  res.status(200).json({ ok: true });
+}

--- a/api/elevenlabs/signed-url.ts
+++ b/api/elevenlabs/signed-url.ts
@@ -1,0 +1,19 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const agentId = req.query.agent_id as string;
+  if (!agentId) return res.status(400).json({ error: 'agent_id is required' });
+
+  const apiKey = process.env.ELEVENLABS_API_KEY;
+  if (!apiKey) return res.status(500).json({ error: 'API key not configured' });
+
+  try {
+    const response = await fetch(`https://api.elevenlabs.io/v1/convai/conversation/get-signed-url?agent_id=${agentId}`, {
+      headers: { 'xi-api-key': apiKey }
+    });
+    const data = await response.json();
+    res.status(200).json({ signedUrl: data.signed_url ?? data });
+  } catch {
+    res.status(500).json({ error: 'failed to get signed url' });
+  }
+}

--- a/api/elevenlabs/webhook.ts
+++ b/api/elevenlabs/webhook.ts
@@ -1,0 +1,71 @@
+import crypto from 'crypto';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient } from '@supabase/supabase-js';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  const rawBody = Buffer.concat(chunks).toString('utf8');
+
+  const signature = req.headers['elevenlabs-signature'] as string;
+  const secret = process.env.ELEVENLABS_WEBHOOK_SECRET || '';
+  if (!signature || !secret) {
+    return res.status(400).json({ error: 'missing signature' });
+  }
+  const [tPart, v0Part] = signature.split(',');
+  const timestamp = tPart?.split('=')[1] || '';
+  const v0 = v0Part?.split('=')[1] || '';
+  const hmac = crypto.createHmac('sha256', secret).update(`${timestamp}.${rawBody}`).digest('hex');
+  if (hmac !== v0) {
+    return res.status(401).json({ error: 'invalid signature' });
+  }
+
+  const payload = JSON.parse(rawBody);
+  if (payload.type !== 'post_call_transcription') {
+    return res.status(200).json({ ok: true });
+  }
+
+  const url = process.env.VITE_SUPABASE_URL as string;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+  const supabase = createClient(url, serviceKey);
+
+  const data = payload.data;
+  const convId = data?.conversation_id;
+  const agentId = data?.agent_id;
+  const transcript = data?.transcript || [];
+  const analysis = data?.analysis;
+  const metadata = { ...(data?.metadata || {}), has_audio: data?.has_audio, has_user_audio: data?.has_user_audio, has_response_audio: data?.has_response_audio };
+
+  await supabase.from('conversations').upsert({
+    conversation_id: convId,
+    agent_id: agentId,
+    ended_at: new Date().toISOString(),
+    duration_secs: metadata.call_duration_secs,
+    call_successful: analysis?.call_successful,
+    transcript_summary: analysis?.transcript_summary,
+    analysis,
+    metadata,
+  });
+
+  if (Array.isArray(transcript) && transcript.length > 0) {
+    const messages = transcript.map((m: any) => ({
+      conversation_id: convId,
+      role: m.role,
+      message: m.message,
+      time_in_call_secs: m.time_in_call_secs,
+    }));
+    await supabase.from('conversation_messages').insert(messages);
+  }
+
+  res.status(200).json({ ok: true });
+}

--- a/database/sql/20250815143023_elevenlabs-conversations.sql
+++ b/database/sql/20250815143023_elevenlabs-conversations.sql
@@ -1,0 +1,21 @@
+create table if not exists public.conversations (
+  conversation_id text primary key,
+  agent_id text not null,
+  simulation_id uuid references public.simulacoes(id),
+  started_at timestamptz default now(),
+  ended_at timestamptz,
+  duration_secs integer,
+  call_successful boolean,
+  transcript_summary text,
+  analysis jsonb,
+  metadata jsonb
+);
+
+create table if not exists public.conversation_messages (
+  id bigserial primary key,
+  conversation_id text references public.conversations(conversation_id),
+  role text check (role in ('user','assistant','system')),
+  message text,
+  time_in_call_secs integer,
+  created_at timestamptz default now()
+);

--- a/docs/elevenlabs_supabase_integration_plan.md
+++ b/docs/elevenlabs_supabase_integration_plan.md
@@ -1,0 +1,53 @@
+# Integração ElevenLabs ↔ Supabase
+
+## Mapa do Projeto
+- **Stack:** React + Vite + TypeScript
+- **Roteamento:** React Router (`src/App.tsx`)
+- **Persistência:** Supabase (`src/lib/supabase.ts`)
+- **Página de Simulação:** `/simulacao` com `SimulationForm` → `SimulationResultDisplay`
+- **Assistente:** nova rota [`/assistente`](../src/pages/Assistente.tsx)
+
+## Mapeamento de Variáveis
+| ElevenLabs | Campo do Projeto |
+| --- | --- |
+| `lead_name` | `simulacoes.nome_completo` |
+| `secret__phone` | `simulacoes.telefone` |
+| `secret__email` | `simulacoes.email` |
+| `sim_property_value` | `simulacoes.valor_imovel` |
+| `sim_requested_amount` | `simulacoes.valor_emprestimo` |
+| `sim_installment_value` | `simulacoes.parcela_inicial` ou cálculo |
+| `sim_min_income` | `simulacoes.renda_minima` ou cálculo |
+| `sim_city` / `sim_state` | parse de `simulacoes.cidade` |
+
+## Pontos de Integração
+- **Front:** [`src/pages/Assistente.tsx`](../src/pages/Assistente.tsx) inicia `Conversation.startSession`
+- **Signed URL:** [`api/elevenlabs/signed-url.ts`](../api/elevenlabs/signed-url.ts)
+- **Link Conversa:** [`api/conversations/link.ts`](../api/conversations/link.ts)
+- **Webhook:** [`api/elevenlabs/webhook.ts`](../api/elevenlabs/webhook.ts)
+- **Edge Functions (alternativa):** `supabase/functions/*`
+
+## Modelo de Dados
+Script SQL: [`database/sql/20250815143023_elevenlabs-conversations.sql`](../database/sql/20250815143023_elevenlabs-conversations.sql)
+
+## Variáveis de Ambiente
+- `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`
+- `VITE_FEATURE_ASSISTANT`
+- `VITE_ELEVENLABS_AGENT_ID`
+- `ELEVENLABS_API_KEY`, `ELEVENLABS_WEBHOOK_SECRET`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+## Teste Local
+```bash
+npm run dev
+# Após simulação: /assistente?sim_id=<id>
+
+# Webhook de teste
+curl -X POST http://localhost:3000/api/elevenlabs/webhook \
+  -H "elevenlabs-signature: t=0,v0=assinatura" \
+  -d '{"type":"post_call_transcription","data":{}}'
+```
+
+## Referências de Arquivos
+- [`src/lib/elevenlabs.ts`](../src/lib/elevenlabs.ts)
+- [`src/components/SimulationResultDisplay.tsx`](../src/components/SimulationResultDisplay.tsx)
+- [`README.md`](../README.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "libra-credito-landing-page",
       "version": "1.0.0",
       "dependencies": {
+        "@elevenlabs/client": "^0.5.0",
         "@emailjs/browser": "^4.4.1",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-progress": "^1.1.0",
@@ -136,6 +137,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
@@ -249,6 +256,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@elevenlabs/client": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/client/-/client-0.5.0.tgz",
+      "integrity": "sha512-w2DdDYU4rW5jMbnw/WfYLk66m+Wx1CYkhYJu8mKJsnmRuncR/2p4YQQ5TEovNz8ngzFopWofqXNximRxoOfLtA==",
+      "license": "MIT",
+      "dependencies": {
+        "livekit-client": "^2.11.4"
       }
     },
     "node_modules/@emailjs/browser": {
@@ -1443,6 +1459,21 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.39.3",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.39.3.tgz",
+      "integrity": "sha512-hfOnbwPCeZBEvMRdRhU2sr46mjGXavQcrb3BFRfG+Gm0Z7WUSeFdy5WLstXJzEepz17Iwp/lkGwJ4ZgOOYfPuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4884,6 +4915,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -5814,6 +5854,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/livekit-client": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.15.5.tgz",
+      "integrity": "sha512-zn36akmDlqZxlrTOUgYXtxtj35HQ44aJ+mgKat9BTSPiZru4RjEHOtp8RJE6jGoN2miJlWiOeEKHB2+ae3YrSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.39.3",
+        "events": "^3.3.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "ts-debounce": "^4.0.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5857,6 +5917,19 @@
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -7359,6 +7432,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7386,6 +7469,21 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/sdp": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
+      "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
       }
     },
     "node_modules/semver": {
@@ -7993,6 +8091,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
+      "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8453,6 +8557,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
       }
     },
     "node_modules/typed.js": {
@@ -9866,6 +9979,19 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz",
+      "integrity": "sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@elevenlabs/client": "^0.5.0",
     "@emailjs/browser": "^4.4.1",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-progress": "^1.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ const SimulacaoLocal = lazy(() => import("./pages/SimulacaoLocal"));
 const Confirmacao = lazy(() => import("./pages/Confirmacao"));
 const Sucesso = lazy(() => import("./pages/Sucesso"));
 const Atendimento = lazy(() => import("./pages/Atendimento"));
+const Assistente = lazy(() => import("./pages/Assistente"));
 
 let devRoutes = null;
 
@@ -116,6 +117,7 @@ const App = () => {
               {devRoutes}
               <Route path="/confirmacao" element={<Confirmacao />} />
               <Route path="/atendimento" element={<Atendimento />} />
+              <Route path="/assistente" element={<Assistente />} />
               <Route path="/sucesso" element={<Sucesso />} />
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Calculator, CheckCircle, Users, Headphones } from 'lucide-react';
 const TrendingUp = React.lazy(() =>
   import('lucide-react').then((m) => ({ default: m.TrendingUp }))
@@ -113,6 +114,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
   onSwitchToPrice
 }) => {
   const isMobile = useIsMobile();
+  const navigate = useNavigate();
   const { valor, amortizacao, parcelas: _parcelas, primeiraParcela, ultimaParcela } = resultado;
   
   // Cálculo da renda mínima familiar
@@ -328,6 +330,14 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
         className="space-y-3"
         inputClassName="bg-white/90 text-gray-800 placeholder-gray-500"
       />
+      {import.meta.env.VITE_FEATURE_ASSISTANT === 'true' && (
+        <Button
+          onClick={() => navigate(`/assistente?sim_id=${resultado.id}`)}
+          className="w-full mt-4 bg-[#003399] text-white"
+        >
+          Falar com especialista
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/lib/elevenlabs.ts
+++ b/src/lib/elevenlabs.ts
@@ -1,0 +1,46 @@
+import { Conversation } from '@elevenlabs/client';
+import type { SimulacaoData } from './supabase';
+
+export function mapCityUf(cidade: string | null | undefined): { city?: string; state?: string } {
+  if (!cidade) return {};
+  const [city, state] = cidade.split('-').map((s) => s.trim());
+  return { city, state };
+}
+
+interface StartAssistantOptions {
+  sim: SimulacaoData;
+  signedUrl: string;
+  callbacks?: {
+    onStatusChange?: (status: string) => void;
+    onMessage?: (msg: unknown) => void;
+    onError?: (err: unknown) => void;
+  };
+}
+
+export async function startAssistantSession({ sim, signedUrl, callbacks }: StartAssistantOptions) {
+  const { city, state } = mapCityUf(sim.cidade);
+  const installment = (sim as any).valor_parcela ?? sim.parcela_inicial ?? null;
+  const minIncome = (sim as any).renda_minima ?? (installment ? Math.round(installment / 0.3) : null);
+
+  const dynamicVariables: Record<string, unknown> = {
+    lead_name: sim.nome_completo,
+    secret__phone: sim.telefone,
+    secret__email: sim.email,
+    sim_property_value: sim.valor_imovel,
+    sim_requested_amount: sim.valor_emprestimo,
+    sim_installment_value: installment,
+    sim_min_income: minIncome,
+    sim_city: city,
+    sim_state: state,
+  };
+
+  const conversation = await Conversation.startSession({
+    signedUrl,
+    dynamicVariables,
+    onStatusChange: callbacks?.onStatusChange,
+    onMessage: callbacks?.onMessage,
+    onError: callbacks?.onError,
+  });
+
+  return conversation;
+}

--- a/src/pages/Assistente.tsx
+++ b/src/pages/Assistente.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import supabase, { type SimulacaoData } from '@/lib/supabase';
+import { startAssistantSession } from '@/lib/elevenlabs';
+
+const Assistente = () => {
+  const [searchParams] = useSearchParams();
+  const simId = searchParams.get('sim_id');
+  const [status, setStatus] = useState<string>('');
+  const [error, setError] = useState<string>('');
+  const [conv, setConv] = useState<any>(null);
+
+  useEffect(() => {
+    if (import.meta.env.VITE_FEATURE_ASSISTANT !== 'true') {
+      setError('Assistente desabilitado');
+      return;
+    }
+    if (!simId) {
+      setError('Simulação não encontrada');
+      return;
+    }
+    let active = true;
+    (async () => {
+      try {
+        const { data: sim, error: simError } = await supabase
+          .from('simulacoes')
+          .select('*')
+          .eq('id', simId)
+          .single<SimulacaoData>();
+        if (simError || !sim) throw simError || new Error('Simulação não encontrada');
+
+        const res = await fetch(`/api/elevenlabs/signed-url?agent_id=${import.meta.env.VITE_ELEVENLABS_AGENT_ID}`);
+        if (!res.ok) throw new Error('Falha ao obter signed URL');
+        const { signedUrl } = await res.json();
+
+        const conversation = await startAssistantSession({
+          sim,
+          signedUrl,
+          callbacks: {
+            onStatusChange: setStatus,
+            onMessage: (m) => console.log('msg', m),
+            onError: (e) => console.error('ElevenLabs error', e)
+          }
+        });
+        if (!active) return;
+        setConv(conversation);
+        const conversationId = conversation.getId();
+        await fetch('/api/conversations/link', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            conversation_id: conversationId,
+            agent_id: import.meta.env.VITE_ELEVENLABS_AGENT_ID,
+            simulation_id: simId
+          })
+        });
+      } catch (err) {
+        console.error(err);
+        if (active) setError('Erro ao iniciar assistente');
+      }
+    })();
+    return () => {
+      active = false;
+      conv?.endSession?.();
+    };
+  }, [simId]);
+
+  if (import.meta.env.VITE_FEATURE_ASSISTANT !== 'true') {
+    return <div className="p-4 text-center">Assistente desabilitado</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Assistente de Voz</h1>
+      {error && <p className="text-red-500 mb-2">{error}</p>}
+      {status && <p className="mb-2">Status: {status}</p>}
+      <p className="text-sm text-gray-600">Permita o uso do microfone para iniciar a conversa.</p>
+    </div>
+  );
+};
+
+export default Assistente;

--- a/supabase/functions/conversations-link/index.ts
+++ b/supabase/functions/conversations-link/index.ts
@@ -1,0 +1,17 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(async (req) => {
+  if (req.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
+  const { conversation_id, agent_id, simulation_id } = await req.json();
+  const url = Deno.env.get('VITE_SUPABASE_URL')!;
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+  const supabase = createClient(url, serviceKey);
+  await supabase.from('conversations').upsert({
+    conversation_id,
+    agent_id,
+    simulation_id,
+    started_at: new Date().toISOString()
+  });
+  return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+});

--- a/supabase/functions/elevenlabs-signed-url/index.ts
+++ b/supabase/functions/elevenlabs-signed-url/index.ts
@@ -1,0 +1,16 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+serve(async (req) => {
+  const url = new URL(req.url);
+  const agentId = url.searchParams.get('agent_id');
+  const apiKey = Deno.env.get('ELEVENLABS_API_KEY');
+  if (!agentId || !apiKey) {
+    return new Response(JSON.stringify({ error: 'missing params' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const resp = await fetch(`https://api.elevenlabs.io/v1/convai/conversation/get-signed-url?agent_id=${agentId}`, {
+    headers: { 'xi-api-key': apiKey }
+  });
+  const text = await resp.text();
+  return new Response(text, { headers: { 'content-type': 'application/json' } });
+});

--- a/supabase/functions/elevenlabs-webhook/index.ts
+++ b/supabase/functions/elevenlabs-webhook/index.ts
@@ -1,0 +1,61 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+async function verifySignature(signature: string | null, body: string): Promise<boolean> {
+  const secret = Deno.env.get('ELEVENLABS_WEBHOOK_SECRET') || '';
+  if (!signature || !secret) return false;
+  const [tPart, v0Part] = signature.split(',');
+  const timestamp = tPart?.split('=')[1] || '';
+  const v0 = v0Part?.split('=')[1] || '';
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const signatureBuffer = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`${timestamp}.${body}`));
+  const hmac = Array.from(new Uint8Array(signatureBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+  return hmac === v0;
+}
+
+serve(async (req) => {
+  if (req.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
+  const body = await req.text();
+  const signature = req.headers.get('elevenlabs-signature');
+  const valid = await verifySignature(signature, body);
+  if (!valid) return new Response(JSON.stringify({ error: 'invalid signature' }), { status: 401, headers: { 'content-type': 'application/json' } });
+
+  const payload = JSON.parse(body);
+  if (payload.type !== 'post_call_transcription') {
+    return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+  }
+
+  const url = Deno.env.get('VITE_SUPABASE_URL')!;
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+  const supabase = createClient(url, serviceKey);
+
+  const data = payload.data;
+  const convId = data?.conversation_id;
+  const agentId = data?.agent_id;
+  const transcript = data?.transcript || [];
+  const analysis = data?.analysis;
+  const metadata = { ...(data?.metadata || {}), has_audio: data?.has_audio, has_user_audio: data?.has_user_audio, has_response_audio: data?.has_response_audio };
+
+  await supabase.from('conversations').upsert({
+    conversation_id: convId,
+    agent_id: agentId,
+    ended_at: new Date().toISOString(),
+    duration_secs: metadata.call_duration_secs,
+    call_successful: analysis?.call_successful,
+    transcript_summary: analysis?.transcript_summary,
+    analysis,
+    metadata
+  });
+
+  if (Array.isArray(transcript) && transcript.length > 0) {
+    const messages = transcript.map((m: any) => ({
+      conversation_id: convId,
+      role: m.role,
+      message: m.message,
+      time_in_call_secs: m.time_in_call_secs
+    }));
+    await supabase.from('conversation_messages').insert(messages);
+  }
+
+  return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+});


### PR DESCRIPTION
## Summary
- add ElevenLabs assistant page and feature flag
- link conversations with Supabase and handle post-call webhook
- document integration and provide SQL migrations

## Testing
- `npm test`
- `npm run lint` *(fails: 307 problems)*
- `npx eslint api/elevenlabs/*.ts api/conversations/*.ts src/pages/Assistente.tsx src/components/SimulationResultDisplay.tsx src/lib/elevenlabs.ts`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f34d94038832da360a559ac1962b7