### PR TITLE
feat: add scheduled cleanup for anonymous visitors

### DIFF
--- a/database/sql/supabase-schedule-anonymous-cleanup.sql
+++ b/database/sql/supabase-schedule-anonymous-cleanup.sql
@@ -1,0 +1,13 @@
+-- Schedules daily cleanup of visitor records lacking contact data.
+-- Requires pg_cron extension enabled in the database.
+select cron.schedule(
+  'daily_anonymous_visitor_cleanup',
+  '0 3 * * *',
+  $$
+    delete from leads
+    where visitor_id is not null
+      and email is null
+      and phone is null
+      and created_at < now() - interval '30 days';
+  $$
+);

--- a/docs/CRON_VISITOR_CLEANUP.md
+++ b/docs/CRON_VISITOR_CLEANUP.md
@@ -1,0 +1,9 @@
+# Cron job for anonymous visitor cleanup
+
+An edge function `cleanup-anonymous-visitors` removes records that only have a `visitor_id` and no contact details after a retention period.
+
+## Schedule
+
+Run the SQL script `database/sql/supabase-schedule-anonymous-cleanup.sql` in your project to register a daily job. The job executes at 03:00 UTC and purges entries older than 30 days.
+
+Adjust the schedule or retention days by editing the script or setting the `ANON_VISITOR_RETENTION_DAYS` environment variable used by the edge function.

--- a/supabase/functions/cleanup-anonymous-visitors/index.ts
+++ b/supabase/functions/cleanup-anonymous-visitors/index.ts
@@ -1,0 +1,30 @@
+import { createClient } from '@supabase/supabase-js'
+
+// Edge function that removes visitor records without contact info after N days
+Deno.serve(async () => {
+  const days = Number(Deno.env.get('ANON_VISITOR_RETENTION_DAYS') ?? '30')
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+
+  const client = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false }
+  })
+
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - days)
+
+  const { error, count } = await client
+    .from('leads')
+    .delete({ count: 'exact' })
+    .not('visitor_id', 'is', null)
+    .is('email', null)
+    .is('phone', null)
+    .lt('created_at', cutoff.toISOString())
+
+  if (error) {
+    console.error('cleanup failed', error)
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 })
+  }
+
+  return new Response(JSON.stringify({ deleted: count }), { status: 200 })
+})


### PR DESCRIPTION
## Summary
- add edge function to remove visitor records without contact info
- schedule daily cleanup job in SQL
- document anonymous visitor purge cron setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac8d552634832da162ac2a86214aab