### PR TITLE
Send simulation data to secondary webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ VITE_PLOOMES_USER_KEY=your_ploomes_user_key_here
 # Webhook Configuration
 # URL para onde os dados da simulação finalizada serão enviados
 VITE_WEBHOOK_URL=http://localhost:5678/webhook/simulacao
+# URL secundária opcional para enviar simulações para outro webhook
+VITE_WEBHOOK_SECONDARY_URL=https://libra-credito-n8n.usybav.easypanel.host/webhook/a85ec971-31b6-4fd8-b4f5-c3c461138e46
 
 # Analytics/Tracking
 VITE_GA_TRACKING_ID=your_google_analytics_id_here

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ cp .env.example .env
 # - `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY`
 #   - **Sem valores válidos a aplicação não inicializa**
 # - `VITE_WEBHOOK_URL` (opcional - para webhook de simulações)
+# - `VITE_WEBHOOK_SECONDARY_URL` (opcional - segundo endpoint para receber dados da simulação)
 # - Outras conforme necessário
 ```
 


### PR DESCRIPTION
## Summary
- send simulation payload to primary and optional secondary webhook endpoints
- document optional `VITE_WEBHOOK_SECONDARY_URL` environment variable

## Testing
- `npm test`
- `npm run lint` *(fails: 43 errors, 246 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a71098ce2c832d99808d33749803c7