### PR TITLE
fix: handle mobile viewport height

### DIFF
--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDevice } from '@/hooks/useDevice';
+import { useViewportHeight } from '@/hooks/useViewportHeight';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 
@@ -14,10 +14,10 @@ const MobileLayout: React.FC<MobileLayoutProps> = ({
   showHeader = true,
   showFooter = true
 }) => {
-  const { isDesktop } = useDevice();
+  useViewportHeight();
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="flex flex-col" style={{ minHeight: 'calc(var(--vh) * 100)' }}>
       {/* Skip Navigation Links for Accessibility */}
       <div className="sr-only focus-within:not-sr-only">
         <a

--- a/src/hooks/useViewportHeight.ts
+++ b/src/hooks/useViewportHeight.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+/**
+ * Hook to set a CSS custom property `--vh` representing 1% of the viewport height.
+ * Updates the value on window resize to address mobile browser UI chrome.
+ */
+export const useViewportHeight = () => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const setVh = () => {
+      const vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty('--vh', `${vh}px`);
+    };
+
+    setVh();
+    window.addEventListener('resize', setVh);
+    return () => window.removeEventListener('resize', setVh);
+  }, []);
+};

--- a/src/index.css
+++ b/src/index.css
@@ -497,7 +497,7 @@
 .wizard-container {
   height: 100vh;
   height: -webkit-fill-available;
-  height: 100dvh;
+  height: calc(var(--vh) * 100);
 }
 
 /* Bottom Navigation Safe Area */


### PR DESCRIPTION
## Summary
- add `useViewportHeight` hook to maintain `--vh` CSS variable
- use viewport height variable in `MobileLayout`
- replace `100dvh` usage in styles

## Testing
- `npm test`
- `npm run lint` *(fails: 302 problems (42 errors, 260 warnings))*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b11325c4b4832daf65ea7260534f88