### PR TITLE
feat: improve BRL formatting

### DIFF
--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { norm, formatBRL } from '../formatters';
+import { norm, formatBRL, formatBRLInput } from '../formatters';
+
+const NBSP = '\u00A0';
 
 describe('norm', () => {
   it('handles empty string', () => {
@@ -27,16 +29,23 @@ describe('formatBRL', () => {
   });
 
   it('formats numbers with separators correctly', () => {
-    expect(formatBRL('1234567')).toBe('R$ 1.234.567');
-    expect(formatBRL('1.234.567')).toBe('R$ 1.234.567');
+    expect(formatBRL('1234567')).toBe(`R$${NBSP}1.234.567,00`);
+    expect(formatBRL('1.234.567')).toBe(`R$${NBSP}1.234.567,00`);
   });
 
   it('strips non numeric characters before formatting', () => {
-    expect(formatBRL('R$ 1.234,56')).toBe('R$ 123.456');
-    expect(formatBRL('abc123456')).toBe('R$ 123.456');
+    expect(formatBRL('R$ 1.234,56')).toBe(`R$${NBSP}123.456,00`);
+    expect(formatBRL('abc123456')).toBe(`R$${NBSP}123.456,00`);
   });
 
   it('handles values with surrounding spaces', () => {
-    expect(formatBRL(' 1234567 ')).toBe('R$ 1.234.567');
+    expect(formatBRL(' 1234567 ')).toBe(`R$${NBSP}1.234.567,00`);
+  });
+});
+
+describe('formatBRLInput', () => {
+  it('formats input preserving cents', () => {
+    expect(formatBRLInput('1')).toBe('0,01');
+    expect(formatBRLInput('123456')).toBe('1.234,56');
   });
 });

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -7,17 +7,22 @@ export const norm = (s: string) =>
 export const formatBRL = (value: string) => {
   const num = value.replace(/\D/g, '');
   if (!num) return '';
-  
-  const formatted = Number(num).toLocaleString('pt-BR');
-  return `R$ ${formatted}`;
+
+  return Number(num).toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+  });
 };
 
 // Função para formatar valores com formatação brasileira em tempo real
 export const formatBRLInput = (value: string) => {
   const num = value.replace(/\D/g, '');
   if (!num) return '';
-  
-  // Formatar com pontos para milhares
-  const formatted = Number(num).toLocaleString('pt-BR');
-  return formatted;
+
+  const amount = Number(num) / 100;
+  return amount.toLocaleString('pt-BR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 };


### PR DESCRIPTION
## Summary
- use Intl toLocaleString for BRL currency formatting
- preserve cents in formatBRLInput
- update tests for new BRL formatting

## Testing
- `npm test`
- `npm run lint` *(fails: 288 problems, 42 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9c4de924832db8849ad916049c81