### PR TITLE
fix: keep city suggestions visible above mobile keyboard

### DIFF
--- a/src/components/form/CityAutocomplete.tsx
+++ b/src/components/form/CityAutocomplete.tsx
@@ -105,26 +105,29 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
     }
   };
 
+  const adjustSuggestionsPosition = (): void => {
+    if (!isFocused || suggestions.length === 0) return;
+    const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+    const container = containerRef.current;
+    const list = container?.querySelector('ul');
+    if (!container || !list) return;
+
+    const containerTop = container.getBoundingClientRect().top;
+    const listHeight = list.getBoundingClientRect().height;
+    const excess = containerTop + listHeight - viewportHeight;
+
+    if (excess > 0) {
+      const headerHeight = 80;
+      scrollToTarget(container, excess - headerHeight);
+    }
+  };
+
   // Ensure suggestion list stays visible above the mobile keyboard
   useEffect(() => {
     if (!isFocused || suggestions.length === 0) return;
-
     const timeout = setTimeout(() => {
-      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
-      const container = containerRef.current;
-      const list = container?.querySelector('ul');
-      if (!container || !list) return;
-
-      const containerTop = container.getBoundingClientRect().top;
-      const listHeight = list.getBoundingClientRect().height;
-      const excess = containerTop + listHeight - viewportHeight;
-
-      if (excess > 0) {
-        const headerHeight = 80;
-        scrollToTarget(container, excess - headerHeight);
-      }
+      adjustSuggestionsPosition();
     }, 0);
-
     return () => clearTimeout(timeout);
   }, [suggestions, isFocused]);
 
@@ -132,6 +135,7 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
   const handleFocus = (): void => {
     setIsFocused(true);
     scrollToInput();
+    adjustSuggestionsPosition();
   };
 
   // Handle blur


### PR DESCRIPTION
## Summary
- adjust city suggestions position based on visual viewport height
- trigger scroll adjustment on focus and when suggestions change

## Testing
- `npm test`
- `npm run lint` (fails: 42 errors, 261 warnings)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b147edd094832d9222df04c2dac3d5