### PR TITLE
Filtrar leads incompletos em getSimulacoes

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -222,6 +222,13 @@ export const supabaseApi = {
     const { data, error } = await supabase
       .from('simulacoes')
       .select('*')
+      .not('nome_completo', 'is', null)
+      .neq('nome_completo', '')
+      .not('email', 'is', null)
+      .neq('email', '')
+      .not('telefone', 'is', null)
+      .neq('telefone', '')
+      .neq('status', 'novo')
       .order('created_at', { ascending: false })
       .limit(limit);
     


### PR DESCRIPTION
## Summary
- Add filters in `getSimulacoes` to exclude leads with missing contact info and status `novo`

## Testing
- `npm test`
- `npm run lint` *(fails: 41 errors, 250 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68af4420a4ac832d97a6b250d18e6ac3