### PR TITLE
Ensure confirmation page scrolls to top on load

### DIFF
--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -45,6 +45,12 @@ const Confirmacao = () => {
         'Confirmação de envio da simulação. Em breve nossa equipe entrará em contato.'
       );
     }
+    const mainContent = document.getElementById('main-content');
+    if (mainContent) {
+      // Garante que o usuário comece no topo da página de confirmação
+      mainContent.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    }
+    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- Scroll mobile layout's main container and window to the top when confirmation page loads

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b14d5690a8832d9fc0978ba3132daf