### PR TITLE
fix: limita casas decimais nos resultados da simulação

### DIFF
--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -149,7 +149,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
                 <div className="bg-green-100 rounded-lg p-3 border border-green-200">
                   <div className="text-xs font-medium mb-1">1ª Parcela</div>
                   <div className="text-lg font-bold whitespace-nowrap">
-                    R$ {primeiraParcela.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                    R$ {primeiraParcela.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                   </div>
                   <div className="text-xs text-gray-500 mt-1">Maior valor</div>
                 </div>
@@ -157,7 +157,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
                 <div className="bg-green-100 rounded-lg p-3 border border-green-200">
                   <div className="text-xs font-medium mb-1">Última Parcela</div>
                   <div className="text-lg font-bold whitespace-nowrap">
-                    R$ {ultimaParcela?.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                    R$ {ultimaParcela?.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                   </div>
                   <div className="text-xs text-gray-500 mt-1">Menor valor</div>
                 </div>
@@ -167,7 +167,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
             <div className="text-center">
               <div className="text-xs mb-1">Parcela Fixa (PRICE)</div>
               <div className="text-2xl font-bold whitespace-nowrap">
-                R$ {valor.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                R$ {valor.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
               </div>
             </div>
           )}
@@ -182,7 +182,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
             </TooltipInfo>
           </div>
           <div className="text-lg font-bold whitespace-nowrap">
-            R$ {rendaMinima.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+            R$ {rendaMinima.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
           </div>
           {amortizacao === 'SAC' && (
             <div className="text-xs mt-2">
@@ -250,7 +250,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
               <div className="text-center bg-green-100 rounded-lg p-1 border border-green-200">
                 <div className="text-xs font-medium mb-1">1ª Parcela</div>
                 <div className="text-lg font-bold">
-                  R$ {primeiraParcela.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                  R$ {primeiraParcela.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                 </div>
                 <div className="text-xs">Maior valor</div>
               </div>
@@ -258,7 +258,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
               <div className="text-center bg-green-100 rounded-lg p-1 border border-green-200">
                 <div className="text-xs font-medium mb-1">Última Parcela</div>
                 <div className="text-base font-bold">
-                  R$ {ultimaParcela?.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                  R$ {ultimaParcela?.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                 </div>
                 <div className="text-xs">Menor valor</div>
               </div>
@@ -271,7 +271,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
                   </TooltipInfo>
                 </div>
                 <div className="text-base font-bold">
-                  R$ {rendaMinima.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                  R$ {rendaMinima.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                 </div>
                 <div className="mt-1 text-xs">
                   <SwitchPriceTip onSwitchToPrice={onSwitchToPrice} />
@@ -285,7 +285,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
 
               <div className="text-xs mb-1">Parcela Fixa (PRICE)</div>
               <div className="text-xl lg:text-2xl font-bold">
-                R$ {valor.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                R$ {valor.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
               </div>
             </div>
             <div className="bg-green-50 rounded-lg p-3 text-center relative">
@@ -296,7 +296,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
                 </TooltipInfo>
               </div>
               <div className="text-xl lg:text-2xl font-bold">
-                R$ {rendaMinima.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                R$ {rendaMinima.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Ajusta `SimulationResultDisplay` para exibir apenas duas casas decimais na última parcela e na renda necessária

## Testing
- `npm test` *(fails: formatCurrency is not defined)*
- `npm run lint` *(fails: 288 problems (42 errors, 246 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68ac9f328008832d90d8921a364a59df