### PR TITLE
fix: ensure confirmation page scrolls to top

### DIFF
--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useLayoutEffect } from 'react';
 import MobileLayout from '@/components/MobileLayout';
 import { Button } from '@/components/ui/button';
 import { Link, useLocation } from 'react-router-dom';
@@ -22,6 +22,7 @@ const Confirmacao = () => {
       : null) ||
     '';
   useEffect(() => {
+    // Runs once on mount to update page metadata
     document.title = 'Simulação Enviada | Libra Crédito';
     const metaDescription = document.querySelector('meta[name="description"]');
     if (metaDescription) {
@@ -30,6 +31,9 @@ const Confirmacao = () => {
         'Confirmação de envio da simulação. Em breve nossa equipe entrará em contato.'
       );
     }
+  }, []);
+
+  useLayoutEffect(() => {
     const mainContent = document.getElementById('main-content');
     if (mainContent) {
       // Garante que o usuário comece no topo da página de confirmação

--- a/src/pages/__tests__/Confirmacao.test.tsx
+++ b/src/pages/__tests__/Confirmacao.test.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import Confirmacao from '../Confirmacao';
 
@@ -19,8 +19,33 @@ vi.mock('@/components/ui/button', () => ({
 }));
 
 describe('Confirmacao page', () => {
+  let mainScrollMock: ReturnType<typeof vi.fn>;
+  let windowScrollMock: ReturnType<typeof vi.fn>;
+  let metaSetAttributeMock: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     window.localStorage.clear();
+
+    const main = document.createElement('div');
+    main.id = 'main-content';
+    mainScrollMock = vi.fn();
+    // @ts-expect-error - assigning mock to scrollTo for test environment
+    main.scrollTo = mainScrollMock;
+    document.body.appendChild(main);
+
+    windowScrollMock = vi.fn();
+    // @ts-expect-error - jsdom doesn't implement scrollTo by default
+    window.scrollTo = windowScrollMock;
+
+    const meta = document.createElement('meta');
+    meta.name = 'description';
+    metaSetAttributeMock = vi.spyOn(meta, 'setAttribute');
+    document.head.appendChild(meta);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
   });
 
   it('renders without preloaded data', () => {
@@ -39,6 +64,33 @@ describe('Confirmacao page', () => {
     expect(
       screen.queryByRole('link', { name: /Falar com a Atendente/i })
     ).toBeNull();
+  });
+
+  it('scrolls to top on mount', () => {
+    render(
+      <MemoryRouter>
+        <Confirmacao />
+      </MemoryRouter>
+    );
+
+    expect(document.title).toBe('Simulação Enviada | Libra Crédito');
+    expect(metaSetAttributeMock).toHaveBeenCalledWith(
+      'content',
+      'Confirmação de envio da simulação. Em breve nossa equipe entrará em contato.'
+    );
+    expect(metaSetAttributeMock).toHaveBeenCalledTimes(1);
+    expect(mainScrollMock).toHaveBeenCalledWith({
+      top: 0,
+      left: 0,
+      behavior: 'auto',
+    });
+    expect(windowScrollMock).toHaveBeenCalledWith({
+      top: 0,
+      left: 0,
+      behavior: 'auto',
+    });
+    expect(mainScrollMock).toHaveBeenCalledTimes(1);
+    expect(windowScrollMock).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure confirmation metadata only updates once
- scroll confirmation view and window to top on mount via `useLayoutEffect`
- add tests covering scroll behavior and metadata updates

## Testing
- `npm test`
- `npm run lint` *(fails: 42 errors, 261 warnings)*
- `npx eslint src/pages/Confirmacao.tsx src/pages/__tests__/Confirmacao.test.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b15f27c9b8832d9c49677fd3dd9f5c