### PR TITLE
feat: track persistent visitor id

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -41,7 +41,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
   buttonClassName = '',
   compact = false
 }) => {
-  const { sessionId, getJourneyData } = useUserJourney();
+  const { sessionId, visitorId, getJourneyData } = useUserJourney();
   const navigate = useNavigate();
   const [nome, setNome] = useState('');
   const [email, setEmail] = useState('');
@@ -148,6 +148,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
       await LocalSimulationService.processContact({
         simulationId: simulationResult.id,
         sessionId,
+        visitorId,
         nomeCompleto: nome,
         email,
         telefone,

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -61,7 +61,7 @@ import { formatBRL, norm } from '@/utils/formatters';
 import { toast } from '@/components/ui/use-toast';
 
 const SimulationForm: React.FC = () => {
-  const { sessionId, trackSimulation } = useUserJourney();
+  const { sessionId, visitorId, trackSimulation } = useUserJourney();
   const isMobile = useIsMobile();
   const [emprestimo, setEmprestimo] = useState('');
   const [garantia, setGarantia] = useState('');
@@ -153,6 +153,7 @@ const SimulationForm: React.FC = () => {
       // Preparar dados para o serviço (sem dados pessoais ainda)
       const simulationInput = {
         sessionId,
+        visitorId,
         nomeCompleto: 'Lead Anônimo', // Temporário até preenchimento do contato
         email: 'nao-informado@temp.com',
         telefone: '(00) 00000-0000',
@@ -270,6 +271,7 @@ const SimulationForm: React.FC = () => {
       try {
         const simulationInput = {
           sessionId,
+          visitorId,
           nomeCompleto: 'Lead Anônimo',
           email: 'nao-informado@temp.com',
           telefone: '(00) 00000-0000',
@@ -366,6 +368,7 @@ const SimulationForm: React.FC = () => {
       try {
         const simulationInput = {
           sessionId,
+          visitorId,
           nomeCompleto: 'Lead Anônimo',
           email: 'nao-informado@temp.com',
           telefone: '(00) 00000-0000',

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -11,6 +11,7 @@ const mockGetJourneyData = vi.fn();
 vi.mock('@/hooks/useUserJourney', () => ({
   useUserJourney: () => ({
     sessionId: 'session123',
+    visitorId: 'visitor123',
     getJourneyData: mockGetJourneyData
   })
 }));

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -41,6 +41,7 @@ if (typeof window !== 'undefined' && import.meta.env.DEV) {
 export interface SimulacaoData {
   id?: string;
   session_id: string;
+  visitor_id?: string;
   nome_completo: string;
   email: string;
   telefone: string;
@@ -81,6 +82,7 @@ export interface ParceiroData {
 export interface UserJourneyData {
   id?: string;
   session_id: string;
+  visitor_id?: string;
   utm_source?: string;
   utm_medium?: string;
   utm_campaign?: string;

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -20,6 +20,7 @@ import { supabaseApi, SimulacaoData, supabase } from '@/lib/supabase';
 // Reutilizar interfaces do serviço original
 export interface SimulationInput {
   sessionId: string;
+  visitorId: string;
   nomeCompleto: string;
   email: string;
   telefone: string;
@@ -44,11 +45,13 @@ export interface SimulationResult {
   valorImovel: number;
   cidade: string;
   sessionId: string;
+  visitorId?: string;
 }
 
 export interface ContactFormInput {
   simulationId: string;
   sessionId: string;
+  visitorId: string;
   nomeCompleto: string;
   email: string;
   telefone: string;
@@ -170,7 +173,8 @@ export class LocalSimulationService {
         valorEmprestimo: input.valorEmprestimo,
         valorImovel: input.valorImovel,
         cidade: input.cidade,
-        sessionId: input.sessionId
+        sessionId: input.sessionId,
+        visitorId: input.visitorId
       };
 
       // 7. Salvar no Supabase apenas se temos dados reais (não salvar placeholders)
@@ -186,6 +190,7 @@ export class LocalSimulationService {
         if (hasRealContactData) {
           const supabaseData = {
             session_id: input.sessionId,
+            visitor_id: input.visitorId,
             nome_completo: input.nomeCompleto,
             email: input.email,
             telefone: input.telefone,
@@ -405,7 +410,8 @@ export class LocalSimulationService {
             email: input.email.trim().toLowerCase(),
             telefone: input.telefone.replace(/\D/g, ''), // Limpar telefone
             imovel_proprio: input.imovelProprio as 'proprio' | 'terceiro', // Garantir tipo correto
-            status: 'interessado' // Status após contato para compatibilidade com AdminDashboard
+            status: 'interessado', // Status após contato para compatibilidade com AdminDashboard
+            visitor_id: input.visitorId
           };
           
           // Validar dados antes da atualização
@@ -471,6 +477,7 @@ export class LocalSimulationService {
               // Criar registro completo no Supabase
               const createData = {
                 session_id: input.sessionId,
+                visitor_id: input.visitorId,
                 nome_completo: updateData.nome_completo,
                 email: updateData.email,
                 telefone: updateData.telefone,


### PR DESCRIPTION
## Summary
- add persistent `visitorId` stored in localStorage and exposed by `useUserJourney`
- send `visitorId` to Supabase in simulation and contact workflows
- wire `visitorId` through forms and service types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac8d4583ac832d8cb39fb832c9977a