### PR TITLE
fix: shorten simulation subtitle on mobile

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -446,7 +446,7 @@ const SimulationForm: React.FC = () => {
               Sua simulação em um clique!
             </CardTitle>
             <p className="text-gray-600 text-xs">
-              Com apenas algumas informações você já entende se as parcelas que cabem no orçamento!
+              Veja se as parcelas encaixam no orçamento.
             </p>
           </CardHeader>
           


### PR DESCRIPTION
## Summary
- shorten simulation subtitle for mobile

## Testing
- `npm test`
- `npm run lint` *(fails: many warnings and errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b147c0fde4832db3edba9ad78aac5e