### PR TITLE
Send secondary webhook for local simulation contacts

### DIFF
--- a/src/services/__tests__/localSimulationService.test.ts
+++ b/src/services/__tests__/localSimulationService.test.ts
@@ -4,6 +4,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const supabaseMock = { from: vi.fn() } as any;
 vi.mock('@/lib/supabase', () => ({ supabase: supabaseMock, supabaseApi: {} }));
 
+const sendSimulationDataMock = vi.fn();
+vi.mock('@/services/webhookService', () => ({
+  WebhookService: {
+    sendSimulationData: sendSimulationDataMock
+  }
+}));
+
 // Simple in-memory localStorage mock
 class LocalStorageMock {
   private store: Record<string, string> = {};
@@ -16,6 +23,7 @@ class LocalStorageMock {
 describe('LocalSimulationService', () => {
   beforeEach(() => {
     supabaseMock.from.mockReset();
+    sendSimulationDataMock.mockReset();
     (global as any).localStorage = new LocalStorageMock();
     (global as any).fetch = vi.fn(async () => ({
       ok: true,
@@ -25,10 +33,14 @@ describe('LocalSimulationService', () => {
       headers: { entries: () => [] }
     }));
     process.env.VITE_ALERT_WEBHOOK_URL = 'https://alert.test';
+    delete process.env.VITE_WEBHOOK_URL;
+    delete process.env.VITE_WEBHOOK_SECONDARY_URL;
   });
 
   afterEach(() => {
     delete (global as any).fetch;
+    delete process.env.VITE_WEBHOOK_URL;
+    delete process.env.VITE_WEBHOOK_SECONDARY_URL;
   });
 
   it('salva contato local e envia alerta quando atualização no Supabase falha', async () => {
@@ -99,5 +111,116 @@ describe('LocalSimulationService', () => {
     expect(stored[0].simulationId).toBe('123');
     const fetchCalls = (global as any).fetch.mock.calls.map((c: any[]) => c[0]);
     expect(fetchCalls).toContain('https://alert.test');
+    expect(sendSimulationDataMock).not.toHaveBeenCalled();
+  });
+
+  it('envia dados para webhooks configurados após contato bem-sucedido', async () => {
+    const simulationRecord = {
+      id: 'supabase-123',
+      session_id: 'sess1',
+      cidade: 'São Paulo',
+      valor_emprestimo: 150000,
+      valor_imovel: 300000,
+      parcelas: 180,
+      tipo_amortizacao: 'PRICE',
+      parcela_inicial: 2500,
+      parcela_final: 2500,
+      status: 'novo',
+      user_agent: 'Agent',
+      ip_address: '127.0.0.1'
+    } as const;
+
+    supabaseMock.from
+      .mockImplementationOnce(() => ({
+        select: () => ({
+          eq: () => ({
+            single: async () => ({ data: simulationRecord, error: null })
+          })
+        })
+      }))
+      .mockImplementationOnce(() => ({
+        select: () => ({
+          eq: () => ({
+            single: async () => ({ data: simulationRecord, error: null })
+          })
+        })
+      }))
+      .mockImplementationOnce(() => ({
+        update: () => ({
+          eq: () => ({
+            select: async () => ({
+              data: [
+                {
+                  ...simulationRecord,
+                  nome_completo: 'John Doe',
+                  email: 'john@example.com',
+                  telefone: '11999999999',
+                  imovel_proprio: 'proprio',
+                  status: 'interessado'
+                }
+              ],
+              error: null
+            })
+          })
+        })
+      }));
+
+    sendSimulationDataMock
+      .mockResolvedValueOnce({ success: true, timestamp: new Date().toISOString(), attempt: 1 })
+      .mockResolvedValueOnce({ success: true, timestamp: new Date().toISOString(), attempt: 1 });
+
+    process.env.VITE_WEBHOOK_URL = 'https://primary.test';
+    process.env.VITE_WEBHOOK_SECONDARY_URL = 'https://secondary.test';
+
+    const { LocalSimulationService } = await import('../localSimulationService');
+
+    const input = {
+      simulationId: 'supabase-123',
+      sessionId: 'sess1',
+      visitorId: 'visit1',
+      nomeCompleto: 'John Doe',
+      email: 'john@example.com',
+      telefone: '11999999999',
+      cidade: 'São Paulo',
+      imovelProprio: 'proprio' as const,
+      valorDesejadoEmprestimo: 150000,
+      valorImovelGarantia: 300000,
+      quantidadeParcelas: 180,
+      tipoAmortizacao: 'PRICE',
+      valorParcelaCalculada: 2500,
+      aceitaPolitica: true
+    };
+
+    const result = await LocalSimulationService.processContact(input);
+
+    expect(result).toEqual({
+      success: true,
+      message: 'Dados enviados com sucesso! Nossa equipe entrará em contato em breve.'
+    });
+
+    expect(sendSimulationDataMock).toHaveBeenCalledTimes(2);
+    const [primaryCall, secondaryCall] = sendSimulationDataMock.mock.calls;
+
+    expect(primaryCall[0]).toMatchObject({
+      simulationId: 'supabase-123',
+      sessionId: 'sess1',
+      nomeCompleto: 'John Doe',
+      email: 'john@example.com',
+      telefone: '11999999999',
+      cidade: 'São Paulo',
+      imovelProprio: 'proprio',
+      valorEmprestimo: 150000,
+      valorImovel: 300000,
+      parcelas: 180,
+      tipoAmortizacao: 'PRICE',
+      valorParcela: 2500,
+      primeiraParcela: 2500,
+      ultimaParcela: 2500,
+      status: 'interessado'
+    });
+    expect(primaryCall[1]).toBeUndefined();
+
+    expect(secondaryCall[0]).toMatchObject({ simulationId: 'supabase-123' });
+    expect(secondaryCall[1]).toEqual({ url: 'https://secondary.test' });
   });
 });

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -21,6 +21,7 @@ import {
   supabase,
   UserJourneySimulacaoData
 } from '@/lib/supabase';
+import { WebhookService } from '@/services/webhookService';
 
 // Reutilizar interfaces do serviço original
 export interface SimulationInput {
@@ -325,7 +326,8 @@ export class LocalSimulationService {
       }
 
       // Obter dados da simulação do Supabase
-      let simulationData = null;
+      let simulationData: SimulacaoData | null = null;
+      let latestSimulationRecord: SimulacaoData | null = null;
       try {
         if (input.simulationId) {
           // Verificar se é um ID local (que não existe no Supabase)
@@ -357,6 +359,7 @@ export class LocalSimulationService {
               console.warn('⚠️ Nenhuma simulação encontrada com session_id:', input.sessionId);
             }
             simulationData = data;
+            latestSimulationRecord = data;
           } else {
             // Para IDs do Supabase, buscar normalmente
             const { data } = await supabase
@@ -365,6 +368,7 @@ export class LocalSimulationService {
               .eq('id', input.simulationId)
               .single();
             simulationData = data;
+            latestSimulationRecord = data;
           }
           console.log('📊 Dados da simulação obtidos:', simulationData);
         }
@@ -486,7 +490,7 @@ export class LocalSimulationService {
 
             // Usar a mesma lógica de busca para atualização/criação
             const isLocalId = input.simulationId.startsWith('local_');
-            let existingData = null;
+            let existingData: SimulacaoData | null = null;
             let updateResult = null;
 
             if (isLocalId) {
@@ -619,6 +623,14 @@ export class LocalSimulationService {
               success: !!data?.[0]
             });
 
+            if (data && data.length > 0) {
+              latestSimulationRecord = data[0] as SimulacaoData;
+            } else if (existingData) {
+              latestSimulationRecord = existingData;
+            } else if (!latestSimulationRecord && simulationData) {
+              latestSimulationRecord = simulationData;
+            }
+
             if (!data || data.length === 0) {
               throw new Error('Nenhuma linha foi atualizada no Supabase');
             }
@@ -646,6 +658,87 @@ export class LocalSimulationService {
       }
 
       console.log('✅ Contato processado com sucesso');
+
+      try {
+        console.log('🪝 Enviando dados para webhook...');
+
+        const baseSimulation = latestSimulationRecord || simulationData;
+        const resolvedCidade = input.cidade?.trim() || baseSimulation?.cidade || 'Não informado';
+        const resolvedValorEmprestimo = baseSimulation?.valor_emprestimo
+          ?? input.valorDesejadoEmprestimo
+          ?? 0;
+        const resolvedValorImovel = baseSimulation?.valor_imovel
+          ?? input.valorImovelGarantia
+          ?? 0;
+        const resolvedParcelas = baseSimulation?.parcelas
+          ?? input.quantidadeParcelas
+          ?? 0;
+        const baseTipo = baseSimulation?.tipo_amortizacao
+          ?? input.tipoAmortizacao
+          ?? 'PRICE';
+        const tipoAmortizacao = baseTipo.toUpperCase();
+        const primeiraParcela = baseSimulation?.parcela_inicial
+          ?? input.valorParcelaCalculada
+          ?? undefined;
+        const ultimaParcela = baseSimulation?.parcela_final
+          ?? input.valorParcelaCalculada
+          ?? undefined;
+        const valorParcela = tipoAmortizacao === 'SAC'
+          ? (primeiraParcela ?? ultimaParcela ?? 0)
+          : (ultimaParcela ?? primeiraParcela ?? 0);
+
+        const webhookPayload = {
+          simulationId: input.simulationId,
+          sessionId: input.sessionId,
+          nomeCompleto: input.nomeCompleto,
+          email: input.email,
+          telefone: input.telefone,
+          cidade: resolvedCidade,
+          imovelProprio: input.imovelProprio,
+          observacoes: input.observacoes,
+          valorEmprestimo: resolvedValorEmprestimo,
+          valorImovel: resolvedValorImovel,
+          parcelas: resolvedParcelas,
+          tipoAmortizacao,
+          valorParcela,
+          primeiraParcela: primeiraParcela ?? undefined,
+          ultimaParcela: ultimaParcela ?? undefined,
+          status: baseSimulation?.status ?? 'interessado',
+          userAgent: baseSimulation?.user_agent ?? undefined,
+          ipAddress: baseSimulation?.ip_address ?? undefined
+        };
+
+        const webhookCalls = [
+          WebhookService.sendSimulationData(webhookPayload)
+        ];
+
+        const secondaryUrl = process.env.VITE_WEBHOOK_SECONDARY_URL;
+        if (secondaryUrl) {
+          webhookCalls.push(
+            WebhookService.sendSimulationData(webhookPayload, { url: secondaryUrl })
+          );
+        }
+
+        const results = await Promise.all(webhookCalls);
+        const primaryResult = results[0];
+        const secondaryResult = results[1];
+
+        if (primaryResult?.success) {
+          console.log('✅ Webhook enviado com sucesso');
+        } else {
+          console.warn('⚠️ Falha no webhook (não crítico):', primaryResult?.message);
+        }
+
+        if (secondaryUrl) {
+          if (secondaryResult?.success) {
+            console.log('✅ Webhook secundário enviado com sucesso');
+          } else {
+            console.warn('⚠️ Falha no webhook secundário (não crítico):', secondaryResult?.message);
+          }
+        }
+      } catch (webhookError) {
+        console.error('❌ Erro no webhook (não crítico):', webhookError);
+      }
 
       // Após sucesso, tentar reenviar contatos pendentes (exceto quando já é uma tentativa)
       if (!options.isRetry) {


### PR DESCRIPTION
## Summary
- send simulation payloads from LocalSimulationService to the configured primary and secondary webhooks once the Supabase update succeeds
- capture the latest Supabase data to build a complete webhook payload and keep the main flow resilient to webhook failures
- extend the localSimulationService tests to mock WebhookService and assert primary/secondary dispatch behavior

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d14edcb0f4832d946cfda155f4bef1