### PR TITLE
gracefully handle missing supabase config

### DIFF
--- a/src/services/imageUploadService.ts
+++ b/src/services/imageUploadService.ts
@@ -3,7 +3,7 @@
  * Suporta tanto armazenamento local quanto Supabase Storage
  */
 
-import { supabaseApi } from '@/lib/supabase';
+import { supabaseApi, supabase } from '@/lib/supabase';
 
 export interface UploadResult {
   url: string;
@@ -37,6 +37,9 @@ export class ImageUploadService {
    * Upload usando Supabase Storage
    */
   private static async uploadToSupabase(file: File): Promise<UploadResult> {
+    if (!supabase) {
+      throw new Error('SERVICO_INDISPONIVEL: Supabase não configurado');
+    }
     try {
       const url = await supabaseApi.uploadBlogImage(file);
       console.log('Upload Supabase realizado com sucesso:', url);
@@ -155,6 +158,9 @@ export class ImageUploadService {
     try {
       // Se for URL do Supabase, tentar deletar de lá
       if (imageUrl.includes('supabase')) {
+        if (!supabase) {
+          throw new Error('SERVICO_INDISPONIVEL: Supabase não configurado');
+        }
         await supabaseApi.deleteBlogImage(imageUrl);
         return true;
       }

--- a/src/services/partnersService.ts
+++ b/src/services/partnersService.ts
@@ -11,7 +11,7 @@
  * - Gestão de status
  */
 
-import { supabaseApi, ParceiroData } from '@/lib/supabase';
+import { supabaseApi, supabase, ParceiroData } from '@/lib/supabase';
 import { validateEmail, validatePhone, formatPhone } from '@/utils/validations';
 import { EmailService, PartnerEmailData } from './emailService';
 
@@ -47,11 +47,15 @@ export class PartnersService {
   
   /**
    * Cria nova solicitação de parceria
-   */
+  */
   static async createPartnership(input: PartnerInput): Promise<PartnerResult> {
     try {
+      if (!supabase) {
+        throw new Error('SERVICO_INDISPONIVEL: Supabase não configurado');
+      }
+
       console.log('🤝 Criando solicitação de parceria:', input);
-      
+
       // 0. Testar conexão primeiro
       console.log('🔄 Testando conexão Supabase...');
       await supabaseApi.testConnection();
@@ -168,6 +172,9 @@ export class PartnersService {
    */
   static async getParceiros(limit = 50) {
     try {
+      if (!supabase) {
+        throw new Error('SERVICO_INDISPONIVEL: Supabase não configurado');
+      }
       return await supabaseApi.getParceiros(limit);
     } catch (error) {
       console.error('❌ Erro ao buscar parceiros:', error);
@@ -180,6 +187,9 @@ export class PartnersService {
    */
   static async updatePartnerStatus(id: string, status: string) {
     try {
+      if (!supabase) {
+        throw new Error('SERVICO_INDISPONIVEL: Supabase não configurado');
+      }
       return await supabaseApi.updateParceiroStatus(id, status);
     } catch (error) {
       console.error('❌ Erro ao atualizar status do parceiro:', error);
@@ -192,7 +202,9 @@ export class PartnersService {
    */
   static async getPartnersStats() {
     try {
-      const { supabase } = await import('@/lib/supabase');
+      if (!supabase) {
+        throw new Error('SERVICO_INDISPONIVEL: Supabase não configurado');
+      }
       const { data, error } = await supabase.rpc('get_parceiros_stats');
       
       if (error) throw error;

--- a/src/services/simulationService.ts
+++ b/src/services/simulationService.ts
@@ -19,7 +19,7 @@
  * 5. Retorna dados para o componente
  */
 
-import { supabaseApi, SimulacaoData } from '@/lib/supabase';
+import { supabaseApi, supabase, SimulacaoData } from '@/lib/supabase';
 import { simulateCredit } from '@/services/simulationApi';
 import { validateEmail, validatePhone, formatPhone } from '@/utils/validations';
 import { PloomesService } from '@/services/ploomesService';
@@ -71,6 +71,10 @@ export class SimulationService {
    */
   static async performSimulation(input: SimulationInput): Promise<SimulationResult> {
     try {
+      if (!supabase) {
+        throw new Error('SERVICO_INDISPONIVEL: Supabase não configurado');
+      }
+
       console.log('🎯 Iniciando simulação:', input);
       
       // 1. Validar dados de entrada
@@ -116,7 +120,7 @@ export class SimulationService {
       };
       
       console.log('💾 Salvando no Supabase:', supabaseData);
-      
+
       // 6. Salvar no Supabase
       const savedSimulation = await supabaseApi.createSimulacao(supabaseData);
       
@@ -309,6 +313,9 @@ export class SimulationService {
    */
   static async getSimulacoes(limit = 50) {
     try {
+      if (!supabase) {
+        throw new Error('SERVICO_INDISPONIVEL: Supabase não configurado');
+      }
       return await supabaseApi.getSimulacoes(limit);
     } catch (error) {
       console.error('❌ Erro ao buscar simulações:', error);
@@ -321,6 +328,9 @@ export class SimulationService {
    */
   static async updateSimulationStatus(id: string, status: string) {
     try {
+      if (!supabase) {
+        throw new Error('SERVICO_INDISPONIVEL: Supabase não configurado');
+      }
       return await supabaseApi.updateSimulacaoStatus(id, status);
     } catch (error) {
       console.error('❌ Erro ao atualizar status:', error);


### PR DESCRIPTION
## Summary
- guard Supabase client creation with try/catch and export a fallback API
- update services to detect missing Supabase configuration and return friendly errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbbdf56ec832d96e399454ac330d0