### PR TITLE
feat: add collapsible UTM details component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@emailjs/browser": "^4.4.1",
+        "@radix-ui/react-collapsible": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-progress": "^1.1.0",
         "@radix-ui/react-select": "^2.1.1",
@@ -1513,6 +1514,66 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
+    "@radix-ui/react-collapsible": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-select": "^2.1.1",

--- a/src/components/UTMDetails.tsx
+++ b/src/components/UTMDetails.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from './ui/collapsible';
 import { Button } from './ui/button';
-import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down';
+import { ChevronDown } from 'lucide-react';
 import type { SessionGroupWithJourney } from '@/services/localSimulationService';
 import { cn } from '@/lib/utils';
 

--- a/src/components/UTMDetails.tsx
+++ b/src/components/UTMDetails.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from './ui/collapsible';
+import { Button } from './ui/button';
+import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down';
+import type { SessionGroupWithJourney } from '@/services/localSimulationService';
+import { cn } from '@/lib/utils';
+
+interface UTMDetailsProps {
+  visitor: SessionGroupWithJourney;
+}
+
+const UTMDetails: React.FC<UTMDetailsProps> = ({ visitor }) => {
+  const [open, setOpen] = React.useState(false);
+
+  const summary = [visitor.utm_source, visitor.utm_medium, visitor.utm_campaign]
+    .filter(Boolean)
+    .join(' / ') || '-';
+
+  const shortenUrl = (url: string) => {
+    try {
+      const { hostname, pathname } = new URL(url);
+      return `${hostname}${pathname}`;
+    } catch {
+      return url;
+    }
+  };
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="text-xs overflow-hidden max-w-[220px]"
+    >
+      <div className="flex items-center gap-1">
+        <div className="truncate">{summary}</div>
+        <CollapsibleTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-5 w-5 p-0"
+            aria-label={open ? 'Esconder detalhes UTM' : 'Mostrar detalhes UTM'}
+          >
+            <ChevronDown
+              className={cn('h-4 w-4 transition-transform', open ? 'rotate-180' : '')}
+            />
+          </Button>
+        </CollapsibleTrigger>
+      </div>
+      <CollapsibleContent className="mt-1 space-y-1">
+        {visitor.utm_term && (
+          <div>
+            <strong>utm_term:</strong> {visitor.utm_term}
+          </div>
+        )}
+        {visitor.utm_content && (
+          <div>
+            <strong>utm_content:</strong> {visitor.utm_content}
+          </div>
+        )}
+        {visitor.landing_page && (
+          <div>
+            <strong>landing_page:</strong>{' '}
+            <a
+              href={visitor.landing_page}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline break-all"
+            >
+              {shortenUrl(visitor.landing_page)}
+            </a>
+          </div>
+        )}
+        {visitor.referrer && (
+          <div>
+            <strong>referrer:</strong>{' '}
+            <a
+              href={visitor.referrer}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline break-all"
+            >
+              {shortenUrl(visitor.referrer)}
+            </a>
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+export default UTMDetails;
+

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,9 +1,7 @@
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
 
 const Collapsible = CollapsiblePrimitive.Root
-
-const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
-
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+const CollapsibleTrigger = CollapsiblePrimitive.Trigger
+const CollapsibleContent = CollapsiblePrimitive.Content
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -289,7 +289,6 @@ const AdminDashboard: React.FC = () => {
     setLoadingConfig(true);
     try {
       localStorage.setItem('libra_simulation_config', JSON.stringify(simulationConfig));
-      console.log('✅ Configurações do simulador salvas:', simulationConfig);
       alert('Configurações do simulador salvas com sucesso!');
     } catch (error) {
       console.error('Erro ao salvar configurações:', error);

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -32,6 +32,7 @@ import AdminLogin from '@/components/AdminLogin';
 import ImageUploader from '@/components/ImageUploader';
 import StorageStats from '@/components/StorageStats';
 import SupabaseDiagnostics from '@/components/SupabaseDiagnostics';
+import UTMDetails from '@/components/UTMDetails';
 import { ParceiroData } from '@/lib/supabase';
 import { formatPhone } from '@/utils/validations';
 import Eye from 'lucide-react/dist/esm/icons/eye';
@@ -475,16 +476,6 @@ const AdminDashboard: React.FC = () => {
     a.click();
   };
 
-  const shortenUrl = (url: string) => {
-    try {
-      const { hostname, pathname } = new URL(url);
-      return `${hostname}${pathname}`;
-    } catch {
-      return url;
-    }
-  };
-
-
   const filteredVisitors = getFilteredVisitors();
 
 
@@ -716,35 +707,7 @@ const AdminDashboard: React.FC = () => {
                         </TableCell>
 
                         <TableCell className="text-xs">
-                          <div>
-                            {[visitor.utm_source, visitor.utm_medium, visitor.utm_campaign]
-                              .filter(Boolean)
-                              .join(' / ') || '-'}
-                          </div>
-                          {visitor.landing_page && (
-                            <a
-                              href={visitor.landing_page}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-blue-600 hover:underline break-all"
-                              title={visitor.landing_page}
-                            >
-                              {shortenUrl(visitor.landing_page)}
-
-                            </a>
-                          )}
-                          {!visitor.landing_page && visitor.referrer && (
-                            <a
-                              href={visitor.referrer}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-blue-600 hover:underline break-all"
-                              title={visitor.referrer}
-                            >
-                              {shortenUrl(visitor.referrer)}
-
-                            </a>
-                          )}
+                          <UTMDetails visitor={visitor} />
                         </TableCell>
                         <TableCell className="font-medium">
                           {simulacao.nome_completo}


### PR DESCRIPTION
## Summary
- create UTMDetails component with collapsible panel to show UTM data
- replace inline UTM rendering in AdminDashboard with UTMDetails

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected console statement and other warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b099b552d0832d9c11518dfc390fc8