### PR TITLE
Add default imovel_proprio to simulation inserts

### DIFF
--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -225,6 +225,7 @@ export class LocalSimulationService {
             tipo_amortizacao: input.tipoAmortizacao,
             parcela_inicial: calculation.parcelaSac.inicial,
             parcela_final: calculation.parcelaSac.final,
+            imovel_proprio: 'proprio',
             user_agent: input.userAgent || '',
             ip_address: input.ipAddress || '',
             status: 'novo' // Status inicial para compatibilidade com AdminDashboard

--- a/src/services/simulationService.ts
+++ b/src/services/simulationService.ts
@@ -111,6 +111,7 @@ export class SimulationService {
         tipo_amortizacao: input.tipoAmortizacao,
         parcela_inicial: processedResult.primeiraParcela,
         parcela_final: processedResult.ultimaParcela || processedResult.valor,
+        imovel_proprio: 'proprio',
         ip_address: input.ipAddress,
         user_agent: input.userAgent,
         status: 'novo'


### PR DESCRIPTION
## Summary
- include `imovel_proprio` when persisting simulations
- ensure local service mirrors new Supabase field

## Testing
- `npm test`
- `npm run lint` *(fails: 294 problems (41 errors, 253 warnings))*
- `npx vite-node temp-files/run-sim.ts` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68af500e99dc832d863b47c560da306f