### PR TITLE
feat: unify user journey and simulation storage

### DIFF
--- a/src/hooks/useUserJourney.ts
+++ b/src/hooks/useUserJourney.ts
@@ -21,7 +21,11 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
-import type { UserJourneyData, PageVisit, DeviceInfo } from '@/lib/supabase';
+import type {
+  UserJourneySimulacaoData,
+  PageVisit,
+  DeviceInfo
+} from '@/lib/supabase';
 
 // Lazy loader para evitar carregar Supabase na primeira pintura
 type SupabaseApi = typeof import('@/lib/supabase').supabaseApi;
@@ -52,7 +56,7 @@ interface UserJourneyHook {
   isTracking: boolean;
   trackPageVisit: (url?: string) => void;
   trackSimulation: (simulationData: unknown) => void;
-  getJourneyData: () => UserJourneyData | null;
+  getJourneyData: () => UserJourneySimulacaoData | null;
   updateTimeOnSite: () => void;
 }
 
@@ -142,7 +146,8 @@ export function useUserJourney(): UserJourneyHook {
   const [sessionId, setSessionId] = useState<string>('');
   const [visitorId, setVisitorId] = useState<string>('');
   const [isTracking, setIsTracking] = useState(false);
-  const [journeyData, setJourneyData] = useState<UserJourneyData | null>(null);
+  const [journeyData, setJourneyData] =
+    useState<UserJourneySimulacaoData | null>(null);
   const pageStartTime = useRef<number>(Date.now());
   const sessionStartTime = useRef<number>(Date.now());
   const ipFetchedRef = useRef<boolean>(false);
@@ -245,7 +250,7 @@ export function useUserJourney(): UserJourneyHook {
           const utms = extractUTMParams();
           const deviceInfo = getDeviceInfo();
 
-          const newJourney: UserJourneyData = {
+          const newJourney: UserJourneySimulacaoData = {
             session_id: sessionId,
             visitor_id: visitorId,
             utm_source: utms.utm_source || null,
@@ -260,7 +265,9 @@ export function useUserJourney(): UserJourneyHook {
             ip_address: null
           };
 
-          existingJourney = await supabaseApi.createUserJourney(newJourney);
+          existingJourney = await supabaseApi.createUserJourneySimulacao(
+            newJourney
+          );
 
           if (process.env.NODE_ENV === 'development') {
             console.log('Nova jornada criada:', existingJourney);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -79,24 +79,6 @@ export interface ParceiroData {
   updated_at?: string;
 }
 
-export interface UserJourneyData {
-  id?: string;
-  session_id: string;
-  visitor_id?: string;
-  utm_source?: string;
-  utm_medium?: string;
-  utm_campaign?: string;
-  utm_term?: string;
-  utm_content?: string;
-  referrer?: string;
-  landing_page: string;
-  pages_visited: PageVisit[];
-  time_on_site?: number;
-  device_info?: DeviceInfo;
-  ip_address?: string;
-  created_at?: string;
-  updated_at?: string;
-}
 
 export interface PageVisit {
   url: string;
@@ -111,6 +93,38 @@ export interface DeviceInfo {
   device_type: 'mobile' | 'tablet' | 'desktop';
   browser: string;
   os: string;
+}
+
+export interface UserJourneySimulacaoData {
+  id?: string;
+  session_id: string;
+  visitor_id?: string;
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+  utm_term?: string | null;
+  utm_content?: string | null;
+  referrer?: string | null;
+  landing_page?: string;
+  pages_visited?: PageVisit[];
+  time_on_site?: number;
+  device_info?: DeviceInfo;
+  ip_address?: string | null;
+  user_agent?: string | null;
+  nome_completo?: string | null;
+  email?: string | null;
+  telefone?: string | null;
+  cidade?: string | null;
+  valor_emprestimo?: number | null;
+  valor_imovel?: number | null;
+  parcelas?: number | null;
+  tipo_amortizacao?: string | null;
+  parcela_inicial?: number | null;
+  parcela_final?: number | null;
+  imovel_proprio?: 'proprio' | 'terceiro' | null;
+  status?: string | null;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export interface BlogPostData {
@@ -145,10 +159,10 @@ export interface Database {
         Insert: Omit<ParceiroData, 'id' | 'created_at' | 'updated_at'>;
         Update: Partial<Omit<ParceiroData, 'id' | 'created_at'>>;
       };
-      user_journey: {
-        Row: UserJourneyData;
-        Insert: Omit<UserJourneyData, 'id' | 'created_at' | 'updated_at'>;
-        Update: Partial<Omit<UserJourneyData, 'id' | 'created_at'>>;
+      user_journey_simulacoes: {
+        Row: UserJourneySimulacaoData;
+        Insert: Omit<UserJourneySimulacaoData, 'id' | 'created_at' | 'updated_at'>;
+        Update: Partial<Omit<UserJourneySimulacaoData, 'id' | 'created_at'>>;
       };
       blog_posts: {
         Row: BlogPostData;
@@ -243,9 +257,23 @@ export const supabaseApi = {
       .eq('id', id)
       .select()
       .single();
-    
+
     if (error) throw error;
     return data;
+  },
+
+  // User Journey + Simulação
+  async createUserJourneySimulacao(
+    data: Database['public']['Tables']['user_journey_simulacoes']['Insert']
+  ) {
+    const { data: result, error } = await supabase
+      .from('user_journey_simulacoes')
+      .upsert(data, { onConflict: 'session_id' })
+      .select()
+      .single();
+
+    if (error) throw error;
+    return result;
   },
 
   // Parceiros
@@ -283,50 +311,27 @@ export const supabaseApi = {
     return data;
   },
 
-  // User Journey
-  async createUserJourney(data: Database['public']['Tables']['user_journey']['Insert']) {
-    // Usar insert simples primeiro, depois upsert se necessário
+  async updateUserJourney(
+    sessionId: string,
+    data: Database['public']['Tables']['user_journey_simulacoes']['Update']
+  ) {
     const { data: result, error } = await supabase
-      .from('user_journey')
-      .insert(data)
-      .select()
-      .maybeSingle();
-    
-    if (error) {
-      // Se der erro de conflito, tentar upsert
-      if (error.code === '23505') { // código de unique constraint violation
-        const { data: upsertResult, error: upsertError } = await supabase
-          .from('user_journey')
-          .upsert(data, { onConflict: 'session_id' })
-          .select()
-          .maybeSingle();
-        
-        if (upsertError) throw upsertError;
-        return upsertResult;
-      }
-      throw error;
-    }
-    return result;
-  },
-
-  async updateUserJourney(sessionId: string, data: Database['public']['Tables']['user_journey']['Update']) {
-    const { data: result, error } = await supabase
-      .from('user_journey')
+      .from('user_journey_simulacoes')
       .update(data)
       .eq('session_id', sessionId)
       .select()
       .maybeSingle();
-    
+
     if (error) throw error;
     return result;
   },
 
   async getUserJourney(sessionId: string) {
     const { data, error } = await supabase
-      .from('user_journey')
+      .from('user_journey_simulacoes')
       .select('*')
       .eq('session_id', sessionId)
-      .maybeSingle(); // Use maybeSingle ao invés de single para evitar erro quando não encontrar
+      .maybeSingle();
 
     if (error) throw error;
     return data;
@@ -334,7 +339,7 @@ export const supabaseApi = {
 
   async getUserJourneysBySessionIds(sessionIds: string[]) {
     const { data, error } = await supabase
-      .from('user_journey')
+      .from('user_journey_simulacoes')
       .select('*')
       .in('session_id', sessionIds);
 
@@ -344,7 +349,7 @@ export const supabaseApi = {
 
   async getUserJourneysByVisitorIds(visitorIds: string[]) {
     const { data, error } = await supabase
-      .from('user_journey')
+      .from('user_journey_simulacoes')
       .select('*')
       .in('visitor_id', visitorIds);
 

--- a/src/lib/supabaseLazy.ts
+++ b/src/lib/supabaseLazy.ts
@@ -126,9 +126,23 @@ async function loadSupabaseClient() {
             .eq('id', id)
             .select()
             .single();
-          
+
           if (error) throw error;
           return data;
+        },
+
+        // User Journey + Simulação
+        async createUserJourneySimulacao(
+          data: Database['public']['Tables']['user_journey_simulacoes']['Insert']
+        ) {
+          const { data: result, error } = await client
+            .from('user_journey_simulacoes')
+            .upsert(data, { onConflict: 'session_id' })
+            .select()
+            .single();
+
+          if (error) throw error;
+          return result;
         },
 
         // Parceiros
@@ -166,49 +180,28 @@ async function loadSupabaseClient() {
           return data;
         },
 
-        // User Journey
-        async createUserJourney(data: Database['public']['Tables']['user_journey']['Insert']) {
+        async updateUserJourney(
+          sessionId: string,
+          data: Database['public']['Tables']['user_journey_simulacoes']['Update']
+        ) {
           const { data: result, error } = await client
-            .from('user_journey')
-            .insert(data)
-            .select()
-            .maybeSingle();
-          
-          if (error) {
-            if (error.code === '23505') {
-              const { data: upsertResult, error: upsertError } = await client
-                .from('user_journey')
-                .upsert(data, { onConflict: 'session_id' })
-                .select()
-                .maybeSingle();
-              
-              if (upsertError) throw upsertError;
-              return upsertResult;
-            }
-            throw error;
-          }
-          return result;
-        },
-
-        async updateUserJourney(sessionId: string, data: Database['public']['Tables']['user_journey']['Update']) {
-          const { data: result, error } = await client
-            .from('user_journey')
+            .from('user_journey_simulacoes')
             .update(data)
             .eq('session_id', sessionId)
             .select()
             .maybeSingle();
-          
+
           if (error) throw error;
           return result;
         },
 
         async getUserJourney(sessionId: string) {
           const { data, error } = await client
-            .from('user_journey')
+            .from('user_journey_simulacoes')
             .select('*')
             .eq('session_id', sessionId)
             .maybeSingle();
-          
+
           if (error) throw error;
           return data;
         },

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -15,7 +15,12 @@
  */
 
 import { validateEmail, validatePhone } from '@/utils/validations';
-import { supabaseApi, SimulacaoData, supabase } from '@/lib/supabase';
+import {
+  supabaseApi,
+  SimulacaoData,
+  supabase,
+  UserJourneySimulacaoData
+} from '@/lib/supabase';
 
 // Reutilizar interfaces do serviço original
 export interface SimulationInput {
@@ -96,7 +101,6 @@ export class LocalSimulationService {
     const results: T[] = [];
     for (let i = 0; i < ids.length; i += chunkSize) {
       const chunk = ids.slice(i, i + chunkSize);
-      let supabaseErrorOccurred = false;
       try {
         results.push(...await fetchFn(chunk));
       } catch (journeyError) {
@@ -212,7 +216,10 @@ export class LocalSimulationService {
                                   input.telefone !== '';
 
         if (hasRealContactData) {
-          const supabaseData = {
+          const supabaseData: Omit<
+            UserJourneySimulacaoData,
+            'id' | 'created_at' | 'updated_at'
+          > = {
             session_id: input.sessionId,
             visitor_id: input.visitorId || null,
 
@@ -240,7 +247,9 @@ export class LocalSimulationService {
             original_local_id: simulationId
           });
 
-          const supabaseResult = await supabaseApi.createSimulacao(supabaseData);
+          const supabaseResult = await supabaseApi.createUserJourneySimulacao(
+            supabaseData
+          );
           console.log('✅ Simulação salva no Supabase:', {
             success: !!supabaseResult?.id,
             supabase_id: supabaseResult?.id,

--- a/src/services/simulationService.ts
+++ b/src/services/simulationService.ts
@@ -19,9 +19,9 @@
  * 5. Retorna dados para o componente
  */
 
-import { supabaseApi, SimulacaoData } from '@/lib/supabase';
+import { supabaseApi, UserJourneySimulacaoData } from '@/lib/supabase';
 import { simulateCredit } from '@/services/simulationApi';
-import { validateEmail, validatePhone, formatPhone } from '@/utils/validations';
+import { validateEmail, formatPhone } from '@/utils/validations';
 import { PloomesService } from '@/services/ploomesService';
 import { WebhookService } from '@/services/webhookService';
 
@@ -96,10 +96,16 @@ export class SimulationService {
       console.log('✅ Resposta da API:', apiResult);
       
       // 4. Processar resultado da API
-      const processedResult = this.processApiResult(apiResult, input.tipoAmortizacao, input.parcelas);
+      const processedResult = this.processApiResult(
+        apiResult,
+        input.tipoAmortizacao
+      );
       
       // 5. Preparar dados para Supabase
-      const supabaseData: Omit<SimulacaoData, 'id' | 'created_at'> = {
+      const supabaseData: Omit<
+        UserJourneySimulacaoData,
+        'id' | 'created_at' | 'updated_at'
+      > = {
         session_id: input.sessionId,
         nome_completo: input.nomeCompleto,
         email: input.email,
@@ -120,7 +126,9 @@ export class SimulationService {
       console.log('💾 Salvando no Supabase:', supabaseData);
       
       // 6. Salvar no Supabase
-      const savedSimulation = await supabaseApi.createSimulacao(supabaseData);
+      const savedSimulation = await supabaseApi.createUserJourneySimulacao(
+        supabaseData
+      );
       
       console.log('✅ Simulação salva:', savedSimulation);
       
@@ -358,7 +366,7 @@ export class SimulationService {
   /**
    * Processar resultado da API
    */
-  private static processApiResult(apiResult: any, amortizacao: string, parcelas: number) {
+  private static processApiResult(apiResult: any, amortizacao: string) {
     if (!apiResult || !apiResult.parcelas || !Array.isArray(apiResult.parcelas)) {
       throw new Error('API retornou estrutura de dados inválida');
     }


### PR DESCRIPTION
## Summary
- add `user_journey_simulacoes` types and CRUD helpers
- consolidate inserts via `createUserJourneySimulacao`
- update services and tracking hook to use unified storage

## Testing
- `npm run lint` *(fails: 42 errors, 261 warnings across repo)*
- `npx eslint src/lib/supabase.ts src/lib/supabaseLazy.ts src/services/simulationService.ts src/services/localSimulationService.ts src/hooks/useUserJourney.ts`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bae38a6098832d8aadf2981983fe17