### PR TITLE
refactor: unify local storage key

### DIFF
--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -491,8 +491,12 @@ export class LocalSimulationService {
               console.log('➕ Simulação não existe no Supabase, criando nova...');
               
               // Buscar dados da simulação do localStorage
-              const localSimulations = JSON.parse(localStorage.getItem('simulationData') || '[]');
-              const localSimulation = localSimulations.find((s: any) => s.id === input.simulationId);
+              const localSimulations = JSON.parse(
+                localStorage.getItem('libra_local_simulations') || '[]'
+              );
+              const localSimulation = localSimulations.find(
+                (s: any) => s.id === input.simulationId
+              );
               
               if (!localSimulation) {
                 throw new Error('Dados da simulação não encontrados no localStorage');


### PR DESCRIPTION
## Summary
- use consistent localStorage key `libra_local_simulations` when restoring saved simulations

## Testing
- `npm test`
- `npm run lint` *(fails: 291 problems, 41 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af30129080832db8904e6903d3bafc