### PR TITLE
Refactor user journey tracking and simulations

### DIFF
--- a/src/hooks/useUserJourney.ts
+++ b/src/hooks/useUserJourney.ts
@@ -22,7 +22,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import type {
-  UserJourneySimulacaoData,
+  UserJourneyData,
   PageVisit,
   DeviceInfo
 } from '@/lib/supabase';
@@ -56,7 +56,7 @@ interface UserJourneyHook {
   isTracking: boolean;
   trackPageVisit: (url?: string) => void;
   trackSimulation: (simulationData: unknown) => void;
-  getJourneyData: () => UserJourneySimulacaoData | null;
+  getJourneyData: () => UserJourneyData | null;
   updateTimeOnSite: () => void;
 }
 
@@ -147,7 +147,7 @@ export function useUserJourney(): UserJourneyHook {
   const [visitorId, setVisitorId] = useState<string>('');
   const [isTracking, setIsTracking] = useState(false);
   const [journeyData, setJourneyData] =
-    useState<UserJourneySimulacaoData | null>(null);
+    useState<UserJourneyData | null>(null);
   const pageStartTime = useRef<number>(Date.now());
   const sessionStartTime = useRef<number>(Date.now());
   const ipFetchedRef = useRef<boolean>(false);
@@ -159,7 +159,8 @@ export function useUserJourney(): UserJourneyHook {
     try {
       const ip = await getUserIP();
       const api = await getSupabaseApi();
-      await api.updateUserJourney(sessionId, { ip_address: ip });
+          const payload: Partial<UserJourneyData> = { ip_address: ip };
+          await api.updateUserJourney(sessionId, payload);
     } catch (error) {
       if (process.env.NODE_ENV === 'development') {
         console.warn('Failed to update IP address:', error);
@@ -250,7 +251,7 @@ export function useUserJourney(): UserJourneyHook {
           const utms = extractUTMParams();
           const deviceInfo = getDeviceInfo();
 
-          const newJourney: UserJourneySimulacaoData = {
+          const newJourney: UserJourneyData = {
             session_id: sessionId,
             visitor_id: visitorId,
             utm_source: utms.utm_source || null,
@@ -261,13 +262,12 @@ export function useUserJourney(): UserJourneyHook {
             referrer: document.referrer || 'direct',
             landing_page: window.location.href,
             pages_visited: [],
+            time_on_site: 0,
             device_info: deviceInfo,
             ip_address: null
           };
 
-          existingJourney = await supabaseApi.createUserJourneySimulacao(
-            newJourney
-          );
+          existingJourney = await supabaseApi.createUserJourney(newJourney);
 
           if (process.env.NODE_ENV === 'development') {
             console.log('Nova jornada criada:', existingJourney);
@@ -320,7 +320,7 @@ export function useUserJourney(): UserJourneyHook {
       setTimeout(() => {
         if (isTracking && updatedJourney.pages_visited) {
           // Garantir que os dados são serializáveis
-          const safeData = {
+          const safeData: Partial<UserJourneyData> = {
             pages_visited: updatedJourney.pages_visited.map(page => ({
               url: String(page.url),
               timestamp: String(page.timestamp),
@@ -328,7 +328,7 @@ export function useUserJourney(): UserJourneyHook {
             })),
             time_on_site: Number(updatedJourney.time_on_site) || 0
           };
-          
+
           getSupabaseApi()
             .then(api =>
               api.updateUserJourney(sessionId, safeData).catch((error) => {
@@ -375,7 +375,7 @@ export function useUserJourney(): UserJourneyHook {
       // Atualizar no Supabase apenas se tracking estiver ativo
       if (isTracking && updatedJourney.pages_visited) {
         // Garantir que os dados são serializáveis
-        const safeData = {
+        const safeData: Partial<UserJourneyData> = {
           pages_visited: updatedJourney.pages_visited.map(page => ({
             url: String(page.url),
             timestamp: String(page.timestamp),
@@ -410,11 +410,11 @@ export function useUserJourney(): UserJourneyHook {
     const timeOnSite = Math.floor((currentTime - sessionStartTime.current) / 1000);
     
     if (isTracking) {
+      const payload: Partial<UserJourneyData> = { time_on_site: timeOnSite };
+
       getSupabaseApi()
         .then(api =>
-          api.updateUserJourney(sessionId, {
-            time_on_site: timeOnSite
-          }).catch((error) => {
+          api.updateUserJourney(sessionId, payload).catch((error) => {
             if (process.env.NODE_ENV === 'development') {
               console.warn('Failed to update time on site:', error);
             }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -41,7 +41,7 @@ if (typeof window !== 'undefined' && import.meta.env.DEV) {
 export interface SimulacaoData {
   id?: string;
   session_id: string;
-  visitor_id?: string;
+  visitor_id?: string | null;
   nome_completo: string;
   email: string;
   telefone: string;
@@ -50,13 +50,15 @@ export interface SimulacaoData {
   valor_imovel: number;
   parcelas: number;
   tipo_amortizacao: string;
-  parcela_inicial?: number;
-  parcela_final?: number;
-  imovel_proprio?: 'proprio' | 'terceiro';
-  ip_address?: string;
-  user_agent?: string;
+  parcela_inicial?: number | null;
+  parcela_final?: number | null;
+  imovel_proprio?: 'proprio' | 'terceiro' | null;
+  ip_address?: string | null;
+  user_agent?: string | null;
+  status?: string | null;
+  integrado_crm?: boolean | null;
   created_at?: string;
-  status?: string;
+  updated_at?: string;
 }
 
 export interface ParceiroData {
@@ -95,7 +97,7 @@ export interface DeviceInfo {
   os: string;
 }
 
-export interface UserJourneySimulacaoData {
+export interface UserJourneyData {
   id?: string;
   session_id: string;
   visitor_id?: string | null;
@@ -151,7 +153,7 @@ export interface Database {
     Tables: {
       simulacoes: {
         Row: SimulacaoData;
-        Insert: Omit<SimulacaoData, 'id' | 'created_at'>;
+        Insert: Omit<SimulacaoData, 'id' | 'created_at' | 'updated_at'>;
         Update: Partial<Omit<SimulacaoData, 'id' | 'created_at'>>;
       };
       parceiros: {
@@ -159,10 +161,10 @@ export interface Database {
         Insert: Omit<ParceiroData, 'id' | 'created_at' | 'updated_at'>;
         Update: Partial<Omit<ParceiroData, 'id' | 'created_at'>>;
       };
-      user_journey_simulacoes: {
-        Row: UserJourneySimulacaoData;
-        Insert: Omit<UserJourneySimulacaoData, 'id' | 'created_at' | 'updated_at'>;
-        Update: Partial<Omit<UserJourneySimulacaoData, 'id' | 'created_at'>>;
+      user_journey: {
+        Row: UserJourneyData;
+        Insert: Omit<UserJourneyData, 'id' | 'created_at' | 'updated_at'>;
+        Update: Partial<Omit<UserJourneyData, 'id' | 'created_at'>>;
       };
       blog_posts: {
         Row: BlogPostData;
@@ -262,12 +264,12 @@ export const supabaseApi = {
     return data;
   },
 
-  // User Journey + Simulação
-  async createUserJourneySimulacao(
-    data: Database['public']['Tables']['user_journey_simulacoes']['Insert']
+  // User Journey
+  async createUserJourney(
+    data: Database['public']['Tables']['user_journey']['Insert']
   ) {
     const { data: result, error } = await supabase
-      .from('user_journey_simulacoes')
+      .from('user_journey')
       .upsert(data, { onConflict: 'session_id' })
       .select()
       .single();
@@ -313,10 +315,10 @@ export const supabaseApi = {
 
   async updateUserJourney(
     sessionId: string,
-    data: Database['public']['Tables']['user_journey_simulacoes']['Update']
+    data: Database['public']['Tables']['user_journey']['Update']
   ) {
     const { data: result, error } = await supabase
-      .from('user_journey_simulacoes')
+      .from('user_journey')
       .update(data)
       .eq('session_id', sessionId)
       .select()
@@ -328,7 +330,7 @@ export const supabaseApi = {
 
   async getUserJourney(sessionId: string) {
     const { data, error } = await supabase
-      .from('user_journey_simulacoes')
+      .from('user_journey')
       .select('*')
       .eq('session_id', sessionId)
       .maybeSingle();
@@ -339,7 +341,7 @@ export const supabaseApi = {
 
   async getUserJourneysBySessionIds(sessionIds: string[]) {
     const { data, error } = await supabase
-      .from('user_journey_simulacoes')
+      .from('user_journey')
       .select('*')
       .in('session_id', sessionIds);
 
@@ -349,7 +351,7 @@ export const supabaseApi = {
 
   async getUserJourneysByVisitorIds(visitorIds: string[]) {
     const { data, error } = await supabase
-      .from('user_journey_simulacoes')
+      .from('user_journey')
       .select('*')
       .in('visitor_id', visitorIds);
 

--- a/src/lib/supabaseLazy.ts
+++ b/src/lib/supabaseLazy.ts
@@ -131,12 +131,12 @@ async function loadSupabaseClient() {
           return data;
         },
 
-        // User Journey + Simulação
-        async createUserJourneySimulacao(
-          data: Database['public']['Tables']['user_journey_simulacoes']['Insert']
+        // User Journey
+        async createUserJourney(
+          data: Database['public']['Tables']['user_journey']['Insert']
         ) {
           const { data: result, error } = await client
-            .from('user_journey_simulacoes')
+            .from('user_journey')
             .upsert(data, { onConflict: 'session_id' })
             .select()
             .single();
@@ -182,10 +182,10 @@ async function loadSupabaseClient() {
 
         async updateUserJourney(
           sessionId: string,
-          data: Database['public']['Tables']['user_journey_simulacoes']['Update']
+          data: Database['public']['Tables']['user_journey']['Update']
         ) {
           const { data: result, error } = await client
-            .from('user_journey_simulacoes')
+            .from('user_journey')
             .update(data)
             .eq('session_id', sessionId)
             .select()
@@ -197,13 +197,33 @@ async function loadSupabaseClient() {
 
         async getUserJourney(sessionId: string) {
           const { data, error } = await client
-            .from('user_journey_simulacoes')
+            .from('user_journey')
             .select('*')
             .eq('session_id', sessionId)
             .maybeSingle();
 
           if (error) throw error;
           return data;
+        },
+
+        async getUserJourneysBySessionIds(sessionIds: string[]) {
+          const { data, error } = await client
+            .from('user_journey')
+            .select('*')
+            .in('session_id', sessionIds);
+
+          if (error) throw error;
+          return data || [];
+        },
+
+        async getUserJourneysByVisitorIds(visitorIds: string[]) {
+          const { data, error } = await client
+            .from('user_journey')
+            .select('*')
+            .in('visitor_id', visitorIds);
+
+          if (error) throw error;
+          return data || [];
         },
 
         // Blog Posts - lazy loaded

--- a/src/services/__tests__/localSimulationService.test.ts
+++ b/src/services/__tests__/localSimulationService.test.ts
@@ -8,7 +8,9 @@ import {
 // Mock supabase module before importing the service
 const supabaseMock = { from: vi.fn() } as any;
 const supabaseApiMock = {
-  createUserJourneySimulacao: vi.fn(),
+  createSimulacao: vi.fn(),
+  createUserJourney: vi.fn(),
+  updateUserJourney: vi.fn(),
   updateSimulacaoStatus: vi.fn(),
   getSimulacoes: vi.fn(),
   getUserJourneysByVisitorIds: vi.fn(),
@@ -58,7 +60,9 @@ describe('LocalSimulationService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     supabaseMock.from.mockReset();
-    supabaseApiMock.createUserJourneySimulacao.mockReset();
+    supabaseApiMock.createSimulacao.mockReset();
+    supabaseApiMock.createUserJourney.mockReset();
+    supabaseApiMock.updateUserJourney.mockReset();
     supabaseApiMock.updateSimulacaoStatus.mockReset();
     supabaseApiMock.getSimulacoes.mockReset();
     supabaseApiMock.getUserJourneysByVisitorIds.mockReset();
@@ -104,11 +108,12 @@ describe('LocalSimulationService', () => {
     });
 
     expect(result).toBeDefined();
-    expect(supabaseApiMock.createUserJourneySimulacao).not.toHaveBeenCalled();
+    expect(supabaseApiMock.createSimulacao).not.toHaveBeenCalled();
+    expect(supabaseApiMock.updateUserJourney).not.toHaveBeenCalled();
   });
 
   it('salva simulação no Supabase quando dados válidos são fornecidos', async () => {
-    supabaseApiMock.createUserJourneySimulacao.mockResolvedValue({ id: 'supabase-123' });
+    supabaseApiMock.createSimulacao.mockResolvedValue({ id: 'supabase-123' });
 
     const { LocalSimulationService } = await import('../localSimulationService');
 
@@ -128,17 +133,25 @@ describe('LocalSimulationService', () => {
       isRuralProperty: false
     });
 
-    expect(supabaseApiMock.createUserJourneySimulacao).toHaveBeenCalledTimes(1);
-    expect(supabaseApiMock.createUserJourneySimulacao).toHaveBeenCalledWith(expect.objectContaining({
+    expect(supabaseApiMock.createSimulacao).toHaveBeenCalledTimes(1);
+    expect(supabaseApiMock.createSimulacao).toHaveBeenCalledWith(expect.objectContaining({
       nome_completo: 'Maria Silva',
       email: 'maria@example.com',
       telefone: '11987654321'
     }));
+    expect(supabaseApiMock.updateUserJourney).toHaveBeenCalledWith(
+      'session-valid',
+      expect.objectContaining({
+        nome_completo: 'Maria Silva',
+        email: 'maria@example.com',
+        telefone: '11987654321'
+      })
+    );
     expect(result.userJourneyId).toBe('supabase-123');
   });
 
   it('inclui dados de origem ao salvar simulação quando disponíveis', async () => {
-    supabaseApiMock.createUserJourneySimulacao.mockResolvedValue({ id: 'supabase-456' });
+    supabaseApiMock.createSimulacao.mockResolvedValue({ id: 'supabase-456' });
 
     const { LocalSimulationService } = await import('../localSimulationService');
 
@@ -165,7 +178,8 @@ describe('LocalSimulationService', () => {
       referrer: 'https://google.com'
     });
 
-    expect(supabaseApiMock.createUserJourneySimulacao).toHaveBeenCalledWith(
+    expect(supabaseApiMock.updateUserJourney).toHaveBeenCalledWith(
+      'session-origin',
       expect.objectContaining({
         utm_source: 'google',
         utm_medium: 'cpc',

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -25,7 +25,7 @@ import {
   supabaseApi,
   SimulacaoData,
   supabase,
-  UserJourneySimulacaoData
+  UserJourneyData
 } from '@/lib/supabase';
 
 // Reutilizar interfaces do serviço original
@@ -244,12 +244,11 @@ export class LocalSimulationService {
 
         if (hasRealContactData) {
           const supabaseData: Omit<
-            UserJourneySimulacaoData,
+            SimulacaoData,
             'id' | 'created_at' | 'updated_at'
           > = {
             session_id: input.sessionId,
             visitor_id: input.visitorId || null,
-
             nome_completo: input.nomeCompleto,
             email: input.email,
             telefone: input.telefone,
@@ -261,32 +260,10 @@ export class LocalSimulationService {
             parcela_inicial: calculation.parcelaSac.inicial,
             parcela_final: calculation.parcelaSac.final,
             imovel_proprio: 'proprio',
-            user_agent: input.userAgent || '',
-            ip_address: input.ipAddress || '',
-            status: 'novo' // Status inicial para compatibilidade com AdminDashboard
+            user_agent: input.userAgent || null,
+            ip_address: input.ipAddress || null,
+            status: 'novo'
           };
-
-          if (input.utmSource !== undefined) {
-            supabaseData.utm_source = input.utmSource;
-          }
-          if (input.utmMedium !== undefined) {
-            supabaseData.utm_medium = input.utmMedium;
-          }
-          if (input.utmCampaign !== undefined) {
-            supabaseData.utm_campaign = input.utmCampaign;
-          }
-          if (input.utmTerm !== undefined) {
-            supabaseData.utm_term = input.utmTerm;
-          }
-          if (input.utmContent !== undefined) {
-            supabaseData.utm_content = input.utmContent;
-          }
-          if (input.referrer !== undefined) {
-            supabaseData.referrer = input.referrer;
-          }
-          if (input.landingPage !== undefined && input.landingPage !== null) {
-            supabaseData.landing_page = input.landingPage;
-          }
 
           console.log('💾 Tentando salvar simulação no Supabase:', {
             session_id: supabaseData.session_id,
@@ -296,9 +273,7 @@ export class LocalSimulationService {
             original_local_id: simulationId
           });
 
-          const supabaseResult = await supabaseApi.createUserJourneySimulacao(
-            supabaseData
-          );
+          const supabaseResult = await supabaseApi.createSimulacao(supabaseData);
           console.log('✅ Simulação salva no Supabase:', {
             success: !!supabaseResult?.id,
             supabase_id: supabaseResult?.id,
@@ -314,6 +289,57 @@ export class LocalSimulationService {
             result.userJourneyId = supabaseResult.id;
           } else {
             console.warn('⚠️ Supabase não retornou ID, mantendo apenas ID local:', result.id);
+          }
+
+          const journeyUpdate: Partial<UserJourneyData> = {
+            visitor_id: input.visitorId || null,
+            nome_completo: input.nomeCompleto,
+            email: input.email,
+            telefone: input.telefone,
+            cidade: input.cidade,
+            valor_emprestimo: input.valorEmprestimo,
+            valor_imovel: input.valorImovel,
+            parcelas: input.parcelas,
+            tipo_amortizacao: input.tipoAmortizacao,
+            parcela_inicial: calculation.parcelaSac.inicial,
+            parcela_final: calculation.parcelaSac.final,
+            imovel_proprio: 'proprio',
+            status: 'novo'
+          };
+
+          if (input.utmSource !== undefined) {
+            journeyUpdate.utm_source = input.utmSource;
+          }
+          if (input.utmMedium !== undefined) {
+            journeyUpdate.utm_medium = input.utmMedium;
+          }
+          if (input.utmCampaign !== undefined) {
+            journeyUpdate.utm_campaign = input.utmCampaign;
+          }
+          if (input.utmTerm !== undefined) {
+            journeyUpdate.utm_term = input.utmTerm;
+          }
+          if (input.utmContent !== undefined) {
+            journeyUpdate.utm_content = input.utmContent;
+          }
+          if (input.referrer !== undefined) {
+            journeyUpdate.referrer = input.referrer;
+          }
+          if (input.landingPage !== undefined && input.landingPage !== null) {
+            journeyUpdate.landing_page = input.landingPage;
+          }
+
+          const sanitizedJourneyUpdate = Object.fromEntries(
+            Object.entries(journeyUpdate).filter(([, value]) => value !== undefined)
+          ) as Partial<UserJourneyData>;
+
+          if (Object.keys(sanitizedJourneyUpdate).length > 0) {
+            try {
+              await supabaseApi.updateUserJourney(input.sessionId, sanitizedJourneyUpdate);
+              console.log('🔁 Jornada do usuário atualizada com dados da simulação local');
+            } catch (journeyError) {
+              console.error('⚠️ Erro ao atualizar user journey:', journeyError);
+            }
           }
         } else {
           const isPlaceholderName = normalizedName.toLowerCase() === placeholderName;
@@ -805,7 +831,7 @@ export class LocalSimulationService {
           simulationData?.tipo_amortizacao
         );
 
-        const journeyUpdatePayload: Partial<UserJourneySimulacaoData> = {
+        const journeyUpdatePayload: Partial<UserJourneyData> = {
           nome_completo: normalizedNome,
           email: normalizedEmail,
           telefone: normalizedTelefone,
@@ -828,7 +854,7 @@ export class LocalSimulationService {
 
         const sanitizedJourneyUpdatePayload = Object.fromEntries(
           Object.entries(journeyUpdatePayload).filter(([, value]) => value !== undefined)
-        ) as Partial<UserJourneySimulacaoData>;
+        ) as Partial<UserJourneyData>;
 
         if (Object.keys(sanitizedJourneyUpdatePayload).length > 0) {
           console.log('🔁 Atualizando jornada do usuário com dados do contato:', sanitizedJourneyUpdatePayload);
@@ -942,7 +968,7 @@ export class LocalSimulationService {
         }
       }
 
-      let journeys: any[] = [];
+      let journeys: UserJourneyData[] = [];
       if (visitorIds.size > 0) {
         journeys = journeys.concat(
           await this.fetchJourneysInChunks(
@@ -960,7 +986,7 @@ export class LocalSimulationService {
         );
       }
 
-      const journeyMap = new Map<string, any>();
+      const journeyMap = new Map<string, UserJourneyData>();
       for (const j of journeys) {
         const key = j?.visitor_id || j?.session_id;
         if (key) journeyMap.set(key, j);

--- a/src/services/simulationService.ts
+++ b/src/services/simulationService.ts
@@ -20,7 +20,7 @@
  */
 
 import { getSecondaryWebhookUrl } from '@/lib/env';
-import { supabaseApi, UserJourneySimulacaoData } from '@/lib/supabase';
+import { supabaseApi, SimulacaoData, UserJourneyData } from '@/lib/supabase';
 import { simulateCredit } from '@/services/simulationApi';
 import { validateEmail, formatPhone } from '@/utils/validations';
 import { PloomesService } from '@/services/ploomesService';
@@ -112,11 +112,11 @@ export class SimulationService {
       
       // 5. Preparar dados para Supabase
       const supabaseData: Omit<
-        UserJourneySimulacaoData,
+        SimulacaoData,
         'id' | 'created_at' | 'updated_at'
       > = {
         session_id: input.sessionId,
-        visitor_id: input.visitorId,
+        visitor_id: input.visitorId || null,
         nome_completo: input.nomeCompleto,
         email: input.email,
         telefone: this.formatPhoneNumber(input.telefone),
@@ -128,43 +128,72 @@ export class SimulationService {
         parcela_inicial: processedResult.primeiraParcela,
         parcela_final: processedResult.ultimaParcela || processedResult.valor,
         imovel_proprio: 'proprio',
-        ip_address: input.ipAddress,
-        user_agent: input.userAgent,
+        ip_address: input.ipAddress || null,
+        user_agent: input.userAgent || null,
+        status: 'novo'
+      };
+      
+      console.log('💾 Salvando no Supabase:', supabaseData);
+
+      // 6. Salvar no Supabase
+      const savedSimulation = await supabaseApi.createSimulacao(supabaseData);
+
+      // 7. Enriquecer jornada do usuário com dados coletados
+      const journeyUpdate: Partial<UserJourneyData> = {
+        visitor_id: input.visitorId || null,
+        nome_completo: input.nomeCompleto,
+        email: input.email,
+        telefone: this.formatPhoneNumber(input.telefone),
+        cidade: input.cidade,
+        valor_emprestimo: input.valorEmprestimo,
+        valor_imovel: input.valorImovel,
+        parcelas: input.parcelas,
+        tipo_amortizacao: input.tipoAmortizacao,
+        parcela_inicial: processedResult.primeiraParcela,
+        parcela_final: processedResult.ultimaParcela || processedResult.valor,
+        imovel_proprio: 'proprio',
         status: 'novo'
       };
 
       if (input.utmSource !== undefined) {
-        supabaseData.utm_source = input.utmSource;
+        journeyUpdate.utm_source = input.utmSource;
       }
       if (input.utmMedium !== undefined) {
-        supabaseData.utm_medium = input.utmMedium;
+        journeyUpdate.utm_medium = input.utmMedium;
       }
       if (input.utmCampaign !== undefined) {
-        supabaseData.utm_campaign = input.utmCampaign;
+        journeyUpdate.utm_campaign = input.utmCampaign;
       }
       if (input.utmTerm !== undefined) {
-        supabaseData.utm_term = input.utmTerm;
+        journeyUpdate.utm_term = input.utmTerm;
       }
       if (input.utmContent !== undefined) {
-        supabaseData.utm_content = input.utmContent;
+        journeyUpdate.utm_content = input.utmContent;
       }
       if (input.referrer !== undefined) {
-        supabaseData.referrer = input.referrer;
+        journeyUpdate.referrer = input.referrer;
       }
       if (input.landingPage !== undefined && input.landingPage !== null) {
-        supabaseData.landing_page = input.landingPage;
+        journeyUpdate.landing_page = input.landingPage;
       }
-      
-      console.log('💾 Salvando no Supabase:', supabaseData);
-      
-      // 6. Salvar no Supabase
-      const savedSimulation = await supabaseApi.createUserJourneySimulacao(
-        supabaseData
-      );
-      
+
+      const sanitizedJourneyUpdate = Object.fromEntries(
+        Object.entries(journeyUpdate).filter(([, value]) => value !== undefined)
+      ) as Partial<UserJourneyData>;
+
+      if (Object.keys(sanitizedJourneyUpdate).length > 0) {
+        try {
+          await supabaseApi.updateUserJourney(input.sessionId, sanitizedJourneyUpdate);
+        } catch (journeyError) {
+          if (process.env.NODE_ENV === 'development') {
+            console.warn('Falha ao atualizar jornada do usuário:', journeyError);
+          }
+        }
+      }
+
       console.log('✅ Simulação salva:', savedSimulation);
-      
-      // 7. Retornar resultado formatado
+
+      // 8. Retornar resultado formatado
       return {
         id: savedSimulation.id!,
         valor: processedResult.valor,


### PR DESCRIPTION
## Summary
- type Supabase clients with dedicated `user_journey` and `simulacoes` helpers and drop the legacy combined table
- create/update journeys from the tracking hook while persisting simulations with the new API in both services
- refresh local aggregation and tests to read journeys directly by session/visitor identifiers and keep UTMs in sync

## Testing
- npx vitest run src/services/__tests__/localSimulationService.test.ts
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e3b2b6c214832d8b28180d621bc6f5