### PR TITLE
feat: show summary and WhatsApp link on confirmation

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -175,8 +175,19 @@ const ContactForm: React.FC<ContactFormProps> = ({
 
       });
       
-      // Redirecionar diretamente para a página de confirmação
-      navigate('/confirmacao');
+      // Redirecionar diretamente para a página de confirmação com resumo
+      const summary = {
+        nome,
+        email,
+        telefone,
+        valorEmprestimo: simulationResult.valorEmprestimo,
+        valorImovel: simulationResult.valorImovel,
+        cidade: simulationResult.cidade,
+        parcelas: simulationResult.parcelas,
+        valorParcela: simulationResult.valor
+      };
+
+      navigate('/confirmacao', { state: { summary } });
       
       // Limpar formulário
       setNome('');

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -40,8 +40,7 @@
  * @see {@link formatBRL} para formatação de valores
  */
 
-import React, { useRef, useState } from 'react';
-
+import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { validateForm } from '@/utils/validations';
@@ -60,7 +59,6 @@ import { ApiMessageAnalysis } from '@/utils/apiMessageAnalyzer';
 import { analyzeLocalMessage } from '@/utils/localMessageAnalyzer';
 import { formatBRL, norm } from '@/utils/formatters';
 import { toast } from '@/components/ui/use-toast';
-import scrollToTarget from '@/utils/scrollToTarget';
 
 const SimulationForm: React.FC = () => {
   const { sessionId, visitorId, trackSimulation } = useUserJourney();
@@ -75,8 +73,6 @@ const SimulationForm: React.FC = () => {
   const [erro, setErro] = useState('');
   const [apiMessage, setApiMessage] = useState<ApiMessageAnalysis | null>(null);
   const [isRuralProperty, setIsRuralProperty] = useState(false);
-
-  const cityAutocompleteRef = useRef<{ handleBlur: () => void }>(null);
 
   // Validações
   const validation = validateForm(emprestimo, garantia, parcelas, amortizacao, cidade);
@@ -128,27 +124,16 @@ const SimulationForm: React.FC = () => {
   const scrollToApiMessage = () => {
     if (isMobile) {
       setTimeout(() => {
-        const messageElement = document.querySelector('[data-api-message="true"]') as HTMLElement | null;
+        const messageElement = document.querySelector('[data-api-message="true"]');
         if (messageElement) {
-          const headerHeight = document.querySelector('header')?.offsetHeight ?? 80;
-          scrollToTarget(messageElement, -headerHeight);
+          (messageElement as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
       }, 300);
     }
   };
 
-  useEffect(() => {
-    if (
-      apiMessage &&
-      (apiMessage.type === 'limit_30_general' || apiMessage.type === 'limit_30_rural')
-    ) {
-      scrollToApiMessage();
-    }
-  }, [apiMessage]);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    cityAutocompleteRef.current?.handleBlur();
 
     if (!validation.formularioValido) {
       toast({
@@ -212,6 +197,9 @@ const SimulationForm: React.FC = () => {
           // É uma mensagem estruturada do serviço local
           setApiMessage(analysis);
           setErro(''); // Limpar erro genérico
+          if (analysis.type === 'limit_30_general' || analysis.type === 'limit_30_rural') {
+            scrollToApiMessage();
+          }
         } else {
           // É um erro genérico
           let errorMessage = 'Erro desconhecido ao realizar simulação';
@@ -235,7 +223,6 @@ const SimulationForm: React.FC = () => {
   };
 
   const handleClear = () => {
-    cityAutocompleteRef.current?.handleBlur();
     setEmprestimo('');
     setGarantia('');
     setParcelas(180);
@@ -325,6 +312,9 @@ const SimulationForm: React.FC = () => {
           if (analysis.type !== 'unknown_error') {
             setApiMessage(analysis);
             setErro('');
+            if (analysis.type === 'limit_30_general' || analysis.type === 'limit_30_rural') {
+              scrollToApiMessage();
+            }
           } else {
             let errorMessage = 'Erro ao processar simulação automática';
             
@@ -419,6 +409,9 @@ const SimulationForm: React.FC = () => {
           if (analysis.type !== 'unknown_error') {
             setApiMessage(analysis);
             setErro('');
+            if (analysis.type === 'limit_30_general' || analysis.type === 'limit_30_rural') {
+              scrollToApiMessage();
+            }
           } else {
             setErro('Erro ao refazer simulação com tabela PRICE');
             setApiMessage(null);
@@ -461,7 +454,6 @@ const SimulationForm: React.FC = () => {
             <form onSubmit={handleSubmit} className="space-y-2">
               
               <CityAutocomplete
-                ref={cityAutocompleteRef}
                 value={cidade}
                 onCityChange={setCidade}
                 isInvalid={invalidCity}

--- a/src/components/form/CityAutocomplete.tsx
+++ b/src/components/form/CityAutocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useImperativeHandle, useRef, useState, forwardRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import MapPin from 'lucide-react/dist/esm/icons/map-pin';
 import scrollToTarget from '@/utils/scrollToTarget';
 
@@ -15,8 +15,7 @@ interface CityAutocompleteProps {
  * Searches city suggestions from LTV_Cidades.json as user types 
  * and only allows selection of valid cities.
  */
-const CityAutocomplete = forwardRef<{ handleBlur: () => void }, CityAutocompleteProps>(
-  ({ value = '', onCityChange, isInvalid = false }, ref) => {
+const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityChange, isInvalid = false }) => {
   const [inputValue, setInputValue] = useState<string>(value);
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -29,19 +28,6 @@ const CityAutocomplete = forwardRef<{ handleBlur: () => void }, CityAutocomplete
   const cancelScrollRef = useRef<((e: PointerEvent) => void) | null>(null);
 
   const containerRef = useRef<HTMLDivElement>(null);
-
-  // Cleanup listeners on unmount
-  useEffect(() => {
-    return () => {
-      if (scrollTimeout.current) {
-        clearTimeout(scrollTimeout.current);
-      }
-      if (cancelScrollRef.current) {
-        document.removeEventListener('pointerdown', cancelScrollRef.current);
-        cancelScrollRef.current = null;
-      }
-    };
-  }, []);
 
   // Keep input in sync if parent resets the value
   useEffect(() => {
@@ -93,9 +79,8 @@ const CityAutocomplete = forwardRef<{ handleBlur: () => void }, CityAutocomplete
       scrollTimeout.current = setTimeout(() => {
         if (!inputRef.current) return;
         const headerHeight = 80;
-        const extraOffset = 240;
         if (document.activeElement === inputRef.current) {
-          scrollToTarget(inputRef.current, -(headerHeight + extraOffset));
+          scrollToTarget(inputRef.current as HTMLElement, -headerHeight);
         }
       }, 300);
 
@@ -181,9 +166,6 @@ const CityAutocomplete = forwardRef<{ handleBlur: () => void }, CityAutocomplete
     }
   };
 
-  // Expose blur handler to parent components
-  useImperativeHandle(ref, () => ({ handleBlur }));
-
   // Check if we should show suggestions
   const showSuggestions = isFocused && inputValue.length >= 2 && (isLoading || error || suggestions.length > 0);
 
@@ -211,7 +193,7 @@ const CityAutocomplete = forwardRef<{ handleBlur: () => void }, CityAutocomplete
               inputValue.length < 2 ? 'Digite 2 ou mais caracteres' : 'Busque a cidade'
             }
             className={cn(
-              'text-sm w-full px-3 py-2 rounded-md border-2 focus:outline-none transition-colors scroll-mt-header scroll-mb-60',
+              'text-sm w-full px-3 py-2 rounded-md border-2 focus:outline-none transition-colors scroll-mt-header',
               isInvalid
                 ? 'border-red-500 focus:border-red-500'
                 : 'border-green-700 focus:border-green-800'
@@ -266,9 +248,6 @@ const CityAutocomplete = forwardRef<{ handleBlur: () => void }, CityAutocomplete
       </div>
     </div>
   );
-  }
-);
-
-CityAutocomplete.displayName = 'CityAutocomplete';
+};
 
 export default CityAutocomplete;

--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -1,10 +1,33 @@
 import React, { useEffect } from 'react';
 import MobileLayout from '@/components/MobileLayout';
 import { Button } from '@/components/ui/button';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 
+interface Summary {
+  nome: string;
+  email: string;
+  telefone: string;
+  valorEmprestimo: number;
+  valorImovel: number;
+  cidade: string;
+  parcelas: number;
+  valorParcela: number;
+}
+
 const Confirmacao = () => {
+  const location = useLocation();
+  const summary = (location.state as { summary?: Summary })?.summary;
+
+  const formatCurrency = (value: number) =>
+    value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+  const summaryText = summary
+    ? `${summary.nome}, você solicitou um crédito de ${formatCurrency(summary.valorEmprestimo)} para um imóvel de ${formatCurrency(summary.valorImovel)} em ${summary.cidade}, em ${summary.parcelas} parcelas de ${formatCurrency(summary.valorParcela)}.`
+    : '';
+
+  const whatsappLink = `https://wa.me/5516997338791?text=${encodeURIComponent(summaryText)}`;
+
   useEffect(() => {
     document.title = 'Simulação Enviada | Libra Crédito';
     const metaDescription = document.querySelector('meta[name="description"]');
@@ -22,11 +45,21 @@ const Confirmacao = () => {
       <div className="flex flex-col items-center justify-center py-12 px-4 text-center space-y-6 bg-white">
         <h1 className="text-2xl font-bold text-libra-navy">✅ Simulação enviada com sucesso!</h1>
         <p className="text-base text-gray-700">Recebemos seus dados e já estamos analisando sua solicitação.</p>
+        {summaryText && (
+          <p className="text-base text-gray-700">{summaryText}</p>
+        )}
         <p className="text-base text-gray-700">Em breve, um de nossos especialistas entrará em contato com você.</p>
         <div className="flex flex-col sm:flex-row gap-4 mt-4">
           <Button asChild variant="default" className="px-6">
             <Link to="/quem-somos">Conheça a Libra</Link>
           </Button>
+          {summaryText && (
+            <Button asChild variant="secondary" className="px-6">
+              <Link to={whatsappLink} target="_blank" rel="noopener noreferrer">
+                Falar no WhatsApp
+              </Link>
+            </Button>
+          )}
         </div>
         <p className="text-sm text-gray-600 mt-4">
           📞 Fique atento ao telefone (16) 3600-7956 para nosso contato.


### PR DESCRIPTION
## Summary
- revert repository to stable commit 53390fc
- send simulation summary to confirmation page
- display summary and WhatsApp contact link on confirmation page

## Testing
- `npm test`
- `npm run lint` *(fails: 303 problems - existing warnings/errors outside touched files)*
- `npx eslint src/components/ContactForm.tsx src/pages/Confirmacao.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b107796490832d85927522aead91d6