### PR TITLE
refactor: simplify BRL formatting

### DIFF
--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -6,8 +6,6 @@ import {
   formatCurrency,
 } from '../formatters';
 
-const NBSP = '\u00A0';
-
 
 describe('norm', () => {
   it('handles empty string', () => {
@@ -35,17 +33,17 @@ describe('formatBRL', () => {
   });
 
   it('formats numbers with separators correctly', () => {
-    expect(formatBRL('1234567')).toBe(`R$${NBSP}1.234.567,00`);
-    expect(formatBRL('1.234.567')).toBe(`R$${NBSP}1.234.567,00`);
+    expect(formatBRL('1234567')).toBe('R$ 1.234.567');
+    expect(formatBRL('1.234.567')).toBe('R$ 1.234.567');
   });
 
   it('strips non numeric characters before formatting', () => {
-    expect(formatBRL('R$ 1.234,56')).toBe(`R$${NBSP}123.456,00`);
-    expect(formatBRL('abc123456')).toBe(`R$${NBSP}123.456,00`);
+    expect(formatBRL('R$ 1.234,56')).toBe('R$ 123.456');
+    expect(formatBRL('abc123456')).toBe('R$ 123.456');
   });
 
   it('handles values with surrounding spaces', () => {
-    expect(formatBRL(' 1234567 ')).toBe(`R$${NBSP}1.234.567,00`);
+    expect(formatBRL(' 1234567 ')).toBe('R$ 1.234.567');
   });
 });
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -7,13 +7,7 @@ export const norm = (s: string) =>
 export const formatBRL = (value: string) => {
   const num = value.replace(/\D/g, '');
   if (!num) return '';
-
-  return Number(num).toLocaleString('pt-BR', {
-    style: 'currency',
-    currency: 'BRL',
-    minimumFractionDigits: 2,
-  });
-
+  return `R$ ${Number(num).toLocaleString('pt-BR')}`;
 };
 
 // Função para formatar valores com formatação brasileira em tempo real


### PR DESCRIPTION
## Summary
- simplify BRL formatter to manually prefix `R$` without forced decimals
- adjust related tests to match new BRL formatting

## Testing
- `npm test`
- `npm run lint` *(fails: ✖ 288 problems (42 errors, 246 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_68acaa5d0a48832dbcd1919d7205e87e