### PR TITLE
Add WhatsApp summary message on contact confirmation

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -192,7 +192,17 @@ const ContactForm: React.FC<ContactFormProps> = ({
 
       };
 
-      navigate('/confirmacao', { state: { summary } });
+      const currency = new Intl.NumberFormat('pt-BR', {
+        style: 'currency',
+        currency: 'BRL'
+      });
+      const valorEmprestimo = currency.format(summary.valorEmprestimo);
+      const valorParcela = currency.format(summary.valorParcela);
+      const valorImovel = currency.format(summary.valorImovel);
+      const mensagem = `Olá, meu nome é ${summary.nome}. Gostaria de um empréstimo de ${valorEmprestimo} em ${summary.parcelas} parcelas pelo sistema ${summary.amortizacao}. A parcela fica ${valorParcela}. Tenho ${summary.imovelProprio === 'proprio' ? 'imóvel próprio' : 'imóvel de terceiro'} em ${summary.cidade} avaliado em ${valorImovel}.`;
+      const whatsappLink = `https://wa.me/5516997338791?text=${encodeURIComponent(mensagem)}`;
+
+      navigate('/confirmacao', { state: { summary, whatsappLink } });
       
       // Limpar formulário
       setNome('');

--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -6,17 +6,10 @@ import WaveSeparator from '@/components/ui/WaveSeparator';
 
 const Confirmacao = () => {
   const location = useLocation();
-  const state =
-    (location.state as {
-      whatsappLink?: string;
-    }) || {};
-
-  const whatsappLink =
-    state.whatsappLink ||
-    (typeof window !== 'undefined'
-      ? localStorage.getItem('whatsappLink')
-      : null) ||
-    'https://wa.me/551636007956';
+  const { summary, whatsappLink: stateWhatsappLink } =
+    (location.state as { summary?: unknown; whatsappLink?: string }) || {};
+  void summary;
+  const whatsappLink = stateWhatsappLink || 'https://wa.me/5516997338791';
   useEffect(() => {
     // Runs once on mount to update page metadata
     document.title = 'Simulação Enviada | Libra Crédito';

--- a/src/pages/__tests__/Confirmacao.test.tsx
+++ b/src/pages/__tests__/Confirmacao.test.tsx
@@ -25,10 +25,23 @@ describe('Confirmacao page', () => {
 
   beforeEach(() => {
     window.localStorage.clear();
-    // Mock scrollTo to avoid jsdom not implemented error
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    window.scrollTo = vi.fn();
+    mainScrollMock = vi.fn();
+    windowScrollMock = vi.fn();
+    metaSetAttributeMock = vi.fn();
+    document.getElementById = vi.fn().mockReturnValue({ scrollTo: mainScrollMock });
+    document.querySelector = vi
+      .fn()
+      .mockImplementation((selector) =>
+        selector === 'meta[name="description"]'
+          ? { setAttribute: metaSetAttributeMock }
+          : null
+      );
+    window.scrollTo = windowScrollMock;
 
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('renders without preloaded data', () => {
@@ -49,7 +62,7 @@ describe('Confirmacao page', () => {
     });
     expect(atendenteLink).toHaveAttribute(
       'href',
-      'https://wa.me/551636007956'
+      'https://wa.me/5516997338791'
     );
   });
 


### PR DESCRIPTION
## Summary
- Compose WhatsApp message with formatted loan details in ContactForm and navigate to confirmation with link
- Read WhatsApp link from navigation state in confirmation page and open chat in new tab
- Update confirmation page tests for new WhatsApp link and state handling

## Testing
- `npm test`
- `npm run lint` *(fails: 303 problems (42 errors, 261 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b16439e6e4832db4655993b9192965