### PR TITLE
feat: improve loan amount focus flow

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -40,7 +40,7 @@
  * @see {@link formatBRL} para formatação de valores
  */
 
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { validateForm } from '@/utils/validations';
@@ -63,6 +63,7 @@ import { toast } from '@/components/ui/use-toast';
 const SimulationForm: React.FC = () => {
   const { sessionId, visitorId, trackSimulation } = useUserJourney();
   const isMobile = useIsMobile();
+  const loanAmountRef = useRef<HTMLInputElement>(null);
   const [emprestimo, setEmprestimo] = useState('');
   const [garantia, setGarantia] = useState('');
   const [parcelas, setParcelas] = useState<number>(180);
@@ -455,11 +456,17 @@ const SimulationForm: React.FC = () => {
               
               <CityAutocomplete
                 value={cidade}
-                onCityChange={setCidade}
+                onCityChange={(city) => {
+                  setCidade(city);
+                  if (isMobile && city) {
+                    setTimeout(() => loanAmountRef.current?.focus(), 0);
+                  }
+                }}
                 isInvalid={invalidCity}
               />
 
               <LoanAmountField
+                ref={loanAmountRef}
                 value={emprestimo}
                 onChange={handleEmprestimoChange}
                 isInvalid={invalidLoan}

--- a/src/components/form/LoanAmountField.tsx
+++ b/src/components/form/LoanAmountField.tsx
@@ -12,29 +12,32 @@ interface LoanAmountFieldProps {
   isInvalid?: boolean;
 }
 
-const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange, isInvalid = false }) => {
-  return (
-    <div className="flex flex-col gap-1">
-      <label className="text-xs font-medium text-green-700 mb-1 flex items-center gap-1">
-        Digite o valor desejado do Empréstimo
-        <ResponsiveInfo content="Insira aqui o valor que você pretende pegar de empréstimo." />
-      </label>
-      <div className="flex items-center gap-2">
-        <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-          <DollarSign className="w-4 h-4 text-green-700" />
-        </div>
-        <div className="flex-1">
-          <Input
-            value={value}
-            onChange={(e) => onChange(e.target.value)}
-            placeholder="entre 100 mil e 5 milhões"
-            className={cn('text-sm', isInvalid && 'border-red-500 focus:border-red-500 focus:ring-red-500')}
-            inputMode="numeric"
-          />
+const LoanAmountField = React.forwardRef<HTMLInputElement, LoanAmountFieldProps>(
+  ({ value, onChange, isInvalid = false }, ref) => {
+    return (
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-green-700 mb-1 flex items-center gap-1">
+          Digite o valor desejado do Empréstimo
+          <ResponsiveInfo content="Insira aqui o valor que você pretende pegar de empréstimo." />
+        </label>
+        <div className="flex items-center gap-2">
+          <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
+            <DollarSign className="w-4 h-4 text-green-700" />
+          </div>
+          <div className="flex-1">
+            <Input
+              ref={ref}
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder="entre 100 mil e 5 milhões"
+              className={cn('text-sm', isInvalid && 'border-red-500 focus:border-red-500 focus:ring-red-500')}
+              inputMode="numeric"
+            />
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
 
 export default LoanAmountField;


### PR DESCRIPTION
## Summary
- allow LoanAmountField to accept refs and forward to underlying input
- focus loan amount field after city selection on mobile

## Testing
- `npm run lint` *(fails: 42 errors)*
- `npx eslint src/components/form/LoanAmountField.tsx src/components/SimulationForm.tsx` *(warn: 1)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b14620e46c832d8adcd23d4fd6a087