### PR TITLE
Shorten origin URLs in admin dashboard

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -468,6 +468,15 @@ const AdminDashboard: React.FC = () => {
     return email;
   };
 
+  const shortenUrl = (url: string) => {
+    try {
+      const { hostname, pathname } = new URL(url);
+      return `${hostname}${pathname}`;
+    } catch {
+      return url;
+    }
+  };
+
   const filteredSessions = getFilteredSessions();
 
   const filteredParceiros = getFilteredParceiros();
@@ -715,8 +724,9 @@ const AdminDashboard: React.FC = () => {
                               target="_blank"
                               rel="noopener noreferrer"
                               className="text-blue-600 hover:underline break-all"
+                              title={session.landing_page}
                             >
-                              {session.landing_page}
+                              {shortenUrl(session.landing_page)}
                             </a>
                           )}
                           {!session.landing_page && session.referrer && (
@@ -725,8 +735,9 @@ const AdminDashboard: React.FC = () => {
                               target="_blank"
                               rel="noopener noreferrer"
                               className="text-blue-600 hover:underline break-all"
+                              title={session.referrer}
                             >
-                              {session.referrer}
+                              {shortenUrl(session.referrer)}
                             </a>
                           )}
                         </TableCell>


### PR DESCRIPTION
## Summary
- add shortenUrl helper to condense URLs
- display shortened origin links with full URL tooltip

## Testing
- `npm test`
- `npm run lint` *(fails: 43 errors, 246 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8da4112c832da934db723c120a84