### PR TITLE
fix viewport height handling

### DIFF
--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -37,7 +37,7 @@ const MobileLayout: React.FC<MobileLayoutProps> = ({
         <main
           id="main-content"
           data-has-header={showHeader ? 'true' : 'false'}
-          className={`flex-1 ${showHeader ? 'pt-header' : ''}`}
+          className={`flex-1 overflow-y-auto ${showHeader ? 'pt-header' : ''}`}
           role="main"
           aria-label="Conteúdo principal"
         >

--- a/src/hooks/useViewportHeight.ts
+++ b/src/hooks/useViewportHeight.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 /**
  * Hook to set a CSS custom property `--vh` representing 1% of the viewport height.
- * Updates the value on window resize to address mobile browser UI chrome.
+ * Updates the value on window resize or orientation change to address mobile browser UI chrome.
  */
 export const useViewportHeight = () => {
   useEffect(() => {
@@ -15,6 +15,11 @@ export const useViewportHeight = () => {
 
     setVh();
     window.addEventListener('resize', setVh);
-    return () => window.removeEventListener('resize', setVh);
+    window.addEventListener('orientationchange', setVh);
+
+    return () => {
+      window.removeEventListener('resize', setVh);
+      window.removeEventListener('orientationchange', setVh);
+    };
   }, []);
 };

--- a/src/index.css
+++ b/src/index.css
@@ -328,11 +328,11 @@
   html {
     /* Ensures minimum 12px fonts for accessibility */
     font-size: 100%;
-    overflow-x: hidden;
+    overflow: hidden;
   }
 
   body {
-    @apply bg-background text-foreground overflow-x-hidden;
+    @apply bg-background text-foreground overflow-hidden;
     scrollbar-gutter: stable both-axis;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
@@ -495,8 +495,6 @@
 
 /* Wizard specific styles */
 .wizard-container {
-  height: 100vh;
-  height: -webkit-fill-available;
   height: calc(var(--vh) * 100);
 }
 


### PR DESCRIPTION
## Summary
- fix viewport height variable and respond to orientation changes
- use `--vh` variable for mobile layout min height and scroll content
- hide overflow on html/body and use `--vh` for wizard container height

## Testing
- `npm test`
- `npm run lint` *(fails: 42 errors, 260 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b11d118c68832d96aa0188dde116bb