### PR TITLE
Filter admin simulations and restore origin data

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -328,9 +328,17 @@ const AdminDashboard: React.FC = () => {
     setLoading(true);
     try {
       const data = await LocalSimulationService.getSimulacoesAgrupadas(1000);
-      setVisitorGroups(data);
+      const completed = data.filter(group => {
+        const sim = group.simulacoes[0];
+        return (
+          !!sim.nome_completo?.trim() &&
+          !!sim.email?.trim() &&
+          !!sim.telefone?.trim()
+        );
+      });
+      setVisitorGroups(completed);
 
-      calculateStats(data);
+      calculateStats(completed);
     } catch (error) {
       console.error('Erro ao carregar simulações:', error);
     } finally {


### PR DESCRIPTION
## Summary
- Ignore anonymous leads on admin simulations tab
- Restore campaign and landing page origin info for simulations

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any ...)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68acaf924f54832d8bc4e8c6e5dc6733