### PR TITLE
fix: restore vertical scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -328,11 +328,11 @@
   html {
     /* Ensures minimum 12px fonts for accessibility */
     font-size: 100%;
-    overflow: hidden;
+    overflow-x: hidden;
   }
 
   body {
-    @apply bg-background text-foreground overflow-hidden;
+    @apply bg-background text-foreground overflow-x-hidden;
     scrollbar-gutter: stable both-axis;
     font-feature-settings: "rlig" 1, "calt" 1;
   }

--- a/src/styles/critical-inline.css
+++ b/src/styles/critical-inline.css
@@ -11,11 +11,11 @@ body {
   font-weight: 300;
   background: #ffffff;
   scrollbar-gutter: stable both-axis;
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 html {
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 :root {

--- a/src/styles/critical.css
+++ b/src/styles/critical.css
@@ -45,11 +45,11 @@
 
 /* Estilos de base do corpo */
 html {
-  @apply overflow-hidden;
+  @apply overflow-x-hidden;
 }
 
 body {
-  @apply bg-background text-foreground overflow-hidden;
+  @apply bg-background text-foreground overflow-x-hidden;
   scrollbar-gutter: stable both-axis;
   font-feature-settings: "rlig" 1, "calt" 1;
 }


### PR DESCRIPTION
## Summary
- fix overflow handling for html and body in main and critical styles so vertical scroll works

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected console statement and other lint errors)*
- `npm run typecheck`
- `npm run build` *(fails: fetch failed when generating sitemap)*

------
https://chatgpt.com/codex/tasks/task_e_68b1414e3aa0832d95e0c18dff55092d