### PR TITLE
Prevent saving placeholder simulation contacts

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -45,6 +45,11 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { validateForm } from '@/utils/validations';
 import { LocalSimulationService, SimulationResult } from '@/services/localSimulationService';
+import {
+  SIMULATION_PLACEHOLDER_EMAIL,
+  SIMULATION_PLACEHOLDER_NAME,
+  SIMULATION_PLACEHOLDER_PHONE
+} from '@/constants/simulationPlaceholders';
 import { useUserJourney } from '@/hooks/useUserJourney';
 import { useIsMobile } from '@/hooks/use-mobile';
 import CityAutocomplete from './form/CityAutocomplete';
@@ -155,9 +160,9 @@ const SimulationForm: React.FC = () => {
       const simulationInput = {
         sessionId,
         visitorId,
-        nomeCompleto: 'Lead Anônimo', // Temporário até preenchimento do contato
-        email: 'nao-informado@temp.com',
-        telefone: '(00) 00000-0000',
+        nomeCompleto: SIMULATION_PLACEHOLDER_NAME, // Temporário até preenchimento do contato
+        email: SIMULATION_PLACEHOLDER_EMAIL,
+        telefone: SIMULATION_PLACEHOLDER_PHONE,
         cidade: cidade,
         valorEmprestimo: validation.emprestimoValue,
         valorImovel: validation.garantiaValue,
@@ -273,9 +278,9 @@ const SimulationForm: React.FC = () => {
         const simulationInput = {
           sessionId,
           visitorId,
-          nomeCompleto: 'Lead Anônimo',
-          email: 'nao-informado@temp.com',
-          telefone: '(00) 00000-0000',
+          nomeCompleto: SIMULATION_PLACEHOLDER_NAME,
+          email: SIMULATION_PLACEHOLDER_EMAIL,
+          telefone: SIMULATION_PLACEHOLDER_PHONE,
           cidade: cidade,
           valorEmprestimo: newValidation.emprestimoValue,
           valorImovel: newValidation.garantiaValue,
@@ -370,9 +375,9 @@ const SimulationForm: React.FC = () => {
         const simulationInput = {
           sessionId,
           visitorId,
-          nomeCompleto: 'Lead Anônimo',
-          email: 'nao-informado@temp.com',
-          telefone: '(00) 00000-0000',
+          nomeCompleto: SIMULATION_PLACEHOLDER_NAME,
+          email: SIMULATION_PLACEHOLDER_EMAIL,
+          telefone: SIMULATION_PLACEHOLDER_PHONE,
           cidade: cidade,
           valorEmprestimo: validation.emprestimoValue,
           valorImovel: validation.garantiaValue,

--- a/src/constants/simulationPlaceholders.ts
+++ b/src/constants/simulationPlaceholders.ts
@@ -1,0 +1,3 @@
+export const SIMULATION_PLACEHOLDER_NAME = 'Lead Anônimo';
+export const SIMULATION_PLACEHOLDER_EMAIL = 'nao-informado@temp.com';
+export const SIMULATION_PLACEHOLDER_PHONE = '(00) 00000-0000';

--- a/src/services/__tests__/localSimulationService.test.ts
+++ b/src/services/__tests__/localSimulationService.test.ts
@@ -1,8 +1,49 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  SIMULATION_PLACEHOLDER_EMAIL,
+  SIMULATION_PLACEHOLDER_NAME,
+  SIMULATION_PLACEHOLDER_PHONE
+} from '@/constants/simulationPlaceholders';
 
 // Mock supabase module before importing the service
 const supabaseMock = { from: vi.fn() } as any;
-vi.mock('@/lib/supabase', () => ({ supabase: supabaseMock, supabaseApi: {} }));
+const supabaseApiMock = {
+  createUserJourneySimulacao: vi.fn(),
+  updateSimulacaoStatus: vi.fn(),
+  getSimulacoes: vi.fn(),
+  getUserJourneysByVisitorIds: vi.fn(),
+  getUserJourneysBySessionIds: vi.fn()
+};
+vi.mock('@/lib/supabase', () => ({ supabase: supabaseMock, supabaseApi: supabaseApiMock }));
+
+const validateCityMock = vi.fn(async (city: string) => ({
+  found: true,
+  status: 'success' as const,
+  allowCalculation: true,
+  city,
+  ltv: 50,
+  message: 'OK'
+}));
+const validateLtvMock = vi.fn(async () => ({ valid: true, message: 'OK' }));
+vi.mock('@/utils/cityLtvService', () => ({
+  validateCity: validateCityMock,
+  validateLTV: validateLtvMock
+}));
+
+const validateLoanParametersMock = vi.fn(() => ({ valid: true }));
+const getInterestRateMock = vi.fn(() => 0.01);
+const calculateLoanMock = vi.fn(() => ({
+  parcelaSac: { inicial: 1500, final: 800 },
+  parcelaPrice: 1200,
+  valorTotal: { sac: 0, price: 0 },
+  jurosTotal: { sac: 0, price: 0 },
+  taxaJurosEfetiva: 0.01
+}));
+vi.mock('@/utils/loanCalculator', () => ({
+  validateLoanParameters: validateLoanParametersMock,
+  getInterestRate: getInterestRateMock,
+  calculateLoan: calculateLoanMock
+}));
 
 // Simple in-memory localStorage mock
 class LocalStorageMock {
@@ -15,7 +56,18 @@ class LocalStorageMock {
 
 describe('LocalSimulationService', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     supabaseMock.from.mockReset();
+    supabaseApiMock.createUserJourneySimulacao.mockReset();
+    supabaseApiMock.updateSimulacaoStatus.mockReset();
+    supabaseApiMock.getSimulacoes.mockReset();
+    supabaseApiMock.getUserJourneysByVisitorIds.mockReset();
+    supabaseApiMock.getUserJourneysBySessionIds.mockReset();
+    validateCityMock.mockClear();
+    validateLtvMock.mockClear();
+    validateLoanParametersMock.mockClear();
+    getInterestRateMock.mockClear();
+    calculateLoanMock.mockClear();
     (global as any).localStorage = new LocalStorageMock();
     (global as any).fetch = vi.fn(async () => ({
       ok: true,
@@ -29,6 +81,59 @@ describe('LocalSimulationService', () => {
 
   afterEach(() => {
     delete (global as any).fetch;
+  });
+
+  it('não cria registros no Supabase quando dados de contato são placeholders', async () => {
+    const { LocalSimulationService } = await import('../localSimulationService');
+
+    const result = await LocalSimulationService.performSimulation({
+      sessionId: 'session-placeholder',
+      visitorId: 'visitor-placeholder',
+      nomeCompleto: SIMULATION_PLACEHOLDER_NAME,
+      email: SIMULATION_PLACEHOLDER_EMAIL,
+      telefone: SIMULATION_PLACEHOLDER_PHONE,
+      cidade: 'São Paulo - SP',
+      valorEmprestimo: 200000,
+      valorImovel: 500000,
+      parcelas: 120,
+      tipoAmortizacao: 'PRICE',
+      userAgent: 'jest',
+      ipAddress: '127.0.0.1',
+      isRuralProperty: false
+    });
+
+    expect(result).toBeDefined();
+    expect(supabaseApiMock.createUserJourneySimulacao).not.toHaveBeenCalled();
+  });
+
+  it('salva simulação no Supabase quando dados válidos são fornecidos', async () => {
+    supabaseApiMock.createUserJourneySimulacao.mockResolvedValue({ id: 'supabase-123' });
+
+    const { LocalSimulationService } = await import('../localSimulationService');
+
+    const result = await LocalSimulationService.performSimulation({
+      sessionId: 'session-valid',
+      visitorId: 'visitor-valid',
+      nomeCompleto: 'Maria Silva',
+      email: 'maria@example.com',
+      telefone: '11987654321',
+      cidade: 'Rio de Janeiro - RJ',
+      valorEmprestimo: 250000,
+      valorImovel: 600000,
+      parcelas: 180,
+      tipoAmortizacao: 'SAC',
+      userAgent: 'jest',
+      ipAddress: '127.0.0.1',
+      isRuralProperty: false
+    });
+
+    expect(supabaseApiMock.createUserJourneySimulacao).toHaveBeenCalledTimes(1);
+    expect(supabaseApiMock.createUserJourneySimulacao).toHaveBeenCalledWith(expect.objectContaining({
+      nome_completo: 'Maria Silva',
+      email: 'maria@example.com',
+      telefone: '11987654321'
+    }));
+    expect(result.id).toBe('supabase-123');
   });
 
   it('salva contato local e envia alerta quando atualização no Supabase falha', async () => {

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -16,6 +16,11 @@
 
 import { validateEmail, validatePhone } from '@/utils/validations';
 import {
+  SIMULATION_PLACEHOLDER_EMAIL,
+  SIMULATION_PLACEHOLDER_NAME,
+  SIMULATION_PLACEHOLDER_PHONE
+} from '@/constants/simulationPlaceholders';
+import {
   supabaseApi,
   SimulacaoData,
   supabase,
@@ -208,12 +213,24 @@ export class LocalSimulationService {
       // 7. Salvar no Supabase apenas se temos dados reais (não salvar placeholders)
       try {
         // Só salvar no Supabase se temos dados de contato reais
-        const hasRealContactData = input.nomeCompleto && 
-                                  input.nomeCompleto !== '' && 
-                                  input.email && 
-                                  input.email !== '' &&
-                                  input.telefone && 
-                                  input.telefone !== '';
+        const normalizedName = (input.nomeCompleto || '').trim();
+        const normalizedEmail = (input.email || '').trim().toLowerCase();
+        const normalizedPhone = (input.telefone || '').trim();
+        const sanitizedPhone = normalizedPhone.replace(/\D/g, '');
+
+        const placeholderName = SIMULATION_PLACEHOLDER_NAME.toLowerCase();
+        const placeholderEmail = SIMULATION_PLACEHOLDER_EMAIL.toLowerCase();
+        const placeholderPhone = SIMULATION_PLACEHOLDER_PHONE.replace(/\D/g, '');
+
+        const hasRealContactData =
+          normalizedName !== '' &&
+          normalizedName.toLowerCase() !== placeholderName &&
+          normalizedEmail !== '' &&
+          normalizedEmail !== placeholderEmail &&
+          validateEmail(normalizedEmail) &&
+          sanitizedPhone !== '' &&
+          sanitizedPhone !== placeholderPhone &&
+          validatePhone(normalizedPhone);
 
         if (hasRealContactData) {
           const supabaseData: Omit<
@@ -268,10 +285,17 @@ export class LocalSimulationService {
             console.warn('⚠️ Supabase não retornou ID, mantendo ID local:', result.id);
           }
         } else {
-          console.log('📝 Simulação não salva no Supabase (dados de contato ausentes):', {
-            nomeCompleto: !!input.nomeCompleto,
-            email: !!input.email, 
-            telefone: !!input.telefone,
+          const isPlaceholderName = normalizedName.toLowerCase() === placeholderName;
+          const isPlaceholderEmail = normalizedEmail === placeholderEmail;
+          const isPlaceholderPhone = sanitizedPhone === placeholderPhone;
+
+          console.log('📝 Simulação não salva no Supabase (dados ausentes ou placeholders):', {
+            nomeCompleto: normalizedName,
+            email: normalizedEmail,
+            telefone: normalizedPhone,
+            isPlaceholderName,
+            isPlaceholderEmail,
+            isPlaceholderPhone,
             session_id: input.sessionId,
             local_id: simulationId
           });


### PR DESCRIPTION
## Summary
- centralize anonymous simulation placeholders in a shared constants module and reuse them across the form/service
- ensure LocalSimulationService.performSimulation skips Supabase persistence when placeholders or invalid contact data are provided
- extend LocalSimulationService tests to cover placeholder handling and successful Supabase writes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d19c13c738832da5f8de74e9390c26