### PR TITLE
Handle city field in contact submissions

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -27,6 +27,9 @@ interface ContactFormProps {
     parcelas: number;
     primeiraParcela?: number;
     ultimaParcela?: number;
+    valorEmprestimo: number;
+    valorImovel: number;
+    cidade: string;
   };
   className?: string;
   inputClassName?: string;
@@ -152,6 +155,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
         nomeCompleto: nome,
         email,
         telefone,
+        cidade: simulationResult.cidade,
         imovelProprio,
         observacoes: `Simulação: ${simulationResult.amortizacao} - ${simulationResult.parcelas}x - R$ ${simulationResult.valor.toLocaleString('pt-BR')}`,
         // Dados adicionais para API Ploomes

--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -222,7 +222,12 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
         </div>
         
         <ContactForm
-          simulationResult={resultado}
+          simulationResult={{
+            ...resultado,
+            valorEmprestimo: _valorEmprestimo,
+            valorImovel: _valorImovel,
+            cidade: _cidade
+          }}
           compact={true}
           className="space-y-3"
           inputClassName="bg-white/90 text-gray-800 placeholder-gray-500"
@@ -335,7 +340,12 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
       </div>
       
       <ContactForm
-        simulationResult={resultado}
+        simulationResult={{
+          ...resultado,
+          valorEmprestimo: _valorEmprestimo,
+          valorImovel: _valorImovel,
+          cidade: _cidade
+        }}
         compact={true}
         className="space-y-3"
         inputClassName="bg-white/90 text-gray-800 placeholder-gray-500"

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -40,7 +40,8 @@ describe('ContactForm', () => {
     amortizacao: 'PRICE',
     parcelas: 12,
     valorEmprestimo: 50000,
-    valorImovel: 100000
+    valorImovel: 100000,
+    cidade: 'São Paulo'
   } as any;
 
   it('forwards journey UTM params to LocalSimulationService.processContact', async () => {
@@ -73,7 +74,8 @@ describe('ContactForm', () => {
           utm_term: 'term',
           utm_content: 'content',
           landing_page: 'https://example.com',
-          referrer: 'https://referrer.com'
+          referrer: 'https://referrer.com',
+          cidade: 'São Paulo'
         })
       );
     });
@@ -101,7 +103,8 @@ describe('ContactForm', () => {
           utm_term: null,
           utm_content: null,
           landing_page: null,
-          referrer: null
+          referrer: null,
+          cidade: 'São Paulo'
         })
       );
     });

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -57,6 +57,7 @@ export interface ContactFormInput {
   nomeCompleto: string;
   email: string;
   telefone: string;
+  cidade?: string;
   imovelProprio: 'proprio' | 'terceiro';
   observacoes?: string;
   utm_source?: string | null;
@@ -359,7 +360,7 @@ export class LocalSimulationService {
 
       // Preparar payload para API Ploomes com validação de tipos
       const ploomesPayload = {
-        cidade: simulationData?.cidade || 'Não informado',
+        cidade: input.cidade?.trim() || simulationData?.cidade || 'Não informado',
         valorDesejadoEmprestimo: Number(input.valorDesejadoEmprestimo || simulationData?.valor_emprestimo || 0),
         valorImovelGarantia: Number(input.valorImovelGarantia || simulationData?.valor_imovel || 0),
         quantidadeParcelas: Number(input.quantidadeParcelas || simulationData?.parcelas || 36),
@@ -380,6 +381,9 @@ export class LocalSimulationService {
       };
 
       // Validar campos obrigatórios
+      if (!ploomesPayload.cidade || ploomesPayload.cidade.trim() === '' || ploomesPayload.cidade === 'Não informado') {
+        throw new Error('Cidade é obrigatória');
+      }
       if (!ploomesPayload.nomeCompleto) {
         throw new Error('Nome completo é obrigatório');
       }

--- a/src/services/simulationService.ts
+++ b/src/services/simulationService.ts
@@ -59,6 +59,7 @@ export interface ContactFormInput {
   nomeCompleto: string;
   email: string;
   telefone: string;
+  cidade?: string;
   imovelProprio: 'proprio' | 'terceiro';
   observacoes?: string;
 }


### PR DESCRIPTION
## Summary
- include optional `cidade` in contact submission types
- forward simulation city into contact processing
- validate city before sending to Ploomes

## Testing
- `npm test`
- `npm run lint` *(fails: 291 problems, 41 errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68af301a63ec832d832432d379f18acd