### PR TITLE
feat: group simulations by session

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -23,7 +23,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { LocalSimulationService, type SimulationWithJourney } from '@/services/localSimulationService';
+import { LocalSimulationService, type SessionGroupWithJourney } from '@/services/localSimulationService';
 
 import { PartnersService } from '@/services/partnersService';
 import { BlogService, type BlogPost } from '@/services/blogService';
@@ -63,8 +63,8 @@ const AdminDashboard: React.FC = () => {
 
   const [activeTab, setActiveTab] = useState<'simulacoes' | 'parceiros' | 'blog' | 'configuracoes'>('simulacoes');
   
-  // Estados para simulações
-  const [simulacoes, setSimulacoes] = useState<SimulationWithJourney[]>([]);
+  // Estados para simulações agrupadas por sessão
+  const [sessionGroups, setSessionGroups] = useState<SessionGroupWithJourney[]>([]);
 
   const [loading, setLoading] = useState(false);
   const [filtroStatus, setFiltroStatus] = useState<string>('todos');
@@ -327,8 +327,7 @@ const AdminDashboard: React.FC = () => {
     setLoading(true);
     try {
       const data = await LocalSimulationService.getSimulacoesAgrupadas(1000);
-      setSimulacoes(data);
-
+      setSessionGroups(data);
       calculateStats(data);
     } catch (error) {
       console.error('Erro ao carregar simulações:', error);
@@ -337,7 +336,7 @@ const AdminDashboard: React.FC = () => {
     }
   };
 
-  const calculateStats = (data: SimulationWithJourney[]) => {
+  const calculateStats = (data: SessionGroupWithJourney[]) => {
 
     const stats = {
       total: data.length,
@@ -359,14 +358,14 @@ const AdminDashboard: React.FC = () => {
   };
 
   const exportToCSV = () => {
-    const filteredData = getFilteredSimulacoes();
+    const filteredData = getFilteredSessions();
     const csv = [
       'Sessao,Quantidade,Data,Nome,Email,Telefone,Cidade,Valor Emprestimo,Valor Imovel,Parcelas,Sistema,Status',
       ...filteredData.map(group => {
         const s = group.simulacoes[0];
         return [
           group.session_id,
-          group.simulacoes.length,
+          group.total_simulacoes,
           s.created_at ? new Date(s.created_at).toLocaleDateString() : '',
           s.nome_completo,
           s.email,
@@ -389,7 +388,7 @@ const AdminDashboard: React.FC = () => {
     a.click();
   };
 
-  const getFilteredSimulacoes = () => {
+  const getFilteredSessions = () => {
     return sessionGroups.filter(group => {
       const sim = group.simulacoes[0];
       const matchStatus = filtroStatus === 'todos' || sim.status === filtroStatus;
@@ -465,7 +464,7 @@ const AdminDashboard: React.FC = () => {
     return email;
   };
 
-  const filteredSessions = getFilteredSimulacoes();
+  const filteredSessions = getFilteredSessions();
   const filteredParceiros = getFilteredParceiros();
 
   // Mostrar loading durante verificação inicial
@@ -701,28 +700,28 @@ const AdminDashboard: React.FC = () => {
                         </TableCell>
                         <TableCell className="text-xs">
                           <div>
-                            {[simulacao.utm_source, simulacao.utm_medium, simulacao.utm_campaign]
+                            {[session.utm_source, session.utm_medium, session.utm_campaign]
                               .filter(Boolean)
                               .join(' / ') || '-'}
                           </div>
-                          {simulacao.landing_page && (
+                          {session.landing_page && (
                             <a
-                              href={simulacao.landing_page}
+                              href={session.landing_page}
                               target="_blank"
                               rel="noopener noreferrer"
                               className="text-blue-600 hover:underline break-all"
                             >
-                              {simulacao.landing_page}
+                              {session.landing_page}
                             </a>
                           )}
-                          {!simulacao.landing_page && simulacao.referrer && (
+                          {!session.landing_page && session.referrer && (
                             <a
-                              href={simulacao.referrer}
+                              href={session.referrer}
                               target="_blank"
                               rel="noopener noreferrer"
                               className="text-blue-600 hover:underline break-all"
                             >
-                              {simulacao.referrer}
+                              {session.referrer}
                             </a>
                           )}
                         </TableCell>
@@ -739,7 +738,7 @@ const AdminDashboard: React.FC = () => {
                           <Badge variant="outline">{simulacao.tipo_amortizacao}</Badge>
                         </TableCell>
                         <TableCell>{simulacao.parcelas}x</TableCell>
-                        <TableCell>{session.simulacoes.length}</TableCell>
+                        <TableCell>{session.total_simulacoes}</TableCell>
                         <TableCell>
                           <Select
                             value={simulacao.status || 'novo'}

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -63,14 +63,17 @@ export interface ContactFormInput {
   referrer?: string | null;
 }
 
-export interface SimulationWithJourney extends SimulacaoData {
+export interface SessionGroupWithJourney {
+  session_id: string;
+  simulacoes: SimulacaoData[];
+  total_simulacoes: number;
   utm_source?: string | null;
   utm_medium?: string | null;
   utm_campaign?: string | null;
+  utm_term?: string | null;
+  utm_content?: string | null;
   landing_page?: string | null;
   referrer?: string | null;
-  total_simulacoes?: number;
-
 }
 
 // Classe principal do serviço local
@@ -649,7 +652,7 @@ export class LocalSimulationService {
     }
   }
 
-  static async getSimulacoesAgrupadas(limit = 1000): Promise<SimulationWithJourney[]> {
+  static async getSimulacoesAgrupadas(limit = 1000): Promise<SessionGroupWithJourney[]> {
     try {
       const simulacoes = await supabaseApi.getSimulacoes(limit);
 
@@ -676,17 +679,19 @@ export class LocalSimulationService {
         if (j?.session_id) journeyMap.set(j.session_id, j);
       }
 
-      const result: SimulationWithJourney[] = [];
+      const result: SessionGroupWithJourney[] = [];
       for (const [sessionId, sims] of grouped.entries()) {
-        const sorted = sims.sort((a, b) => new Date(b.created_at || '').getTime() - new Date(a.created_at || '').getTime());
-        const latest = sorted[0];
+        sims.sort((a, b) => new Date(b.created_at || '').getTime() - new Date(a.created_at || '').getTime());
         const journey = journeyMap.get(sessionId);
         result.push({
-          ...latest,
+          session_id: sessionId,
+          simulacoes: sims,
           total_simulacoes: sims.length,
           utm_source: journey?.utm_source ?? null,
           utm_medium: journey?.utm_medium ?? null,
           utm_campaign: journey?.utm_campaign ?? null,
+          utm_term: journey?.utm_term ?? null,
+          utm_content: journey?.utm_content ?? null,
           landing_page: journey?.landing_page ?? null,
           referrer: journey?.referrer ?? null,
         });


### PR DESCRIPTION
## Summary
- return grouped sessions with journey metadata from `getSimulacoesAgrupadas`
- add `SessionGroupWithJourney` type
- update AdminDashboard to use session groups and session-level UTM data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33a7a0abc832d86cf10805d8a39cf