### PR TITLE
Improve mobile guarantee step flow

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -40,7 +40,7 @@
  * @see {@link formatBRL} para formatação de valores
  */
 
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { validateForm } from '@/utils/validations';
@@ -73,6 +73,14 @@ const SimulationForm: React.FC = () => {
   const [erro, setErro] = useState('');
   const [apiMessage, setApiMessage] = useState<ApiMessageAnalysis | null>(null);
   const [isRuralProperty, setIsRuralProperty] = useState(false);
+
+  const amortizationRef = useRef<HTMLDivElement>(null);
+
+  const handleProceedToAmortization = () => {
+    const active = document.activeElement as HTMLElement | null;
+    active?.blur();
+    amortizationRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
 
   // Validações
   const validation = validateForm(emprestimo, garantia, parcelas, amortizacao, cidade);
@@ -472,13 +480,25 @@ const SimulationForm: React.FC = () => {
                 isInvalid={invalidGuarantee}
               />
 
+              {isMobile && (
+                <Button
+                  type="button"
+                  onClick={handleProceedToAmortization}
+                  className="w-full bg-green-500 hover:bg-green-600 text-white py-2 text-sm font-semibold"
+                >
+                  Prosseguir
+                </Button>
+              )}
+
               <InstallmentsField value={parcelas} onChange={setParcelas} />
 
-              <AmortizationField
-                value={amortizacao}
-                onChange={setAmortizacao}
-                isInvalid={invalidAmortization}
-              />
+              <div ref={amortizationRef}>
+                <AmortizationField
+                  value={amortizacao}
+                  onChange={setAmortizacao}
+                  isInvalid={invalidAmortization}
+                />
+              </div>
 
               {/* Botões */}
               <div className="flex gap-2 pt-2">


### PR DESCRIPTION
## Summary
- add mobile-only prosseguir button after guarantee field to hide keyboard and reveal amortization options
- scroll to amortization section when proceeding from guarantee input

## Testing
- `npm test`
- `npm run lint` *(fails: 42 errors, 260 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b146771ad8832d8c0e7e7d8c0398c9