### PR TITLE
Ensure global tracker mounts on client router

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import ScrollToTop from '@/components/ScrollToTop';
 import { MobileProvider } from '@/hooks/useMobileContext';
+import LazyGlobalTracker from '@/components/LazyGlobalTracker';
 
 // Lazy load TooltipProvider para LCP
 const TooltipProvider = lazy(() => import('@/components/ui/tooltip').then(m => ({ default: m.TooltipProvider })));
@@ -87,6 +88,7 @@ const App = () => {
       <MobileProvider>
         <BrowserRouter>
           <ScrollToTop />
+          {typeof window !== 'undefined' && <LazyGlobalTracker />}
           <Suspense fallback={<Loading />}>
             <Routes>
               <Route path="/" element={<Index />} />


### PR DESCRIPTION
## Summary
- import LazyGlobalTracker into the client App component
- render the tracker inside BrowserRouter so user journey tracking starts on mount
- guard the tracker with a window check to avoid SSR build issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e02ceead1c832db3172243f0a05409