### PR TITLE
fix: add defaults for confirmacao page

### DIFF
--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -1,9 +1,26 @@
 import React, { useEffect } from 'react';
 import MobileLayout from '@/components/MobileLayout';
 import { Button } from '@/components/ui/button';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 const Confirmacao = () => {
+  const location = useLocation();
+  const state = (location.state as {
+    summaryText?: string;
+    whatsappLink?: string;
+  }) || {};
+  const summaryText =
+    state.summaryText ||
+    (typeof window !== 'undefined'
+      ? localStorage.getItem('summaryText')
+      : null) ||
+    '';
+  const whatsappLink =
+    state.whatsappLink ||
+    (typeof window !== 'undefined'
+      ? localStorage.getItem('whatsappLink')
+      : null) ||
+    '';
   useEffect(() => {
     document.title = 'Simulação Enviada | Libra Crédito';
     const metaDescription = document.querySelector('meta[name="description"]');

--- a/src/pages/__tests__/Confirmacao.test.tsx
+++ b/src/pages/__tests__/Confirmacao.test.tsx
@@ -1,0 +1,44 @@
+/* @vitest-environment jsdom */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import Confirmacao from '../Confirmacao';
+
+vi.mock('@/components/MobileLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/WaveSeparator', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+describe('Confirmacao page', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders without preloaded data', () => {
+    render(
+      <MemoryRouter>
+        <Confirmacao />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText(/Simulação enviada com sucesso/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Conheça a Libra/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /Falar com a Atendente/i })
+    ).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- prevent ReferenceError on `Confirmacao` by reading data from location or localStorage with safe defaults
- add test ensuring confirmation page renders without preloaded data

## Testing
- `npm test`
- `npm run lint` *(fails: 304 problems)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b15993580c832da075bc7b75bdb387