### PR TITLE
fix: use dvh in mobile layout

### DIFF
--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -17,7 +17,7 @@ const MobileLayout: React.FC<MobileLayoutProps> = ({
   const { isDesktop } = useDevice();
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-[100dvh] flex flex-col">
       {/* Skip Navigation Links for Accessibility */}
       <div className="sr-only focus-within:not-sr-only">
         <a


### PR DESCRIPTION
## Summary
- use 100dvh in `MobileLayout` to avoid unwanted scrolling on mobile

## Testing
- `npm test`
- `npm run lint` (fails: 43 errors)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b10eec0d3c832d9a9c42638b959e8a