### PR TITLE
feat: retry pending contacts on startup

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import App from './App.tsx'
 import './index.css';
 import './styles/overflow-fix.css';
 import { requestIdleCallback as requestIdleCb } from './utils/performance';
+import { LocalSimulationService } from '@/services/localSimulationService';
 
 // Hidratação do HTML pré-renderizado para LCP otimizado
 const renderApp = () => {
@@ -30,3 +31,4 @@ const renderApp = () => {
 };
 
 renderApp();
+LocalSimulationService.resendPendingContacts();


### PR DESCRIPTION
## Summary
- resend pending contacts from localStorage to Supabase
- clear successfully sent contacts to avoid duplicates
- call retry routine on app start

## Testing
- `npm test`
- `npm run lint` *(fails: 294 problems (41 errors, 253 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68af4425ea48832d9c05ce31f7bd5cab