### PR TITLE
Sanitize contact phone input and extend coverage

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -11,6 +11,47 @@ import Home from 'lucide-react/dist/esm/icons/home';
 import Building from 'lucide-react/dist/esm/icons/building';
 import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
 import { cn } from '@/lib/utils';
+import { formatPhone, validatePhone } from '@/utils/validations';
+
+interface SanitizedPhoneResult {
+  sanitized: string;
+  ddiRemoved: boolean;
+  addedNine: boolean;
+}
+
+const sanitizePhoneInput = (value: string): SanitizedPhoneResult => {
+  let digitsOnly = value.replace(/\D/g, '');
+  let ddiRemoved = false;
+  let addedNine = false;
+
+  if (digitsOnly.length > 11 && digitsOnly.startsWith('55')) {
+    digitsOnly = digitsOnly.slice(2);
+    ddiRemoved = true;
+  }
+
+  if (digitsOnly.length > 11) {
+    digitsOnly = digitsOnly.slice(0, 11);
+  }
+
+  if (digitsOnly.length > 2) {
+    const ddd = digitsOnly.slice(0, 2);
+    const subscriber = digitsOnly.slice(2);
+    if (subscriber.length === 8) {
+      digitsOnly = `${ddd}9${subscriber}`;
+      addedNine = true;
+    }
+  }
+
+  if (digitsOnly.length > 11) {
+    digitsOnly = digitsOnly.slice(0, 11);
+  }
+
+  return {
+    sanitized: digitsOnly,
+    ddiRemoved,
+    addedNine
+  };
+};
 
 /**
  * Props for the contact form component.
@@ -50,6 +91,11 @@ const ContactForm: React.FC<ContactFormProps> = ({
   const [nome, setNome] = useState('');
   const [email, setEmail] = useState('');
   const [telefone, setTelefone] = useState('');
+  const [telefoneSanitizado, setTelefoneSanitizado] = useState('');
+  const [phoneSanitizationWarnings, setPhoneSanitizationWarnings] = useState({
+    extraDDI: false,
+    missingNine: false
+  });
   const [imovelProprio, setImovelProprio] = useState<'proprio' | 'terceiro' | ''>('');
   const [aceitePrivacidade, setAceitePrivacidade] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -58,7 +104,8 @@ const ContactForm: React.FC<ContactFormProps> = ({
   const invalidNome = nome.trim() === '';
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   const invalidEmail = !emailRegex.test(email.trim());
-  const invalidTelefone = telefone.trim() === '';
+  const sanitizedTelefone = telefoneSanitizado || sanitizePhoneInput(telefone).sanitized;
+  const invalidTelefone = !validatePhone(sanitizedTelefone);
   const invalidImovelProprio = imovelProprio === '';
   const invalidAceite = !aceitePrivacidade;
   const formComplete =
@@ -74,26 +121,14 @@ const ContactForm: React.FC<ContactFormProps> = ({
     }
   }, [formComplete]);
 
-  // Função para aplicar máscara de telefone
-  const formatPhoneNumber = (value: string) => {
-    // Remove tudo que não é número
-    const numbers = value.replace(/\D/g, '');
-    
-    // Aplica a máscara conforme o número de dígitos
-    if (numbers.length <= 2) {
-      return `(${numbers}`;
-    } else if (numbers.length <= 7) {
-      return `(${numbers.slice(0, 2)}) ${numbers.slice(2)}`;
-    } else if (numbers.length <= 10) {
-      return `(${numbers.slice(0, 2)}) ${numbers.slice(2, 6)}-${numbers.slice(6)}`;
-    } else {
-      return `(${numbers.slice(0, 2)}) ${numbers.slice(2, 7)}-${numbers.slice(7, 11)}`;
-    }
-  };
-
   const handlePhoneChange = (value: string) => {
-    const formatted = formatPhoneNumber(value);
-    setTelefone(formatted);
+    const { sanitized, ddiRemoved, addedNine } = sanitizePhoneInput(value);
+    setTelefoneSanitizado(sanitized);
+    setTelefone(sanitized ? formatPhone(sanitized) : '');
+    setPhoneSanitizationWarnings({
+      extraDDI: ddiRemoved,
+      missingNine: addedNine
+    });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -143,7 +178,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
         sessionId,
         nome,
         email,
-        telefone,
+        telefone: sanitizedTelefone,
         imovelProprio,
         imovelProprioTexto: imovelProprio === 'proprio' ? 'Imóvel Próprio' : 'Imóvel de Terceiro'
       });
@@ -158,7 +193,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
         ...(simulationResult.userJourneyId ? { userJourneyId: simulationResult.userJourneyId } : {}),
         nomeCompleto: nome,
         email,
-        telefone,
+        telefone: sanitizedTelefone,
         cidade: simulationResult.cidade,
         imovelProprio,
         observacoes: `Simulação: ${simulationResult.amortizacao} - ${simulationResult.parcelas}x - R$ ${simulationResult.valor.toLocaleString('pt-BR')}`,
@@ -211,6 +246,8 @@ const ContactForm: React.FC<ContactFormProps> = ({
       setNome('');
       setEmail('');
       setTelefone('');
+      setTelefoneSanitizado('');
+      setPhoneSanitizationWarnings({ extraDDI: false, missingNine: false });
       setImovelProprio('');
       setAceitePrivacidade(false);
       
@@ -305,6 +342,16 @@ const ContactForm: React.FC<ContactFormProps> = ({
             required
             aria-required="true"
           />
+          {(phoneSanitizationWarnings.extraDDI || phoneSanitizationWarnings.missingNine) && (
+            <div className="mt-1 text-xs text-yellow-100">
+              {phoneSanitizationWarnings.extraDDI && (
+                <p>Removemos o DDI internacional +55 do número informado.</p>
+              )}
+              {phoneSanitizationWarnings.missingNine && (
+                <p>Adicionamos o dígito 9 obrigatório após o DDD.</p>
+              )}
+            </div>
+          )}
         </div>
         
         <fieldset className={cn('space-y-2', invalidImovelProprio && 'border border-red-500 rounded-md p-2')}>
@@ -497,6 +544,16 @@ const ContactForm: React.FC<ContactFormProps> = ({
                   required
                   aria-required="true"
                 />
+                {(phoneSanitizationWarnings.extraDDI || phoneSanitizationWarnings.missingNine) && (
+                  <div className="mt-1 text-xs text-yellow-700">
+                    {phoneSanitizationWarnings.extraDDI && (
+                      <p>Removemos o DDI internacional +55 do número informado.</p>
+                    )}
+                    {phoneSanitizationWarnings.missingNine && (
+                      <p>Adicionamos o dígito 9 obrigatório após o DDD.</p>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
 

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -122,5 +122,106 @@ describe('ContactForm', () => {
       );
     });
   });
+
+  it('sanitizes phone numbers with DDI 55 and informs the user', async () => {
+    mockGetJourneyData.mockReturnValue(undefined);
+
+    const simulationResult = {
+      id: 'local_sim3',
+      valor: 1000,
+      amortizacao: 'PRICE',
+      parcelas: 12,
+      valorEmprestimo: 50000,
+      valorImovel: 100000,
+      cidade: 'São Paulo'
+    } as any;
+
+    render(<ContactForm simulationResult={simulationResult} />);
+
+    fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'Maria Silva' } });
+    fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'maria@example.com' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '5511999999999' } });
+
+    expect(screen.getByText('Removemos o DDI internacional +55 do número informado.')).toBeInTheDocument();
+    expect(screen.queryByText('Adicionamos o dígito 9 obrigatório após o DDD.')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Solicitar análise agora/i }));
+
+    await waitFor(() => {
+      expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
+        expect.objectContaining({ telefone: '11999999999' })
+      );
+    });
+  });
+
+  it('adds the missing ninth digit after the DDD and warns the user', async () => {
+    mockGetJourneyData.mockReturnValue(undefined);
+
+    const simulationResult = {
+      id: 'local_sim4',
+      valor: 1000,
+      amortizacao: 'PRICE',
+      parcelas: 12,
+      valorEmprestimo: 50000,
+      valorImovel: 100000,
+      cidade: 'São Paulo'
+    } as any;
+
+    render(<ContactForm simulationResult={simulationResult} />);
+
+    fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'Carlos Souza' } });
+    fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'carlos@example.com' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '1188888888' } });
+
+    expect(screen.getByText('Adicionamos o dígito 9 obrigatório após o DDD.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Solicitar análise agora/i }));
+
+    await waitFor(() => {
+      expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
+        expect.objectContaining({ telefone: '11988888888' })
+      );
+    });
+  });
+
+  it('keeps already valid phone numbers unchanged without warnings', async () => {
+    mockGetJourneyData.mockReturnValue(undefined);
+
+    const simulationResult = {
+      id: 'local_sim5',
+      valor: 1000,
+      amortizacao: 'PRICE',
+      parcelas: 12,
+      valorEmprestimo: 50000,
+      valorImovel: 100000,
+      cidade: 'São Paulo'
+    } as any;
+
+    render(<ContactForm simulationResult={simulationResult} />);
+
+    fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'Ana Lima' } });
+    fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'ana@example.com' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '11912345678' } });
+
+    expect(screen.queryByText('Removemos o DDI internacional +55 do número informado.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Adicionamos o dígito 9 obrigatório após o DDD.')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Solicitar análise agora/i }));
+
+    await waitFor(() => {
+      expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
+        expect.objectContaining({ telefone: '11912345678' })
+      );
+    });
+  });
 });
 

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -379,6 +379,8 @@ export class LocalSimulationService {
         throw new Error('Telefone inválido');
       }
 
+      const sanitizedPhone = input.telefone.replace(/\D/g, '');
+
       // Obter dados da simulação do Supabase
       let simulationData: SimulacaoData | null = null;
       const simulationIdIsLocal = input.simulationId?.startsWith('local_');
@@ -440,7 +442,7 @@ export class LocalSimulationService {
         valorParcelaCalculada: Number(input.valorParcelaCalculada || simulationData?.parcela_inicial || 0),
         nomeCompleto: input.nomeCompleto.trim(),
         email: input.email.trim().toLowerCase(),
-        telefone: input.telefone.replace(/\D/g, ''), // Remove all non-digits
+        telefone: sanitizedPhone,
         imovelProprio: input.imovelProprio === 'proprio' ? 'Imóvel próprio' : 'Imóvel de terceiro',
         aceitaPolitica: Boolean(input.aceitaPolitica),
         utm_source: input.utm_source || null,
@@ -513,7 +515,7 @@ export class LocalSimulationService {
             const updateData = {
               nome_completo: input.nomeCompleto.trim(),
               email: input.email.trim().toLowerCase(),
-              telefone: input.telefone.replace(/\D/g, ''), // Limpar telefone
+              telefone: sanitizedPhone, // Limpar telefone
               imovel_proprio: input.imovelProprio as 'proprio' | 'terceiro', // Garantir tipo correto
               status: 'interessado', // Status após contato para compatibilidade com AdminDashboard
               visitor_id: input.visitorId


### PR DESCRIPTION
## Summary
- add a sanitizePhoneInput helper to normalize contact phone numbers, surface warnings for extra DDI/missing ninth digit, and use formatPhone/validatePhone for consistency
- send sanitized phone digits to LocalSimulationService payloads to keep CRM updates coherent
- extend ContactForm tests to cover numbers with international prefix, missing ninth digit, and already valid inputs

## Testing
- npm run test -- src/components/__tests__/ContactForm.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e3b57b5ad4832d8df6b07e445ae5d3