### PR TITLE
Ensure global tracker initializes safely with routing context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import ScrollToTop from '@/components/ScrollToTop';
 import { MobileProvider } from '@/hooks/useMobileContext';
+import LazyGlobalTracker from '@/components/LazyGlobalTracker';
 
 // Lazy load TooltipProvider para LCP
 const TooltipProvider = lazy(() => import('@/components/ui/tooltip').then(m => ({ default: m.TooltipProvider })));
@@ -86,6 +87,7 @@ const App = () => {
     <QueryClientProvider client={queryClient}>
       <MobileProvider>
         <BrowserRouter>
+          <LazyGlobalTracker />
           <ScrollToTop />
           <Suspense fallback={<Loading />}>
             <Routes>

--- a/src/AppServer.tsx
+++ b/src/AppServer.tsx
@@ -7,6 +7,7 @@ import { MobileProvider } from '@/hooks/useMobileContext';
 import { Toaster } from '@/components/ui/toast';
 import { Analytics } from '@vercel/analytics/react';
 import type { BlogPost as BlogPostType } from '@/data/blogPosts';
+import LazyGlobalTracker from '@/components/LazyGlobalTracker';
 
 const TooltipProvider = lazy(() => import('@/components/ui/tooltip').then(m => ({ default: m.TooltipProvider })));
 
@@ -64,6 +65,7 @@ const AppServer: React.FC<AppServerProps> = ({ url, initialData = {} }) => {
     <QueryClientProvider client={queryClient}>
       <MobileProvider>
         <StaticRouter location={url}>
+          {typeof window !== 'undefined' && <LazyGlobalTracker />}
           <ScrollToTop />
           <Suspense fallback={<Loading />}>
             <Routes>


### PR DESCRIPTION
## Summary
- render LazyGlobalTracker within the BrowserRouter so user journey tracking starts as soon as the app mounts
- guard LazyGlobalTracker usage in the server bundle to avoid SSR issues when `window` is undefined

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e25a6bcb70832d93633e3bb5726c31