### PR TITLE
Atualiza valor mínimo de empréstimo para R$100 mil

### DIFF
--- a/src/components/LoanSimulator.tsx
+++ b/src/components/LoanSimulator.tsx
@@ -13,7 +13,7 @@
  * - Integração com WhatsApp para contato
  * 
  * @businessRules
- * - Valor mínimo do empréstimo: R$ 75.000
+ * - Valor mínimo do empréstimo: R$ 100.000
  * - Valor máximo do empréstimo: R$ 5.000.000
  * - Taxa de juros: 1.09% a.m.
  * - Prazo máximo: 180 meses (15 anos)
@@ -168,7 +168,7 @@ const LoanSimulator: React.FC = () => {
                     </label>
                     <Slider 
                       value={[loanAmount]} 
-                      min={75000}
+                      min={100000}
                       max={5000000} 
                       step={50000} 
                       onValueChange={handleLoanAmountChange} 
@@ -176,7 +176,7 @@ const LoanSimulator: React.FC = () => {
                       aria-labelledby={loanAmountLabelId}
                     />
                     <div className="flex justify-between text-sm text-gray-700">
-                      <span>R$ 75 mil</span>
+                      <span>R$ 100 mil</span>
                       <span>R$ 5 milhões</span>
                     </div>
                   </div>

--- a/src/components/MobileWizard/steps.tsx
+++ b/src/components/MobileWizard/steps.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 // Step 1: Valor necessário
 export const ValueStep: React.FC<WizardStepProps> = ({ data, updateData, errors }) => {
   const values = [
-    { label: 'R$ 75 mil', value: 75000 },
+    { label: 'R$ 100 mil', value: 100000 },
     { label: 'R$ 300 mil', value: 300000 },
     { label: 'R$ 500 mil', value: 500000 },
     { label: 'R$ 750 mil', value: 750000 },

--- a/src/components/form/LoanAmountField.tsx
+++ b/src/components/form/LoanAmountField.tsx
@@ -27,7 +27,7 @@ const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange, isIn
           <Input
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            placeholder="entre 75 mil e 5 milhões"
+            placeholder="entre 100 mil e 5 milhões"
             className={cn('text-sm', isInvalid && 'border-red-500 focus:border-red-500 focus:ring-red-500')}
             inputMode="numeric"
           />

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -103,7 +103,7 @@ const AdminDashboard: React.FC = () => {
   
   // Estados para configurações do simulador interno
   const [simulationConfig, setSimulationConfig] = useState({
-    valorMinimo: 75000,
+    valorMinimo: 100000,
     valorMaximo: 5000000,
     parcelasMin: 36,
     parcelasMax: 180,
@@ -194,7 +194,7 @@ const AdminDashboard: React.FC = () => {
       if (storedConfig) {
         const config = JSON.parse(storedConfig);
         setSimulationConfig({
-          valorMinimo: config.valorMinimo || 75000,
+          valorMinimo: config.valorMinimo || 100000,
           valorMaximo: config.valorMaximo || 5000000,
           parcelasMin: config.parcelasMin || 36,
           parcelasMax: config.parcelasMax || 180,

--- a/src/services/blogService.ts
+++ b/src/services/blogService.ts
@@ -876,7 +876,7 @@ export class BlogService {
       const stored = localStorage.getItem(this.CONFIG_KEY);
       return stored ? JSON.parse(stored) : {
         // Limites de valor (baseado na API atual)
-        valorMinimo: 75000,
+        valorMinimo: 100000,
         valorMaximo: 5000000,
         
         // Limites de parcelas

--- a/src/services/simulationApi.ts
+++ b/src/services/simulationApi.ts
@@ -4,7 +4,7 @@
  * @interface SimulationPayload
  * @description Define a estrutura de dados necessária para realizar uma simulação de crédito
  * 
- * @property {number} valor_solicitado - Valor do empréstimo solicitado (R$ 75.000 a R$ 5.000.000)
+ * @property {number} valor_solicitado - Valor do empréstimo solicitado (R$ 100.000 a R$ 5.000.000)
  * @property {number} vlr_imovel - Valor do imóvel em garantia (mínimo 2x valor solicitado)
  * @property {number} numero_parcelas - Quantidade de parcelas (36 a 180 meses)
  * @property {string} amortizacao - Sistema de amortização ('SAC' ou 'PRICE')

--- a/src/services/simulationService.ts
+++ b/src/services/simulationService.ts
@@ -347,8 +347,8 @@ export class SimulationService {
       throw new Error('Telefone inválido');
     }
     if (!input.cidade) throw new Error('Cidade é obrigatória');
-    if (input.valorEmprestimo < 75000 || input.valorEmprestimo > 5000000) {
-      throw new Error('Valor do empréstimo deve estar entre R$ 75.000 e R$ 5.000.000');
+    if (input.valorEmprestimo < 100000 || input.valorEmprestimo > 5000000) {
+      throw new Error('Valor do empréstimo deve estar entre R$ 100.000 e R$ 5.000.000');
     }
     if (input.valorImovel < input.valorEmprestimo * 2) {
       throw new Error('Valor do imóvel deve ser pelo menos 2x o valor do empréstimo');

--- a/src/services/webhookService.ts
+++ b/src/services/webhookService.ts
@@ -269,7 +269,7 @@ export class WebhookService {
       email: 'teste@exemplo.com',
       telefone: '(11) 99999-9999',
       cidade: 'São Paulo',
-      valorEmprestimo: 75000,
+      valorEmprestimo: 100000,
       valorImovel: 300000,
       parcelas: 36,
       tipoAmortizacao: 'SAC',

--- a/src/utils/loanCalculator.ts
+++ b/src/utils/loanCalculator.ts
@@ -227,7 +227,7 @@ export function getValorLimits(): { min: number; max: number } {
     if (config) {
       const parsed = JSON.parse(config);
       return {
-        min: parsed.valorMinimo || 75000,
+        min: parsed.valorMinimo || 100000,
         max: parsed.valorMaximo || 5000000
       };
     }
@@ -235,7 +235,7 @@ export function getValorLimits(): { min: number; max: number } {
     console.warn('Erro ao obter limites de valor:', error);
   }
   
-  return { min: 75000, max: 5000000 };
+  return { min: 100000, max: 5000000 };
 }
 
 /**

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -139,8 +139,8 @@ export const validateForm = (
   const emprestimoValue = norm(emprestimo);
   const garantiaValue = norm(garantia);
   
-  // Empréstimo deve estar entre 75k e 5M
-  const emprestimoForaRange = emprestimoValue < 75000 || emprestimoValue > 5000000;
+  // Empréstimo deve estar entre 100k e 5M
+  const emprestimoForaRange = emprestimoValue < 100000 || emprestimoValue > 5000000;
   
   // Garantia deve ser pelo menos 2x o empréstimo
   const emprestimoExcedeGarantia = emprestimoValue > (garantiaValue / 2);
@@ -150,7 +150,7 @@ export const validateForm = (
   
   // Validações básicas
   const dadosBasicosValidos = 
-    emprestimoValue >= 75000 &&
+    emprestimoValue >= 100000 &&
     emprestimoValue <= 5000000 &&
     garantiaValue > 0 && 
     parcelasValidas && 

--- a/temp-files/test-pages/SimpleWizardTest.tsx
+++ b/temp-files/test-pages/SimpleWizardTest.tsx
@@ -85,7 +85,7 @@ const SimpleWizardTest = () => {
                 <div>
                   <p className="mb-4">Selecione o valor desejado:</p>
                   <div className="grid grid-cols-2 gap-2">
-                    {['R$ 75 mil', 'R$ 300 mil', 'R$ 500 mil', 'R$ 1 milhão'].map((value) => (
+                    {['R$ 100 mil', 'R$ 300 mil', 'R$ 500 mil', 'R$ 1 milhão'].map((value) => (
                       <button
                         key={value}
                         onClick={() => setData({ ...data, value })}


### PR DESCRIPTION
## Summary
- Atualiza validações e mensagens para exigir valor mínimo de R$100.000
- Ajusta componentes e placeholders para refletir o novo intervalo de R$100.000 a R$5.000.000

## Testing
- `npm test`
- `npm run lint` *(fails: 43 errors, 260 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b09efed5bc832d991f708241267018