### PR TITLE
Remove unnecessary mobile proceed button

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -75,14 +75,6 @@ const SimulationForm: React.FC = () => {
   const [apiMessage, setApiMessage] = useState<ApiMessageAnalysis | null>(null);
   const [isRuralProperty, setIsRuralProperty] = useState(false);
 
-  const amortizationRef = useRef<HTMLDivElement>(null);
-
-  const handleProceedToAmortization = () => {
-    const active = document.activeElement as HTMLElement | null;
-    active?.blur();
-    amortizationRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  };
-
   // Validações
   const validation = validateForm(emprestimo, garantia, parcelas, amortizacao, cidade);
 
@@ -487,19 +479,9 @@ const SimulationForm: React.FC = () => {
                 isInvalid={invalidGuarantee}
               />
 
-              {isMobile && (
-                <Button
-                  type="button"
-                  onClick={handleProceedToAmortization}
-                  className="w-full bg-green-500 hover:bg-green-600 text-white py-2 text-sm font-semibold"
-                >
-                  Prosseguir
-                </Button>
-              )}
-
               <InstallmentsField value={parcelas} onChange={setParcelas} />
 
-              <div ref={amortizationRef}>
+              <div>
                 <AmortizationField
                   value={amortizacao}
                   onChange={setAmortizacao}


### PR DESCRIPTION
## Summary
- remove extra Prosseguir button below guarantee field in simulation form
- simplify form flow by dropping unused scroll helper

## Testing
- `npm test`
- `npm run lint` *(fails: 42 errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b154d21664832d90a43c471cc052b5