### PR TITLE
Remove WhatsApp CTA from confirmation page

### DIFF
--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -1,15 +1,10 @@
 import React, { useEffect, useLayoutEffect } from 'react';
 import MobileLayout from '@/components/MobileLayout';
 import { Button } from '@/components/ui/button';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 
 const Confirmacao = () => {
-  const location = useLocation();
-  const { summary, whatsappLink: stateWhatsappLink } =
-    (location.state as { summary?: unknown; whatsappLink?: string }) || {};
-  void summary;
-  const whatsappLink = stateWhatsappLink || 'https://wa.me/5516997338791';
   useEffect(() => {
     // Runs once on mount to update page metadata
     document.title = 'Simulação Enviada | Libra Crédito';
@@ -49,15 +44,10 @@ const Confirmacao = () => {
           Fique atento ao telefone (16) 36007956 para nosso contato.
         </p>
         <p className="text-base text-gray-700">
-          Quer acelerar seu processo? Fale com nossa Atendente Virtual
+          Enquanto isso, aproveite para conhecer mais sobre a Libra e nossas soluções clicando
+          no botão abaixo.
         </p>
-
         <div className="flex flex-col sm:flex-row gap-4 mt-4">
-          <Button asChild variant="whatsapp">
-            <Link to={whatsappLink} target="_blank" rel="noopener noreferrer">
-              Falar com a Atendente
-            </Link>
-          </Button>
           <Button asChild variant="default" className="px-6">
             <Link to="/quem-somos">Conheça a Libra</Link>
           </Button>


### PR DESCRIPTION
## Summary
- remove the WhatsApp-specific logic and button from the confirmation page
- update the messaging to direct users solely to the "Conheça a Libra" page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfda4a86e8832da3a97dee4146c209