### PR TITLE
Remove mobile "Prosseguir" button from simulation form

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -75,14 +75,6 @@ const SimulationForm: React.FC = () => {
   const [apiMessage, setApiMessage] = useState<ApiMessageAnalysis | null>(null);
   const [isRuralProperty, setIsRuralProperty] = useState(false);
 
-  const amortizationRef = useRef<HTMLDivElement>(null);
-
-  const handleProceedToAmortization = () => {
-    const active = document.activeElement as HTMLElement | null;
-    active?.blur();
-    amortizationRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  };
-
   // Validações
   const validation = validateForm(emprestimo, garantia, parcelas, amortizacao, cidade);
 
@@ -487,25 +479,13 @@ const SimulationForm: React.FC = () => {
                 isInvalid={invalidGuarantee}
               />
 
-              {isMobile && (
-                <Button
-                  type="button"
-                  onClick={handleProceedToAmortization}
-                  className="w-full bg-green-500 hover:bg-green-600 text-white py-2 text-sm font-semibold"
-                >
-                  Prosseguir
-                </Button>
-              )}
-
               <InstallmentsField value={parcelas} onChange={setParcelas} />
 
-              <div ref={amortizationRef}>
-                <AmortizationField
-                  value={amortizacao}
-                  onChange={setAmortizacao}
-                  isInvalid={invalidAmortization}
-                />
-              </div>
+              <AmortizationField
+                value={amortizacao}
+                onChange={setAmortizacao}
+                isInvalid={invalidAmortization}
+              />
 
               {/* Botões */}
               <div className="flex gap-2 pt-2">


### PR DESCRIPTION
## Summary
- remove explicit "Prosseguir" button from simulation form
- drop unused scroll helper for amortization field

## Testing
- `npm test`
- `npm run lint` *(fails: 42 errors, 261 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b155d7e4a8832db9d0d9d6599503cf