### PR TITLE
feat: make WhatsApp button configurable

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -23,6 +23,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Switch } from '@/components/ui/switch';
 import { LocalSimulationService, type SessionGroupWithJourney } from '@/services/localSimulationService';
 
 import { PartnersService } from '@/services/partnersService';
@@ -111,7 +112,8 @@ const AdminDashboard: React.FC = () => {
     custoOperacional: 11.0,
     dfiPercentual: 0.014,
     prestamistaPercentual: 0.035,
-    taxaAdministrativa: 40
+    taxaAdministrativa: 40,
+    showWhatsappButton: true
   });
   const [loadingConfig, setLoadingConfig] = useState(false);
   const [loadingParceiros, setLoadingParceiros] = useState(false);
@@ -202,7 +204,8 @@ const AdminDashboard: React.FC = () => {
           custoOperacional: config.custoOperacional || 11.0,
           dfiPercentual: config.dfiPercentual || 0.014,
           prestamistaPercentual: config.prestamistaPercentual || 0.035,
-          taxaAdministrativa: config.taxaAdministrativa || 40
+          taxaAdministrativa: config.taxaAdministrativa || 40,
+          showWhatsappButton: config.showWhatsappButton ?? true
         });
       }
     } catch (error) {
@@ -1619,10 +1622,27 @@ Escreva seu conteúdo aqui...
                     </div>
                   </div>
                 </div>
+                <div>
+                  <h4 className="font-medium text-gray-900 mb-3">Botão do WhatsApp</h4>
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id="show-whatsapp-button"
+                      checked={simulationConfig.showWhatsappButton}
+                      onCheckedChange={(checked) =>
+                        setSimulationConfig({
+                          ...simulationConfig,
+                          showWhatsappButton: checked
+                        })
+                      }
+                    />
+                    <label htmlFor="show-whatsapp-button" className="text-sm text-gray-700">
+                      Exibir botão "Falar com a Atendente" na confirmação
+                    </label>
+                  </div>
+                </div>
 
-                
                 <div className="pt-4 border-t">
-                  <Button 
+                  <Button
                     className="bg-libra-blue hover:bg-libra-blue/90"
                     onClick={handleSaveConfig}
                     disabled={loadingConfig}

--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useLayoutEffect } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import MobileLayout from '@/components/MobileLayout';
 import { Button } from '@/components/ui/button';
 import { Link, useLocation } from 'react-router-dom';
 import WaveSeparator from '@/components/ui/WaveSeparator';
+import { BlogService } from '@/services/blogService';
 
 const Confirmacao = () => {
   const location = useLocation();
@@ -10,6 +11,7 @@ const Confirmacao = () => {
     (location.state as { summary?: unknown; whatsappLink?: string }) || {};
   void summary;
   const whatsappLink = stateWhatsappLink || 'https://wa.me/5516997338791';
+  const [showWhatsappButton, setShowWhatsappButton] = useState(true);
   useEffect(() => {
     // Runs once on mount to update page metadata
     document.title = 'Simulação Enviada | Libra Crédito';
@@ -20,6 +22,18 @@ const Confirmacao = () => {
         'Confirmação de envio da simulação. Em breve nossa equipe entrará em contato.'
       );
     }
+  }, []);
+
+  useEffect(() => {
+    const loadConfig = async () => {
+      try {
+        const config = await BlogService.getSimulationConfig();
+        setShowWhatsappButton(config.showWhatsappButton);
+      } catch (error) {
+        console.error('Erro ao carregar configuração:', error);
+      }
+    };
+    void loadConfig();
   }, []);
 
   useLayoutEffect(() => {
@@ -43,19 +57,23 @@ const Confirmacao = () => {
         <p className="text-base text-gray-700">
           Fique atento ao telefone (16) 36007956 para nosso contato.
         </p>
-        <p className="text-base text-gray-700">
-          Quer acelerar seu processo? Fale com nossa Atendente Virtual
-        </p>
+        {showWhatsappButton && (
+          <p className="text-base text-gray-700">
+            Quer acelerar seu processo? Fale com nossa Atendente Virtual
+          </p>
+        )}
 
         <div className="flex flex-col sm:flex-row gap-4 mt-4">
-          <Button
-            asChild
-            className="px-6 bg-[#25D366] hover:bg-[#1EBEA5] text-white"
-          >
-            <Link to={whatsappLink} target="_blank" rel="noopener noreferrer">
-              Falar com a Atendente
-            </Link>
-          </Button>
+          {showWhatsappButton && (
+            <Button
+              asChild
+              className="px-6 bg-[#25D366] hover:bg-[#1EBEA5] text-white"
+            >
+              <Link to={whatsappLink} target="_blank" rel="noopener noreferrer">
+                Falar com a Atendente
+              </Link>
+            </Button>
+          )}
           <Button asChild variant="default" className="px-6">
             <Link to="/quem-somos">Conheça a Libra</Link>
           </Button>

--- a/src/services/blogService.ts
+++ b/src/services/blogService.ts
@@ -59,9 +59,10 @@ export interface SimulationConfig {
   
   // URL da API
   apiUrl: string;
-  
+
   // Configurações gerais
   custoOperacional: number;
+  showWhatsappButton: boolean;
   updateAt?: string;
 }
 
@@ -874,7 +875,14 @@ export class BlogService {
   static async getSimulationConfig(): Promise<SimulationConfig> {
     try {
       const stored = localStorage.getItem(this.CONFIG_KEY);
-      return stored ? JSON.parse(stored) : {
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        return {
+          showWhatsappButton: true,
+          ...parsed
+        } as SimulationConfig;
+      }
+      return {
         // Limites de valor (baseado na API atual)
         valorMinimo: 100000,
         valorMaximo: 5000000,
@@ -891,9 +899,10 @@ export class BlogService {
         
         // URL da API
         apiUrl: 'https://api-calculos.vercel.app/simulacao',
-        
+
         // Configurações gerais
-        custoOperacional: 0.5
+        custoOperacional: 0.5,
+        showWhatsappButton: true
       };
     } catch (error) {
       console.error('Erro ao carregar configurações:', error);


### PR DESCRIPTION
## Summary
- allow simulation config to specify if the WhatsApp button should be shown
- expose toggle in admin dashboard
- hide confirmation WhatsApp text and button when disabled

## Testing
- `npm run lint` *(fails: Unexpected console statement, Unexpected any)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b16e78b10c832da767c761aa992014