### PR TITLE
fix: use visitor filter in admin dashboard

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -486,7 +486,7 @@ const AdminDashboard: React.FC = () => {
   };
 
 
-  const filteredSessions = getFilteredSessions();
+  const filteredVisitors = getFilteredVisitors();
 
 
   const filteredParceiros = getFilteredParceiros();


### PR DESCRIPTION
## Summary
- replace legacy `getFilteredSessions` usage with `getFilteredVisitors` in admin panel
- restore unintended changes to exported hero snippet

## Testing
- `npm test`
- `npm run lint` *(fails: 41 errors, 246 warnings)*
- `npm run build`
- `curl -s -D - http://localhost:4173/admin | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68acb74cc8e0832db6c020d1784f8005