### PR TITLE
fix: improve mobile scrolling to API messages

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -40,7 +40,7 @@
  * @see {@link formatBRL} para formatação de valores
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { validateForm } from '@/utils/validations';
@@ -59,6 +59,7 @@ import { ApiMessageAnalysis } from '@/utils/apiMessageAnalyzer';
 import { analyzeLocalMessage } from '@/utils/localMessageAnalyzer';
 import { formatBRL, norm } from '@/utils/formatters';
 import { toast } from '@/components/ui/use-toast';
+import scrollToTarget from '@/utils/scrollToTarget';
 
 const SimulationForm: React.FC = () => {
   const { sessionId, visitorId, trackSimulation } = useUserJourney();
@@ -124,13 +125,23 @@ const SimulationForm: React.FC = () => {
   const scrollToApiMessage = () => {
     if (isMobile) {
       setTimeout(() => {
-        const messageElement = document.querySelector('[data-api-message="true"]');
+        const messageElement = document.querySelector('[data-api-message="true"]') as HTMLElement | null;
         if (messageElement) {
-          (messageElement as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
+          const headerHeight = document.querySelector('header')?.offsetHeight ?? 80;
+          scrollToTarget(messageElement, -headerHeight);
         }
       }, 300);
     }
   };
+
+  useEffect(() => {
+    if (
+      apiMessage &&
+      (apiMessage.type === 'limit_30_general' || apiMessage.type === 'limit_30_rural')
+    ) {
+      scrollToApiMessage();
+    }
+  }, [apiMessage]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -197,9 +208,6 @@ const SimulationForm: React.FC = () => {
           // É uma mensagem estruturada do serviço local
           setApiMessage(analysis);
           setErro(''); // Limpar erro genérico
-          if (analysis.type === 'limit_30_general' || analysis.type === 'limit_30_rural') {
-            scrollToApiMessage();
-          }
         } else {
           // É um erro genérico
           let errorMessage = 'Erro desconhecido ao realizar simulação';
@@ -312,9 +320,6 @@ const SimulationForm: React.FC = () => {
           if (analysis.type !== 'unknown_error') {
             setApiMessage(analysis);
             setErro('');
-            if (analysis.type === 'limit_30_general' || analysis.type === 'limit_30_rural') {
-              scrollToApiMessage();
-            }
           } else {
             let errorMessage = 'Erro ao processar simulação automática';
             
@@ -409,9 +414,6 @@ const SimulationForm: React.FC = () => {
           if (analysis.type !== 'unknown_error') {
             setApiMessage(analysis);
             setErro('');
-            if (analysis.type === 'limit_30_general' || analysis.type === 'limit_30_rural') {
-              scrollToApiMessage();
-            }
           } else {
             setErro('Erro ao refazer simulação com tabela PRICE');
             setApiMessage(null);


### PR DESCRIPTION
## Summary
- scroll API limit messages with header offset using `scrollToTarget`
- trigger scrolling after render with an `apiMessage` effect

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected console statement, Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b0dddc1c832d85604ddcbc62d86b