### PR TITLE
Reduce Supabase write payloads

### DIFF
--- a/src/hooks/useUserJourney.ts
+++ b/src/hooks/useUserJourney.ts
@@ -265,9 +265,14 @@ export function useUserJourney(): UserJourneyHook {
             ip_address: null
           };
 
-          existingJourney = await supabaseApi.createUserJourneySimulacao(
+          const createdJourney = await supabaseApi.createUserJourneySimulacao(
             newJourney
           );
+
+          existingJourney = {
+            ...newJourney,
+            id: createdJourney?.id || null
+          };
 
           if (process.env.NODE_ENV === 'development') {
             console.log('Nova jornada criada:', existingJourney);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -250,42 +250,53 @@ export const supabaseApi = {
     return data;
   },
 
-  async updateSimulacaoStatus(id: string, status: string) {
+  async updateSimulacaoStatus(
+    id: string,
+    status: string
+  ): Promise<Pick<SimulacaoData, 'id' | 'status'>> {
     const { data, error } = await supabase
       .from('simulacoes')
       .update({ status })
       .eq('id', id)
-      .select()
+      .select('id, status')
       .single();
 
     if (error) throw error;
-    return data;
+    return data ?? { id, status };
   },
 
   // User Journey + Simulação
   async createUserJourneySimulacao(
     data: Database['public']['Tables']['user_journey_simulacoes']['Insert']
-  ) {
+  ): Promise<UserJourneySimulacaoData> {
     const { data: result, error } = await supabase
       .from('user_journey_simulacoes')
       .upsert(data, { onConflict: 'session_id' })
-      .select()
+      .select('id')
       .single();
 
     if (error) throw error;
-    return result;
+    return {
+      ...data,
+      id: result?.id || null
+    } as UserJourneySimulacaoData;
   },
 
   // Parceiros
-  async createParceiro(data: Database['public']['Tables']['parceiros']['Insert']) {
+  async createParceiro(
+    data: Database['public']['Tables']['parceiros']['Insert']
+  ): Promise<ParceiroData> {
     const { data: result, error } = await supabase
       .from('parceiros')
       .insert(data)
-      .select()
+      .select('id')
       .single();
-    
+
     if (error) throw error;
-    return result;
+    return {
+      ...data,
+      id: result?.id || null
+    } as ParceiroData;
   },
 
   async getParceiros(limit = 50) {
@@ -299,31 +310,31 @@ export const supabaseApi = {
     return data;
   },
 
-  async updateParceiroStatus(id: string, status: string) {
+  async updateParceiroStatus(
+    id: string,
+    status: string
+  ): Promise<Pick<ParceiroData, 'id' | 'status'>> {
     const { data, error } = await supabase
       .from('parceiros')
       .update({ status })
       .eq('id', id)
-      .select()
+      .select('id, status')
       .single();
-    
+
     if (error) throw error;
-    return data;
+    return data ?? { id, status };
   },
 
   async updateUserJourney(
     sessionId: string,
     data: Database['public']['Tables']['user_journey_simulacoes']['Update']
-  ) {
-    const { data: result, error } = await supabase
+  ): Promise<void> {
+    const { error } = await supabase
       .from('user_journey_simulacoes')
-      .update(data)
-      .eq('session_id', sessionId)
-      .select()
-      .maybeSingle();
+      .update(data, { returning: 'minimal' })
+      .eq('session_id', sessionId);
 
     if (error) throw error;
-    return result;
   },
 
   async getUserJourney(sessionId: string) {

--- a/src/lib/supabaseLazy.ts
+++ b/src/lib/supabaseLazy.ts
@@ -124,11 +124,11 @@ async function loadSupabaseClient() {
             .from('simulacoes')
             .update({ status })
             .eq('id', id)
-            .select()
+            .select('id, status')
             .single();
 
           if (error) throw error;
-          return data;
+          return data ?? { id, status };
         },
 
         // User Journey + Simulação
@@ -138,11 +138,14 @@ async function loadSupabaseClient() {
           const { data: result, error } = await client
             .from('user_journey_simulacoes')
             .upsert(data, { onConflict: 'session_id' })
-            .select()
+            .select('id')
             .single();
 
           if (error) throw error;
-          return result;
+          return {
+            ...data,
+            id: result?.id || null
+          } as UserJourneySimulacaoData;
         },
 
         // Parceiros
@@ -150,11 +153,14 @@ async function loadSupabaseClient() {
           const { data: result, error } = await client
             .from('parceiros')
             .insert(data)
-            .select()
+            .select('id')
             .single();
-          
+
           if (error) throw error;
-          return result;
+          return {
+            ...data,
+            id: result?.id || null
+          } as ParceiroData;
         },
 
         async getParceiros(limit = 50) {
@@ -173,26 +179,23 @@ async function loadSupabaseClient() {
             .from('parceiros')
             .update({ status })
             .eq('id', id)
-            .select()
+            .select('id, status')
             .single();
-          
+
           if (error) throw error;
-          return data;
+          return data ?? { id, status };
         },
 
         async updateUserJourney(
           sessionId: string,
           data: Database['public']['Tables']['user_journey_simulacoes']['Update']
         ) {
-          const { data: result, error } = await client
+          const { error } = await client
             .from('user_journey_simulacoes')
-            .update(data)
-            .eq('session_id', sessionId)
-            .select()
-            .maybeSingle();
+            .update(data, { returning: 'minimal' })
+            .eq('session_id', sessionId);
 
           if (error) throw error;
-          return result;
         },
 
         async getUserJourney(sessionId: string) {


### PR DESCRIPTION
## Summary
- switch Supabase write operations for simulations, journeys, and partners to only return minimal columns while keeping IDs available
- mirror the minimal returning strategy in the lazy Supabase client helpers
- update the user journey hook to hydrate local state from the minimal create response

## Testing
- npm run test -- src/services/__tests__/localSimulationService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e3b27ee6a0832d855374cd427ab68c