### PR TITLE
refactor: use currency formatter in local simulation

### DIFF
--- a/src/components/LocalSimulationForm.tsx
+++ b/src/components/LocalSimulationForm.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import type { CityValidationResult } from '@/utils/cityLtvService';
-import { formatBRL, norm } from '@/utils/formatters';
+import { formatBRL, formatCurrency, norm } from '@/utils/formatters';
 import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
 import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
 import XCircle from 'lucide-react/dist/esm/icons/x-circle';
@@ -262,7 +262,7 @@ const LocalSimulationForm: React.FC = () => {
                     onClick={adjustLoanAmount}
                     className="text-xs"
                   >
-                    Ajustar para R$ {validation.suggestedLoanAmount.toLocaleString('pt-BR')}
+                    Ajustar para {formatCurrency(validation.suggestedLoanAmount)}
                   </Button>
                 </div>
               )}
@@ -425,7 +425,7 @@ const LocalSimulationForm: React.FC = () => {
                     </div>
                     <div>
                       <span className="text-gray-600">Empréstimo:</span>
-                      <p className="font-medium">R$ {resultado.valorEmprestimo.toLocaleString('pt-BR')}</p>
+                      <p className="font-medium">{formatCurrency(resultado.valorEmprestimo)}</p>
                     </div>
                     <div>
                       <span className="text-gray-600">Taxa Juros:</span>
@@ -443,10 +443,7 @@ const LocalSimulationForm: React.FC = () => {
                     <h4 className="font-medium text-blue-800 mb-1">Sistema PRICE</h4>
                     <p className="text-sm text-blue-600 mb-2">Parcelas fixas</p>
                     <p className="text-xl font-bold text-blue-800">
-                      R$ {resultado.parcelaPrice.toLocaleString('pt-BR', { 
-                        minimumFractionDigits: 2, 
-                        maximumFractionDigits: 2 
-                      })}
+                      {formatCurrency(resultado.parcelaPrice)}
                     </p>
                   </div>
 
@@ -458,19 +455,13 @@ const LocalSimulationForm: React.FC = () => {
                       <div>
                         <p className="text-xs text-green-600">1ª parcela</p>
                         <p className="text-lg font-bold text-green-800">
-                          R$ {resultado.parcelaSac.inicial.toLocaleString('pt-BR', { 
-                            minimumFractionDigits: 2, 
-                            maximumFractionDigits: 2 
-                          })}
+                          {formatCurrency(resultado.parcelaSac.inicial)}
                         </p>
                       </div>
                       <div className="text-right">
                         <p className="text-xs text-green-600">Última parcela</p>
                         <p className="text-lg font-bold text-green-800">
-                          R$ {resultado.parcelaSac.final.toLocaleString('pt-BR', { 
-                            minimumFractionDigits: 2, 
-                            maximumFractionDigits: 2 
-                          })}
+                          {formatCurrency(resultado.parcelaSac.final)}
                         </p>
                       </div>
                     </div>

--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { norm, formatBRL } from '../formatters';
+import { norm, formatBRL, formatCurrency } from '../formatters';
 
 describe('norm', () => {
   it('handles empty string', () => {
@@ -38,5 +38,11 @@ describe('formatBRL', () => {
 
   it('handles values with surrounding spaces', () => {
     expect(formatBRL(' 1234567 ')).toBe('R$ 1.234.567');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('formats number to Brazilian currency with cents', () => {
+    expect(formatCurrency(1234.56)).toBe('R$ 1.234,56');
   });
 });

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -7,7 +7,7 @@ export const norm = (s: string) =>
 export const formatBRL = (value: string) => {
   const num = value.replace(/\D/g, '');
   if (!num) return '';
-  
+
   const formatted = Number(num).toLocaleString('pt-BR');
   return `R$ ${formatted}`;
 };
@@ -16,8 +16,15 @@ export const formatBRL = (value: string) => {
 export const formatBRLInput = (value: string) => {
   const num = value.replace(/\D/g, '');
   if (!num) return '';
-  
+
   // Formatar com pontos para milhares
   const formatted = Number(num).toLocaleString('pt-BR');
   return formatted;
 };
+
+// Função para formatar números em moeda brasileira com duas casas decimais
+export const formatCurrency = (value: number) =>
+  `R$ ${value.toLocaleString('pt-BR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })}`;


### PR DESCRIPTION
## Summary
- add reusable `formatCurrency` helper for BRL formatting
- use currency formatter in `LocalSimulationForm`
- cover currency formatter with tests

## Testing
- `npm test`
- `npm run lint` *(fails: 42 errors, 246 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9c4fccb4832db7ecbbda0f8d519d