### PR TITLE
feat: scroll simulation card on city focus

### DIFF
--- a/src/components/form/CityAutocomplete.tsx
+++ b/src/components/form/CityAutocomplete.tsx
@@ -70,17 +70,17 @@ const CityAutocomplete: React.FC<CityAutocompleteProps> = ({ value = '', onCityC
     };
   }, [inputValue]);
 
-  // Function to scroll input to top of viewport
+  // Function to scroll simulation card to top of viewport on mobile
   const scrollToInput = (): void => {
-    if (inputRef.current && window.innerWidth < 768) {
+    if (window.innerWidth < 768) {
       if (scrollTimeout.current) {
         clearTimeout(scrollTimeout.current);
       }
       scrollTimeout.current = setTimeout(() => {
-        if (!inputRef.current) return;
         const headerHeight = 80;
-        if (document.activeElement === inputRef.current) {
-          scrollToTarget(inputRef.current as HTMLElement, -headerHeight);
+        const card = document.getElementById('simulation-card');
+        if (document.activeElement === inputRef.current && card) {
+          scrollToTarget(card as HTMLElement, -headerHeight);
         }
       }, 300);
 


### PR DESCRIPTION
## Summary
- ensure mobile scrolls to simulation card when city field gains focus

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected console statement, Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68b14a911bd0832dbc1f4b191f76fd0a