### PR TITLE
Optimize blog post fetching for summaries and detail

### DIFF
--- a/src/components/SupabaseDiagnostics.tsx
+++ b/src/components/SupabaseDiagnostics.tsx
@@ -47,7 +47,7 @@ const SupabaseDiagnostics: React.FC = () => {
       // 2. Teste da tabela blog_posts
       setSyncStatus('Verificando tabela blog_posts...');
       try {
-        const posts = await supabaseApi.getAllBlogPosts();
+        const posts = await supabaseApi.getBlogPostSummaries();
         addResult({
           test: 'Tabela blog_posts',
           status: 'success',

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -378,12 +378,14 @@ export const supabaseApi = {
   },
 
   // Blog Posts
-  async getAllBlogPosts() {
+  async getBlogPostSummaries() {
     const { data, error } = await supabase
       .from('blog_posts')
-      .select('*')
+      .select(
+        'id,title,description,category,image_url,slug,read_time,published,featured_post,created_at'
+      )
       .order('created_at', { ascending: false });
-    
+
     if (error) throw error;
     return data || [];
   },

--- a/src/lib/supabaseLazy.ts
+++ b/src/lib/supabaseLazy.ts
@@ -210,12 +210,14 @@ async function loadSupabaseClient() {
         },
 
         // Blog Posts - lazy loaded
-        async getAllBlogPosts() {
+        async getBlogPostSummaries() {
           const { data, error } = await client
             .from('blog_posts')
-            .select('*')
+            .select(
+              'id,title,description,category,image_url,slug,read_time,published,featured_post,created_at'
+            )
             .order('created_at', { ascending: false });
-          
+
           if (error) throw error;
           return data || [];
         },

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -28,7 +28,7 @@ const BlogPost: React.FC<BlogPostPageProps> = ({ initialPost }) => {
       }
 
       try {
-        const foundPost = await BlogService.getPostBySlug(slug);
+        const foundPost = await BlogService.getPostWithContent(slug);
         if (foundPost) {
           setPost(foundPost);
         }
@@ -39,7 +39,7 @@ const BlogPost: React.FC<BlogPostPageProps> = ({ initialPost }) => {
       }
     };
 
-    if (!initialPost) {
+    if (!initialPost || !initialPost.content) {
       loadPost();
     } else {
       setLoading(false);

--- a/src/services/blogService.ts
+++ b/src/services/blogService.ts
@@ -466,7 +466,7 @@ export class BlogService {
       category: supabasePost.category as BlogCategory,
       imageUrl: supabasePost.image_url || '',
       slug: supabasePost.slug,
-      content: supabasePost.content,
+      content: supabasePost.content ?? '',
       readTime: supabasePost.read_time || 5,
       published: supabasePost.published,
       featuredPost: supabasePost.featured_post,
@@ -533,7 +533,7 @@ export class BlogService {
       console.log('🔍 Buscando posts do Supabase...');
       
       // Tentar buscar do Supabase primeiro (SEMPRE)
-      const supabasePosts = await supabaseApi.getAllBlogPosts();
+      const supabasePosts = await supabaseApi.getBlogPostSummaries();
       console.log(`📊 Posts encontrados no Supabase: ${supabasePosts?.length || 0}`);
       
       if (supabasePosts && supabasePosts.length >= 0) {
@@ -546,7 +546,7 @@ export class BlogService {
           await this.syncLocalToSupabase();
           
           // Tentar buscar novamente após sync
-          const reloadedPosts = await supabaseApi.getAllBlogPosts();
+          const reloadedPosts = await supabaseApi.getBlogPostSummaries();
           if (reloadedPosts && reloadedPosts.length > 0) {
             const reloadedConverted = reloadedPosts.map(this.convertSupabaseToBlogPost);
             this.saveToLocalStorageWithCleanup(reloadedConverted);
@@ -613,6 +613,52 @@ export class BlogService {
   static async getPostBySlug(slug: string): Promise<BlogPost | null> {
     const posts = await this.getAllPosts();
     return posts.find(post => post.slug === slug) || null;
+  }
+
+  /**
+   * Buscar post com conteúdo completo diretamente do Supabase
+   */
+  static async getPostWithContent(slug: string): Promise<BlogPost | null> {
+    try {
+      const supabasePost = await supabaseApi.getBlogPostBySlug(slug);
+      if (!supabasePost) {
+        return null;
+      }
+
+      const convertedPost = this.convertSupabaseToBlogPost(supabasePost);
+
+      // Atualizar cache local com o conteúdo completo
+      if (typeof window !== 'undefined') {
+        try {
+          const stored = localStorage.getItem(this.STORAGE_KEY);
+          const cachedPosts: BlogPost[] = stored ? JSON.parse(stored) : [];
+
+          const index = cachedPosts.findIndex(post => post.slug === slug);
+          if (index !== -1) {
+            cachedPosts[index] = { ...cachedPosts[index], ...convertedPost };
+          } else {
+            cachedPosts.unshift(convertedPost);
+          }
+
+          this.saveToLocalStorageWithCleanup(cachedPosts);
+        } catch (storageError) {
+          console.warn('⚠️ Não foi possível atualizar cache local com conteúdo completo:', storageError);
+        }
+      }
+
+      return convertedPost;
+    } catch (error) {
+      console.error('❌ Erro ao buscar conteúdo completo do Supabase:', error);
+
+      // Fallback: tentar retornar dados do cache (sem conteúdo completo)
+      try {
+        const cachedPosts = await this.getAllPosts();
+        return cachedPosts.find(post => post.slug === slug) || null;
+      } catch (cacheError) {
+        console.error('❌ Erro ao carregar post do cache local:', cacheError);
+        return null;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a dedicated Supabase query that only returns blog post summary fields for listings
- update the blog service to rely on the lighter query, provide a helper to fetch full post content on demand, and refresh the blog post page accordingly
- adjust the Supabase diagnostics helper to exercise the new summary query

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3be5c1098832db7102914e39818b8