### PR TITLE
fix: enable scrolling for compact property radios

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -304,13 +304,14 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 imovelProprio === 'proprio' ? 'bg-white text-libra-blue' : 'bg-white/50 text-libra-navy'
               }`}
             >
+              {/* Disable pointer events on hidden input to allow page scrolling */}
               <input
                 type="radio"
                 name="imovelProprioCompact"
                 value="proprio"
                 checked={imovelProprio === 'proprio'}
                 onChange={(e) => setImovelProprio(e.target.value as 'proprio')}
-                className="absolute inset-0 opacity-0"
+                className="absolute inset-0 opacity-0 pointer-events-none"
                 required
               />
               <Home className="w-4 h-4" />
@@ -327,7 +328,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
                 value="terceiro"
                 checked={imovelProprio === 'terceiro'}
                 onChange={(e) => setImovelProprio(e.target.value as 'terceiro')}
-                className="absolute inset-0 opacity-0"
+                className="absolute inset-0 opacity-0 pointer-events-none"
                 required
               />
               <Building className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- disable pointer events on compact property radio inputs so they no longer block vertical scrolling
- document the pointer-events trick on the hidden radio input

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: 302 problems, 42 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b139668f8c832db759ef0a7a75c4c2