### PR TITLE
fix: add space in confirmation title

### DIFF
--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -43,7 +43,7 @@ const Confirmacao = () => {
       <WaveSeparator variant="hero" height="md" inverted />
       <div className="flex flex-col items-center justify-center py-12 px-4 text-center space-y-6 bg-white">
 
-        <h1 className="text-2xl font-bold text-libra-navy">✅Simulação enviada com sucesso</h1>
+        <h1 className="text-2xl font-bold text-libra-navy">✅ Simulação enviada com sucesso</h1>
         <p className="text-base text-gray-700">
           Recebemos seus dados e em breve, um dos nossos analistas entrará em contato com você.
         </p>


### PR DESCRIPTION
## Summary
- ensure the confirmation page heading includes a space after the emoji for readability

## Testing
- `npm test`
- `npm run lint` *(fails: 303 problems across repo)*
- `npx eslint src/pages/Confirmacao.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b15f2e7504832d99ca37a33518175e