### PR TITLE
Remove email masking in Admin dashboard

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -460,14 +460,6 @@ const AdminDashboard: React.FC = () => {
     return phone;
   };
 
-  const formatEmail = (email: string) => {
-    const [user, domain] = email.split('@');
-    if (user.length > 3) {
-      return user.substring(0, 3) + '***@' + domain;
-    }
-    return email;
-  };
-
   const filteredSessions = getFilteredSessions();
 
   const filteredParceiros = getFilteredParceiros();
@@ -700,7 +692,7 @@ const AdminDashboard: React.FC = () => {
                           {simulacao.nome_completo}
                         </TableCell>
                         <TableCell className="text-sm">
-                          <div>{formatEmail(simulacao.email)}</div>
+                          <div>{simulacao.email}</div>
                           <div className="text-gray-500">{formatPhone(simulacao.telefone)}</div>
                         </TableCell>
                         <TableCell className="text-xs">
@@ -909,7 +901,7 @@ const AdminDashboard: React.FC = () => {
                           {parceiro.nome}
                         </TableCell>
                         <TableCell className="text-sm">
-                          <div>{formatEmail(parceiro.email)}</div>
+                          <div>{parceiro.email}</div>
                           <div className="text-gray-500">{formatPhone(parceiro.telefone)}</div>
                         </TableCell>
                         <TableCell>{parceiro.cidade}</TableCell>


### PR DESCRIPTION
## Summary
- remove email masking helper
- show unmasked email addresses in simulation and partner tables

## Testing
- `npm run lint` *(fails: 43 errors, 246 warnings)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8d902f0c832db50ef76c3cb34008