### PR TITLE
Use import.meta.env for webhook configuration

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,32 @@
+export type WebhookUrl = string;
+export type OptionalWebhookUrl = WebhookUrl | undefined;
+
+type MaybeString = string | null | undefined;
+
+type WebhookEnvKeys =
+  | 'VITE_WEBHOOK_URL'
+  | 'VITE_WEBHOOK_SECONDARY_URL'
+  | 'VITE_ALERT_WEBHOOK_URL';
+
+const normalizeEnvValue = (value: unknown): OptionalWebhookUrl => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const readWebhookEnv = (key: WebhookEnvKeys): OptionalWebhookUrl => {
+  return normalizeEnvValue(import.meta.env[key] as MaybeString);
+};
+
+export const getPrimaryWebhookUrl = (): OptionalWebhookUrl => readWebhookEnv('VITE_WEBHOOK_URL');
+
+export const getSecondaryWebhookUrl = (): OptionalWebhookUrl => readWebhookEnv('VITE_WEBHOOK_SECONDARY_URL');
+
+export const getAlertWebhookUrl = (): OptionalWebhookUrl => readWebhookEnv('VITE_ALERT_WEBHOOK_URL');
+
+export const resolveWebhookUrl = (override?: MaybeString): OptionalWebhookUrl => {
+  return normalizeEnvValue(override) ?? getPrimaryWebhookUrl();
+};

--- a/src/services/__tests__/localSimulationService.test.ts
+++ b/src/services/__tests__/localSimulationService.test.ts
@@ -24,11 +24,12 @@ describe('LocalSimulationService', () => {
       statusText: 'OK',
       headers: { entries: () => [] }
     }));
-    process.env.VITE_ALERT_WEBHOOK_URL = 'https://alert.test';
+    vi.stubEnv('VITE_ALERT_WEBHOOK_URL', 'https://alert.test');
   });
 
   afterEach(() => {
     delete (global as any).fetch;
+    vi.unstubAllEnvs();
   });
 
   it('salva contato local e envia alerta quando atualização no Supabase falha', async () => {

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -14,6 +14,7 @@
  * - Compatibilidade total com componentes existentes
  */
 
+import { getAlertWebhookUrl } from '@/lib/env';
 import { validateEmail, validatePhone } from '@/utils/validations';
 import {
   supabaseApi,
@@ -896,7 +897,7 @@ export class LocalSimulationService {
    * Envia alerta via webhook quando o contato não pôde ser salvo
    */
   private static async sendFailureAlert(input: ContactFormInput, error: unknown): Promise<void> {
-    const webhookUrl = process.env.VITE_ALERT_WEBHOOK_URL;
+    const webhookUrl = getAlertWebhookUrl();
     if (!webhookUrl) {
       console.warn('⚠️ URL de alerta não configurada');
       return;

--- a/src/services/simulationService.ts
+++ b/src/services/simulationService.ts
@@ -19,6 +19,7 @@
  * 5. Retorna dados para o componente
  */
 
+import { getSecondaryWebhookUrl } from '@/lib/env';
 import { supabaseApi, UserJourneySimulacaoData } from '@/lib/supabase';
 import { simulateCredit } from '@/services/simulationApi';
 import { validateEmail, formatPhone } from '@/utils/validations';
@@ -280,7 +281,7 @@ export class SimulationService {
           WebhookService.sendSimulationData(webhookPayload)
         ];
 
-        const secondaryUrl = process.env.VITE_WEBHOOK_SECONDARY_URL;
+        const secondaryUrl = getSecondaryWebhookUrl();
         if (secondaryUrl) {
           webhookCalls.push(
             WebhookService.sendSimulationData(webhookPayload, { url: secondaryUrl })

--- a/src/services/webhookService.ts
+++ b/src/services/webhookService.ts
@@ -1,16 +1,16 @@
 /**
  * Serviço de Webhook para envio de dados de simulação
- * 
+ *
  * @service webhookService
  * @description Serviço responsável por enviar dados da simulação finalizada para webhooks externos
- * 
+ *
  * @features
  * - Envio de dados completos da simulação
  * - Retry automático em caso de falha
  * - Logging detalhado
  * - Validação de payload
  * - Configuração flexível de URLs
- * 
+ *
  * @workflow
  * 1. Recebe dados da simulação completa
  * 2. Valida e formata os dados
@@ -18,6 +18,8 @@
  * 4. Implementa retry em caso de falha
  * 5. Registra resultado
  */
+
+import { resolveWebhookUrl, type WebhookUrl } from '@/lib/env';
 
 export interface WebhookPayload {
   // Dados da simulação
@@ -54,7 +56,7 @@ export interface WebhookPayload {
 }
 
 export interface WebhookConfig {
-  url: string;
+  url: WebhookUrl;
   timeout?: number;
   retries?: number;
   headers?: Record<string, string>;
@@ -82,7 +84,7 @@ export class WebhookService {
   ): Promise<WebhookResult> {
     
     // Obter URL do webhook das variáveis de ambiente
-    const webhookUrl = config?.url || process.env.VITE_WEBHOOK_URL;
+    const webhookUrl = resolveWebhookUrl(config?.url);
     
     if (!webhookUrl) {
       console.warn('⚠️ URL do webhook não configurada');
@@ -172,7 +174,7 @@ export class WebhookService {
    * Fazer requisição HTTP para o webhook
    */
   private static async makeWebhookRequest(
-    url: string,
+    url: WebhookUrl,
     payload: WebhookPayload,
     config?: WebhookConfig,
     attempt: number = 1
@@ -249,8 +251,8 @@ export class WebhookService {
   /**
    * Testar conectividade do webhook
    */
-  static async testWebhook(url?: string): Promise<WebhookResult> {
-    const testUrl = url || process.env.VITE_WEBHOOK_URL;
+  static async testWebhook(url?: WebhookUrl): Promise<WebhookResult> {
+    const testUrl = resolveWebhookUrl(url);
     
     if (!testUrl) {
       return {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_WEBHOOK_URL?: string;
+  readonly VITE_WEBHOOK_SECONDARY_URL?: string;
+  readonly VITE_ALERT_WEBHOOK_URL?: string;
+}

--- a/temp-files/test-pages/TestWebhook.tsx
+++ b/temp-files/test-pages/TestWebhook.tsx
@@ -9,11 +9,13 @@ import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { getPrimaryWebhookUrl } from '@/lib/env';
 import { WebhookService, WebhookResult } from '@/services/webhookService';
 import MobileLayout from '@/components/MobileLayout';
 
 const TestWebhook: React.FC = () => {
-  const [webhookUrl, setWebhookUrl] = useState(process.env.VITE_WEBHOOK_URL || '');
+  const defaultWebhookUrl = getPrimaryWebhookUrl() || '';
+  const [webhookUrl, setWebhookUrl] = useState(defaultWebhookUrl);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<WebhookResult | null>(null);
   const [customData, setCustomData] = useState({
@@ -109,8 +111,8 @@ const TestWebhook: React.FC = () => {
                 className="w-full"
               />
               <p className="text-sm text-gray-500">
-                {process.env.VITE_WEBHOOK_URL ? 
-                  `URL padrão: ${process.env.VITE_WEBHOOK_URL}` : 
+                {defaultWebhookUrl ?
+                  `URL padrão: ${defaultWebhookUrl}` :
                   'Nenhuma URL configurada no .env'
                 }
               </p>


### PR DESCRIPTION
## Summary
- add a centralised env helper for webhook URLs that normalises Vite environment variables
- refactor webhook, simulation and local simulation services plus related test utilities to consume the new helper instead of process.env
- update the webhook test page and Vite env typings to keep consistent import.meta.env usage

## Testing
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19bf5b938832d950bc40134491d5d