### PR TITLE
feat: adjust city autocomplete mobile scroll

### DIFF
--- a/src/components/form/CityAutocomplete.tsx
+++ b/src/components/form/CityAutocomplete.tsx
@@ -79,8 +79,9 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
       scrollTimeout.current = setTimeout(() => {
         if (!inputRef.current) return;
         const headerHeight = 80;
+        const extraOffset = 240;
         if (document.activeElement === inputRef.current) {
-          scrollToTarget(inputRef.current as HTMLElement, -headerHeight);
+          scrollToTarget(inputRef.current, -(headerHeight + extraOffset));
         }
       }, 300);
 
@@ -193,7 +194,7 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
               inputValue.length < 2 ? 'Digite 2 ou mais caracteres' : 'Busque a cidade'
             }
             className={cn(
-              'text-sm w-full px-3 py-2 rounded-md border-2 focus:outline-none transition-colors scroll-mt-header',
+              'text-sm w-full px-3 py-2 rounded-md border-2 focus:outline-none transition-colors scroll-mt-header scroll-mb-60',
               isInvalid
                 ? 'border-red-500 focus:border-red-500'
                 : 'border-green-700 focus:border-green-800'


### PR DESCRIPTION
## Summary
- ensure city autocomplete scrolls with extra offset on mobile
- add scroll margin to input to prevent suggestion cutoff

## Testing
- `npm test`
- `npm run lint` *(fails: multiple lint errors in repository)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0b0e07a74832d8129b1794540e57a