### PR TITLE
Fix mobile radio input overlay blocking scroll

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -310,7 +310,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 value="proprio"
                 checked={imovelProprio === 'proprio'}
                 onChange={(e) => setImovelProprio(e.target.value as 'proprio')}
-                className="absolute inset-0 opacity-0"
+                className="absolute inset-0 opacity-0 pointer-events-none"
                 required
               />
               <Home className="w-4 h-4" />
@@ -327,7 +327,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 value="terceiro"
                 checked={imovelProprio === 'terceiro'}
                 onChange={(e) => setImovelProprio(e.target.value as 'terceiro')}
-                className="absolute inset-0 opacity-0"
+                className="absolute inset-0 opacity-0 pointer-events-none"
                 required
               />
               <Building className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- add `pointer-events-none` to hidden radio inputs in compact property selection so scroll works on mobile
- ensure labels remain positioned with `relative`

## Testing
- `npm run lint` *(fails: 302 problems, 42 errors)*
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b139668f8c832db759ef0a7a75c4c2