### PR TITLE
feat: track visitor id in simulations

### DIFF
--- a/database/sql/supabase-add-visitor-id.sql
+++ b/database/sql/supabase-add-visitor-id.sql
@@ -1,0 +1,25 @@
+-- =====================================================
+-- ADICIONAR COLUNA visitor_id - LIBRA CRÉDITO
+-- =====================================================
+-- Este script adiciona a coluna visitor_id na tabela simulacoes
+-- e cria um índice para otimizar buscas.
+
+-- Verificar e adicionar coluna visitor_id se não existir
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'simulacoes'
+        AND column_name = 'visitor_id'
+        AND table_schema = 'public'
+    ) THEN
+        ALTER TABLE public.simulacoes ADD COLUMN visitor_id UUID;
+        RAISE NOTICE 'Coluna visitor_id adicionada à tabela simulacoes';
+    ELSE
+        RAISE NOTICE 'Coluna visitor_id já existe na tabela simulacoes';
+    END IF;
+END
+$$;
+
+-- Criar índice para visitor_id
+CREATE INDEX IF NOT EXISTS idx_simulacoes_visitor_id ON public.simulacoes(visitor_id);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -41,6 +41,7 @@ if (typeof window !== 'undefined' && import.meta.env.DEV) {
 export interface SimulacaoData {
   id?: string;
   session_id: string;
+  visitor_id?: string;
   nome_completo: string;
   email: string;
   telefone: string;
@@ -178,11 +179,11 @@ export const supabaseApi = {
   // Teste de conexão
   async testConnection() {
     try {
-      const { data, error } = await supabase
+      const { error } = await supabase
         .from('parceiros')
         .select('*')
         .limit(1);
-      
+
       if (error) {
         // Log silencioso para evitar poluição do console
         if (import.meta.env.DEV) {
@@ -452,7 +453,7 @@ export const supabaseApi = {
     const finalFileName = fileName || `${Date.now()}-${Math.random().toString(36).substr(2, 9)}.${fileExt}`;
     const filePath = `${new Date().getFullYear()}/${String(new Date().getMonth() + 1).padStart(2, '0')}/${finalFileName}`;
 
-    const { data, error } = await supabase.storage
+    const { error } = await supabase.storage
       .from('blog-images')
       .upload(filePath, file, {
         cacheControl: '3600',

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -20,6 +20,7 @@ import { supabaseApi, SimulacaoData, supabase } from '@/lib/supabase';
 // Reutilizar interfaces do serviço original
 export interface SimulationInput {
   sessionId: string;
+  visitorId?: string;
   nomeCompleto: string;
   email: string;
   telefone: string;
@@ -44,11 +45,13 @@ export interface SimulationResult {
   valorImovel: number;
   cidade: string;
   sessionId: string;
+  visitorId?: string;
 }
 
 export interface ContactFormInput {
   simulationId: string;
   sessionId: string;
+  visitorId?: string;
   nomeCompleto: string;
   email: string;
   telefone: string;
@@ -170,7 +173,8 @@ export class LocalSimulationService {
         valorEmprestimo: input.valorEmprestimo,
         valorImovel: input.valorImovel,
         cidade: input.cidade,
-        sessionId: input.sessionId
+        sessionId: input.sessionId,
+        visitorId: input.visitorId
       };
 
       // 7. Salvar no Supabase apenas se temos dados reais (não salvar placeholders)
@@ -186,6 +190,7 @@ export class LocalSimulationService {
         if (hasRealContactData) {
           const supabaseData = {
             session_id: input.sessionId,
+            visitor_id: input.visitorId || null,
             nome_completo: input.nomeCompleto,
             email: input.email,
             telefone: input.telefone,
@@ -203,6 +208,7 @@ export class LocalSimulationService {
 
           console.log('💾 Tentando salvar simulação no Supabase:', {
             session_id: supabaseData.session_id,
+            visitor_id: supabaseData.visitor_id,
             cidade: supabaseData.cidade,
             valor_emprestimo: supabaseData.valor_emprestimo,
             original_local_id: simulationId
@@ -305,7 +311,7 @@ export class LocalSimulationService {
               console.log('📋 Tentando buscar todas as simulações para debug...');
               const { data: allData } = await supabase
                 .from('simulacoes')
-                .select('id, session_id, created_at')
+                .select('id, session_id, visitor_id, created_at')
                 .eq('session_id', input.sessionId)
                 .order('created_at', { ascending: false });
               console.log('📋 Simulações encontradas:', allData);
@@ -443,7 +449,7 @@ export class LocalSimulationService {
             // Para IDs locais, buscar pela session_id mais recente
             const { data: searchResults, error: selectError } = await supabase
               .from('simulacoes')
-              .select('id, nome_completo, email, telefone, imovel_proprio, status, session_id, created_at')
+              .select('id, nome_completo, email, telefone, imovel_proprio, status, session_id, visitor_id, created_at')
               .eq('session_id', input.sessionId)
               .order('created_at', { ascending: false })
               .limit(1);
@@ -471,6 +477,7 @@ export class LocalSimulationService {
               // Criar registro completo no Supabase
               const createData = {
                 session_id: input.sessionId,
+                visitor_id: input.visitorId || null,
                 nome_completo: updateData.nome_completo,
                 email: updateData.email,
                 telefone: updateData.telefone,
@@ -519,7 +526,7 @@ export class LocalSimulationService {
             // Para IDs do Supabase, buscar e atualizar normalmente
             const { data: searchData, error: selectError } = await supabase
               .from('simulacoes')
-              .select('id, nome_completo, email, telefone, imovel_proprio, status')
+              .select('id, nome_completo, email, telefone, imovel_proprio, status, visitor_id')
               .eq('id', input.simulationId)
               .single();
               


### PR DESCRIPTION
## Summary
- add SQL migration for `visitor_id` column and index on `simulacoes`
- extend Supabase types and local simulation service to handle `visitor_id`
- include `visitor_id` in Supabase queries and inserts

## Testing
- `npm test`
- `npm run lint` *(fails: multiple existing errors)*
- `npx eslint src/lib/supabase.ts src/services/localSimulationService.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac8d49ba10832da27d8cc301faef6c