### PR TITLE
Preserve local simulation IDs when syncing contacts

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -21,7 +21,8 @@ import { cn } from '@/lib/utils';
  */
 interface ContactFormProps {
   simulationResult: {
-    id?: string;
+    id: string;
+    userJourneyId?: string;
     valor: number;
     amortizacao: string;
     parcelas: number;
@@ -106,6 +107,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
     console.log('🔍 Debug dados da simulação:', {
       simulationResult,
       simulationId: simulationResult.id,
+      userJourneyId: simulationResult.userJourneyId,
       sessionId,
       hasId: !!simulationResult.id,
       hasSessionId: !!sessionId
@@ -153,6 +155,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
         simulationId: simulationResult.id,
         sessionId,
         visitorId,
+        ...(simulationResult.userJourneyId ? { userJourneyId: simulationResult.userJourneyId } : {}),
         nomeCompleto: nome,
         email,
         telefone,

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -34,15 +34,6 @@ beforeEach(() => {
 });
 
 describe('ContactForm', () => {
-  const simulationResult = {
-    id: 'sim1',
-    valor: 1000,
-    amortizacao: 'PRICE',
-    parcelas: 12,
-    valorEmprestimo: 50000,
-    valorImovel: 100000,
-    cidade: 'São Paulo'
-  } as any;
 
   it('forwards journey UTM params to LocalSimulationService.processContact', async () => {
     mockGetJourneyData.mockReturnValue({
@@ -54,6 +45,17 @@ describe('ContactForm', () => {
       landing_page: 'https://example.com',
       referrer: 'https://referrer.com'
     });
+
+    const simulationResult = {
+      id: 'local_sim1',
+      userJourneyId: 'supabase-123',
+      valor: 1000,
+      amortizacao: 'PRICE',
+      parcelas: 12,
+      valorEmprestimo: 50000,
+      valorImovel: 100000,
+      cidade: 'São Paulo'
+    } as any;
 
     render(<ContactForm simulationResult={simulationResult} />);
 
@@ -68,6 +70,7 @@ describe('ContactForm', () => {
     await waitFor(() => {
       expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
         expect.objectContaining({
+          userJourneyId: 'supabase-123',
           utm_source: 'google',
           utm_medium: 'cpc',
           utm_campaign: 'camp',
@@ -83,6 +86,16 @@ describe('ContactForm', () => {
 
   it('handles missing journey data and submits with null UTM fields', async () => {
     mockGetJourneyData.mockReturnValue(undefined);
+
+    const simulationResult = {
+      id: 'local_sim2',
+      valor: 1000,
+      amortizacao: 'PRICE',
+      parcelas: 12,
+      valorEmprestimo: 50000,
+      valorImovel: 100000,
+      cidade: 'São Paulo'
+    } as any;
 
     render(<ContactForm simulationResult={simulationResult} />);
 

--- a/src/services/__tests__/localSimulationService.test.ts
+++ b/src/services/__tests__/localSimulationService.test.ts
@@ -100,4 +100,89 @@ describe('LocalSimulationService', () => {
     const fetchCalls = (global as any).fetch.mock.calls.map((c: any[]) => c[0]);
     expect(fetchCalls).toContain('https://alert.test');
   });
+
+  it('cria registro no Supabase quando recebe ID local sem correspondência', async () => {
+    const inserted: any[] = [];
+
+    supabaseMock.from.mockImplementation((table: string) => {
+      if (table !== 'simulacoes') {
+        throw new Error(`Unexpected table ${table}`);
+      }
+
+      const createOrderResult = () => {
+        const response = { data: [] as any[], error: null };
+        const orderResult: any = {};
+        orderResult.limit = async () => response;
+        orderResult.then = (resolve: any) => resolve(response);
+        orderResult.catch = () => orderResult;
+        orderResult.finally = () => orderResult;
+        return orderResult;
+      };
+
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            order: vi.fn(() => createOrderResult()),
+            single: vi.fn(async () => ({ data: null, error: null }))
+          }))
+        })),
+        insert: vi.fn((data: any) => {
+          inserted.push(data);
+          return {
+            select: async () => ({ data: [{ id: 'supabase-id', ...data }], error: null })
+          };
+        }),
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: async () => ({ data: [{ id: 'supabase-id' }], error: null })
+          }))
+        }))
+      };
+    });
+
+    const { LocalSimulationService } = await import('../localSimulationService');
+
+    localStorage.setItem('libra_local_simulations', JSON.stringify([
+      {
+        id: 'local_abc',
+        valor: 100,
+        amortizacao: 'PRICE',
+        parcelas: 36,
+        primeiraParcela: 100,
+        ultimaParcela: 80,
+        valorEmprestimo: 1000,
+        valorImovel: 2000,
+        cidade: 'Cidade'
+      }
+    ]));
+
+    const input = {
+      simulationId: 'local_abc',
+      sessionId: 'sess1',
+      visitorId: 'visit1',
+      nomeCompleto: 'John Local',
+      email: 'john@example.com',
+      telefone: '11999999999',
+      cidade: 'Cidade',
+      imovelProprio: 'proprio' as const,
+      valorDesejadoEmprestimo: 1000,
+      valorImovelGarantia: 2000,
+      quantidadeParcelas: 36,
+      tipoAmortizacao: 'PRICE',
+      valorParcelaCalculada: 100,
+      aceitaPolitica: true
+    };
+
+    const result = await LocalSimulationService.processContact(input);
+
+    expect(result.success).toBe(true);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      session_id: 'sess1',
+      visitor_id: 'visit1',
+      cidade: 'Cidade',
+      valor_emprestimo: 1000,
+      valor_imovel: 2000
+    });
+  });
 });

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -42,6 +42,7 @@ export interface SimulationInput {
 
 export interface SimulationResult {
   id: string;
+  userJourneyId?: string;
   valor: number;
   amortizacao: string;
   parcelas: number;
@@ -56,6 +57,7 @@ export interface SimulationResult {
 
 export interface ContactFormInput {
   simulationId: string;
+  userJourneyId?: string;
   sessionId: string;
   visitorId?: string;
 
@@ -256,16 +258,15 @@ export class LocalSimulationService {
             local_id: simulationId,
             result: supabaseResult
           });
-          
-          // Usar ID do Supabase se disponível
+
           if (supabaseResult?.id) {
-            console.log('🔄 Substituindo ID local pelo ID do Supabase:', {
-              antes: result.id,
-              depois: supabaseResult.id
+            console.log('🆔 ID do Supabase associado à simulação local:', {
+              local_id: result.id,
+              supabase_id: supabaseResult.id
             });
-            result.id = supabaseResult.id;
+            result.userJourneyId = supabaseResult.id;
           } else {
-            console.warn('⚠️ Supabase não retornou ID, mantendo ID local:', result.id);
+            console.warn('⚠️ Supabase não retornou ID, mantendo apenas ID local:', result.id);
           }
         } else {
           console.log('📝 Simulação não salva no Supabase (dados de contato ausentes):', {
@@ -326,24 +327,35 @@ export class LocalSimulationService {
 
       // Obter dados da simulação do Supabase
       let simulationData = null;
+      const simulationIdIsLocal = input.simulationId?.startsWith('local_');
+      const supabaseSimulationId =
+        input.userJourneyId && !input.userJourneyId.startsWith('local_')
+          ? input.userJourneyId
+          : simulationIdIsLocal
+            ? null
+            : input.simulationId;
+
       try {
         if (input.simulationId) {
-          // Verificar se é um ID local (que não existe no Supabase)
-          const isLocalId = input.simulationId.startsWith('local_');
-          
-          if (isLocalId) {
+          if (supabaseSimulationId) {
+            console.log('🔍 Buscando simulação no Supabase pelo ID informado:', supabaseSimulationId);
+            const { data } = await supabase
+              .from('simulacoes')
+              .select('*')
+              .eq('id', supabaseSimulationId)
+              .single();
+            simulationData = data;
+          } else if (simulationIdIsLocal) {
             console.log('🏠 ID local detectado, buscando por session_id:', input.sessionId);
-            // Para IDs locais, buscar pela session_id mais recente
             const { data: results, error: searchError } = await supabase
               .from('simulacoes')
               .select('*')
               .eq('session_id', input.sessionId)
               .order('created_at', { ascending: false })
               .limit(1);
-              
-            // Pegar o primeiro resultado se existir
+
             const data = results && results.length > 0 ? results[0] : null;
-            
+
             if (searchError) {
               console.warn('⚠️ Erro ao buscar por session_id:', searchError);
               console.log('📋 Tentando buscar todas as simulações para debug...');
@@ -356,14 +368,6 @@ export class LocalSimulationService {
             } else if (!data) {
               console.warn('⚠️ Nenhuma simulação encontrada com session_id:', input.sessionId);
             }
-            simulationData = data;
-          } else {
-            // Para IDs do Supabase, buscar normalmente
-            const { data } = await supabase
-              .from('simulacoes')
-              .select('*')
-              .eq('id', input.simulationId)
-              .single();
             simulationData = data;
           }
           console.log('📊 Dados da simulação obtidos:', simulationData);
@@ -485,13 +489,34 @@ export class LocalSimulationService {
             });
 
             // Usar a mesma lógica de busca para atualização/criação
-            const isLocalId = input.simulationId.startsWith('local_');
+            const isLocalId = Boolean(simulationIdIsLocal);
             let existingData = null;
             let updateResult = null;
 
-            if (isLocalId) {
+            if (supabaseSimulationId) {
+              console.log('🆔 Atualizando simulação no Supabase pelo ID informado:', supabaseSimulationId);
+              const { data: searchData, error: selectError } = await supabase
+                .from('simulacoes')
+                .select('id, nome_completo, email, telefone, imovel_proprio, status, visitor_id')
+                .eq('id', supabaseSimulationId)
+                .single();
+
+              if (selectError) {
+                console.error('❌ Erro ao buscar simulação por ID:', selectError);
+                throw new Error(`Simulação não encontrada: ${selectError.message}`);
+              }
+
+              existingData = searchData;
+
+              const { data, error } = await supabase
+                .from('simulacoes')
+                .update(updateData)
+                .eq('id', supabaseSimulationId)
+                .select();
+
+              updateResult = { data, error };
+            } else if (isLocalId) {
               console.log('🏠 Verificando se existe simulação por session_id:', input.sessionId);
-              // Para IDs locais, buscar pela session_id mais recente
               const { data: searchResults, error: selectError } = await supabase
                 .from('simulacoes')
                 .select('id, nome_completo, email, telefone, imovel_proprio, status, session_id, visitor_id, created_at')
@@ -499,7 +524,6 @@ export class LocalSimulationService {
                 .order('created_at', { ascending: false })
                 .limit(1);
 
-              // Pegar o primeiro resultado se existir
               const searchData = searchResults && searchResults.length > 0 ? searchResults[0] : null;
 
               if (selectError) {
@@ -508,10 +532,8 @@ export class LocalSimulationService {
               }
 
               if (!searchData) {
-                // Não existe no Supabase, criar novo registro
                 console.log('➕ Simulação não existe no Supabase, criando nova...');
 
-                // Buscar dados da simulação do localStorage
                 const localSimulations = JSON.parse(
                   localStorage.getItem('libra_local_simulations') || '[]'
                 );
@@ -523,7 +545,6 @@ export class LocalSimulationService {
                   throw new Error('Dados da simulação não encontrados no localStorage');
                 }
 
-                // Criar registro completo no Supabase
                 const createData = {
                   session_id: input.sessionId,
                   visitor_id: input.visitorId || null,
@@ -553,7 +574,6 @@ export class LocalSimulationService {
                 updateResult = { data, error };
                 console.log('✅ Nova simulação criada:', { data, error });
               } else {
-                // Existe no Supabase, atualizar
                 existingData = searchData;
                 console.log('✅ Simulação encontrada para atualização:', {
                   id: existingData.id,
@@ -562,7 +582,6 @@ export class LocalSimulationService {
                   novo_nome: updateData.nome_completo
                 });
 
-                // Atualizar usando o ID real do Supabase
                 const { data, error } = await supabase
                   .from('simulacoes')
                   .update(updateData)
@@ -573,7 +592,6 @@ export class LocalSimulationService {
                 updateResult = { data, error };
               }
             } else {
-              // Para IDs do Supabase, buscar e atualizar normalmente
               const { data: searchData, error: selectError } = await supabase
                 .from('simulacoes')
                 .select('id, nome_completo, email, telefone, imovel_proprio, status, visitor_id')


### PR DESCRIPTION
## Summary
- keep LocalSimulationService simulation IDs in the local `local_*` format while storing the Supabase journey ID separately and update contact processing to rely on the local ID with an optional journey override
- update ContactForm submissions to forward the optional `userJourneyId` only when present
- extend unit coverage for ContactForm and LocalSimulationService to verify the local-ID flow and Supabase insert behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d19bff9f54832d906ee288ffee84b3