### PR TITLE
Agrupar simulações por sessão no AdminDashboard

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -23,7 +23,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { LocalSimulationService } from '@/services/localSimulationService';
+import { LocalSimulationService, type SimulacoesPorSessao } from '@/services/localSimulationService';
 import { PartnersService } from '@/services/partnersService';
 import { BlogService, type BlogPost } from '@/services/blogService';
 import { AuthService, type LoginCredentials, type AuthUser } from '@/services/authService';
@@ -31,7 +31,7 @@ import AdminLogin from '@/components/AdminLogin';
 import ImageUploader from '@/components/ImageUploader';
 import StorageStats from '@/components/StorageStats';
 import SupabaseDiagnostics from '@/components/SupabaseDiagnostics';
-import { SimulacaoData, ParceiroData } from '@/lib/supabase';
+import { ParceiroData } from '@/lib/supabase';
 import Eye from 'lucide-react/dist/esm/icons/eye';
 import Download from 'lucide-react/dist/esm/icons/download';
 import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw';
@@ -63,7 +63,7 @@ const AdminDashboard: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'simulacoes' | 'parceiros' | 'blog' | 'configuracoes'>('simulacoes');
   
   // Estados para simulações
-  const [simulacoes, setSimulacoes] = useState<SimulacaoData[]>([]);
+  const [sessionGroups, setSessionGroups] = useState<SimulacoesPorSessao[]>([]);
   const [loading, setLoading] = useState(false);
   const [filtroStatus, setFiltroStatus] = useState<string>('todos');
   const [filtroNome, setFiltroNome] = useState('');
@@ -324,8 +324,8 @@ const AdminDashboard: React.FC = () => {
   const loadSimulacoes = async () => {
     setLoading(true);
     try {
-      const data = await LocalSimulationService.getSimulacoes(1000);
-      setSimulacoes(data);
+      const data = await LocalSimulationService.getSimulacoesGroupedBySession(1000);
+      setSessionGroups(data);
       calculateStats(data);
     } catch (error) {
       console.error('Erro ao carregar simulações:', error);
@@ -334,13 +334,13 @@ const AdminDashboard: React.FC = () => {
     }
   };
 
-  const calculateStats = (data: SimulacaoData[]) => {
+  const calculateStats = (data: SimulacoesPorSessao[]) => {
     const stats = {
       total: data.length,
-      novos: data.filter(s => s.status === 'novo').length,
-      interessados: data.filter(s => s.status === 'interessado').length,
-      contatados: data.filter(s => s.status === 'contatado').length,
-      finalizados: data.filter(s => s.status === 'finalizado').length
+      novos: data.filter(s => s.simulacoes[0]?.status === 'novo').length,
+      interessados: data.filter(s => s.simulacoes[0]?.status === 'interessado').length,
+      contatados: data.filter(s => s.simulacoes[0]?.status === 'contatado').length,
+      finalizados: data.filter(s => s.simulacoes[0]?.status === 'finalizado').length
     };
     setStats(stats);
   };
@@ -357,19 +357,24 @@ const AdminDashboard: React.FC = () => {
   const exportToCSV = () => {
     const filteredData = getFilteredSimulacoes();
     const csv = [
-      'Data,Nome,Email,Telefone,Cidade,Valor Emprestimo,Valor Imovel,Parcelas,Sistema,Status',
-      ...filteredData.map(s => [
-        new Date(s.created_at!).toLocaleDateString(),
-        s.nome_completo,
-        s.email,
-        s.telefone,
-        s.cidade,
-        s.valor_emprestimo,
-        s.valor_imovel,
-        s.parcelas,
-        s.tipo_amortizacao,
-        s.status
-      ].join(','))
+      'Sessao,Quantidade,Data,Nome,Email,Telefone,Cidade,Valor Emprestimo,Valor Imovel,Parcelas,Sistema,Status',
+      ...filteredData.map(group => {
+        const s = group.simulacoes[0];
+        return [
+          group.session_id,
+          group.simulacoes.length,
+          s.created_at ? new Date(s.created_at).toLocaleDateString() : '',
+          s.nome_completo,
+          s.email,
+          s.telefone,
+          s.cidade,
+          s.valor_emprestimo,
+          s.valor_imovel,
+          s.parcelas,
+          s.tipo_amortizacao,
+          s.status
+        ].join(',');
+      })
     ].join('\n');
 
     const blob = new Blob([csv], { type: 'text/csv' });
@@ -381,9 +386,10 @@ const AdminDashboard: React.FC = () => {
   };
 
   const getFilteredSimulacoes = () => {
-    return simulacoes.filter(s => {
-      const matchStatus = filtroStatus === 'todos' || s.status === filtroStatus;
-      const matchNome = !filtroNome || s.nome_completo.toLowerCase().includes(filtroNome.toLowerCase());
+    return sessionGroups.filter(group => {
+      const sim = group.simulacoes[0];
+      const matchStatus = filtroStatus === 'todos' || sim.status === filtroStatus;
+      const matchNome = !filtroNome || sim.nome_completo.toLowerCase().includes(filtroNome.toLowerCase());
       return matchStatus && matchNome;
     });
   };
@@ -455,7 +461,7 @@ const AdminDashboard: React.FC = () => {
     return email;
   };
 
-  const filteredSimulacoes = getFilteredSimulacoes();
+  const filteredSessions = getFilteredSimulacoes();
   const filteredParceiros = getFilteredParceiros();
 
   // Mostrar loading durante verificação inicial
@@ -563,7 +569,7 @@ const AdminDashboard: React.FC = () => {
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm font-medium text-gray-600">Total de Simulações</p>
+                    <p className="text-sm font-medium text-gray-600">Total de Sessões</p>
                     <p className="text-3xl font-bold text-blue-600">{stats.total}</p>
                   </div>
                   <Users className="w-8 h-8 text-blue-600" />
@@ -650,7 +656,7 @@ const AdminDashboard: React.FC = () => {
 
           <Card>
             <CardHeader>
-              <CardTitle>Simulações ({filteredSimulacoes.length})</CardTitle>
+              <CardTitle>Sessões ({filteredSessions.length})</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="overflow-x-auto">
@@ -664,13 +670,16 @@ const AdminDashboard: React.FC = () => {
                       <TableHead>Empréstimo</TableHead>
                       <TableHead>Sistema</TableHead>
                       <TableHead>Parcelas</TableHead>
+                      <TableHead>Simulações</TableHead>
                       <TableHead>Status</TableHead>
                       <TableHead>Ações</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {filteredSimulacoes.map((simulacao) => (
-                      <TableRow key={simulacao.id}>
+                    {filteredSessions.map((session) => {
+                      const simulacao = session.simulacoes[0];
+                      return (
+                      <TableRow key={session.session_id}>
                         <TableCell className="text-sm">
                           {simulacao.created_at ? new Date(simulacao.created_at).toLocaleDateString('pt-BR') : 'Data não informada'}
                           <br />
@@ -698,9 +707,10 @@ const AdminDashboard: React.FC = () => {
                           <Badge variant="outline">{simulacao.tipo_amortizacao}</Badge>
                         </TableCell>
                         <TableCell>{simulacao.parcelas}x</TableCell>
+                        <TableCell>{session.simulacoes.length}</TableCell>
                         <TableCell>
-                          <Select 
-                            value={simulacao.status || 'novo'} 
+                          <Select
+                            value={simulacao.status || 'novo'}
                             onValueChange={(value) => updateStatus(simulacao.id!, value)}
                           >
                             <SelectTrigger className="w-[120px]">
@@ -720,12 +730,13 @@ const AdminDashboard: React.FC = () => {
                           </Button>
                         </TableCell>
                       </TableRow>
-                    ))}
+                      );
+                    })}
                   </TableBody>
                 </Table>
               </div>
 
-              {filteredSimulacoes.length === 0 && (
+              {filteredSessions.length === 0 && (
                 <div className="text-center py-8 text-gray-500">
                   Nenhuma simulação encontrada.
                 </div>

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -63,6 +63,11 @@ export interface ContactFormInput {
   referrer?: string | null;
 }
 
+export interface SimulacoesPorSessao {
+  session_id: string;
+  simulacoes: SimulacaoData[];
+}
+
 // Classe principal do serviço local
 export class LocalSimulationService {
   
@@ -635,6 +640,24 @@ export class LocalSimulationService {
       return await supabaseApi.getSimulacoes(limit);
     } catch (error) {
       console.error('❌ Erro ao buscar simulações:', error);
+      throw error;
+    }
+  }
+
+  static async getSimulacoesGroupedBySession(limit = 1000): Promise<SimulacoesPorSessao[]> {
+    try {
+      const simulacoes = await this.getSimulacoes(limit);
+      const grouped = simulacoes.reduce((map, simulacao) => {
+        const sessionId = simulacao.session_id;
+        if (!map.has(sessionId)) {
+          map.set(sessionId, []);
+        }
+        map.get(sessionId)!.push(simulacao);
+        return map;
+      }, new Map<string, SimulacaoData[]>());
+      return Array.from(grouped.entries()).map(([session_id, simulacoes]) => ({ session_id, simulacoes }));
+    } catch (error) {
+      console.error('❌ Erro ao agrupar simulações por sessão:', error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- adicionar `getSimulacoesGroupedBySession` no serviço local para agrupar por `session_id`
- renderizar sessões agrupadas no AdminDashboard e contabilizar simulações por sessão
- ajustar exportação CSV para refletir a estrutura agrupada

## Testing
- `npm test`
- `npm run lint` *(fails: 298 problems (51 errors, 247 warnings))*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a3344e41b0832d92dbc17f3f786357