### PR TITLE
Reset scroll position on success page

### DIFF
--- a/src/pages/Sucesso.tsx
+++ b/src/pages/Sucesso.tsx
@@ -6,6 +6,7 @@ const Sucesso = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    window.scrollTo(0, 0);
     document.title = 'Solicitação Recebida | Libra Crédito';
     const metaDescription = document.querySelector('meta[name="description"]');
     if (metaDescription) {


### PR DESCRIPTION
## Summary
- reset scroll position when success page loads

## Testing
- `npm test`
- `npm run lint` *(fails: 303 problems, 43 errors, 260 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a915cafc832d8f9a7d4f23772291