### PR TITLE
fix: cancel CityAutocomplete scroll when input loses focus

### DIFF
--- a/src/components/form/CityAutocomplete.tsx
+++ b/src/components/form/CityAutocomplete.tsx
@@ -24,6 +24,8 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const fetchTimeout = useRef<NodeJS.Timeout | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const scrollTimeout = useRef<NodeJS.Timeout | null>(null);
+  const cancelScrollRef = useRef<((e: PointerEvent) => void) | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Keep input in sync if parent resets the value
@@ -70,12 +72,35 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
   // Function to scroll input to top of viewport
   const scrollToInput = (): void => {
     if (inputRef.current && window.innerWidth < 768) {
-      setTimeout(() => {
+      if (scrollTimeout.current) {
+        clearTimeout(scrollTimeout.current);
+      }
+      scrollTimeout.current = setTimeout(() => {
         if (!inputRef.current) return;
         const headerHeight = 80;
-        scrollToTarget(inputRef.current as HTMLElement, -headerHeight);
-
+        if (document.activeElement === inputRef.current) {
+          scrollToTarget(inputRef.current as HTMLElement, -headerHeight);
+        }
       }, 300);
+
+      if (cancelScrollRef.current) {
+        document.removeEventListener('pointerdown', cancelScrollRef.current);
+      }
+
+      const cancelScroll = (e: PointerEvent): void => {
+        if (inputRef.current && e.target instanceof Node && inputRef.current.contains(e.target)) {
+          return;
+        }
+        if (scrollTimeout.current) {
+          clearTimeout(scrollTimeout.current);
+          scrollTimeout.current = null;
+        }
+        document.removeEventListener('pointerdown', cancelScroll);
+        cancelScrollRef.current = null;
+      };
+
+      cancelScrollRef.current = cancelScroll;
+      document.addEventListener('pointerdown', cancelScroll);
     }
   };
 
@@ -87,6 +112,14 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
 
   // Handle blur
   const handleBlur = (): void => {
+    if (scrollTimeout.current) {
+      clearTimeout(scrollTimeout.current);
+      scrollTimeout.current = null;
+    }
+    if (cancelScrollRef.current) {
+      document.removeEventListener('pointerdown', cancelScrollRef.current);
+      cancelScrollRef.current = null;
+    }
     // Delay hiding suggestions to allow selection
     setTimeout(() => {
       setIsFocused(false);


### PR DESCRIPTION
## Summary
- cancel CityAutocomplete scroll when user interacts outside input
- remove pointerdown listener on blur to avoid stray scroll

## Testing
- `npm test`
- `npm run lint` *(fails: 303 problems, 43 errors)*
- `npx eslint src/components/form/CityAutocomplete.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0a91204c0832d8398a12fe01778d6