### PR TITLE
feat: adjust autocomplete scroll on mobile

### DIFF
--- a/src/components/form/CityAutocomplete.tsx
+++ b/src/components/form/CityAutocomplete.tsx
@@ -105,6 +105,29 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
     }
   };
 
+  // Ensure suggestion list stays visible above the mobile keyboard
+  useEffect(() => {
+    if (!isFocused || suggestions.length === 0) return;
+
+    const timeout = setTimeout(() => {
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const container = containerRef.current;
+      const list = container?.querySelector('ul');
+      if (!container || !list) return;
+
+      const containerTop = container.getBoundingClientRect().top;
+      const listHeight = list.getBoundingClientRect().height;
+      const excess = containerTop + listHeight - viewportHeight;
+
+      if (excess > 0) {
+        const headerHeight = 80;
+        scrollToTarget(container, excess - headerHeight);
+      }
+    }, 0);
+
+    return () => clearTimeout(timeout);
+  }, [suggestions, isFocused]);
+
   // Handle focus
   const handleFocus = (): void => {
     setIsFocused(true);


### PR DESCRIPTION
## Summary
- ensure city autocomplete suggestions stay above the mobile keyboard

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, console statements)*

------
https://chatgpt.com/codex/tasks/task_e_68b146086bf4832da0e2e6d9e3fa7e8b