### PR TITLE
Refine Supabase blog post queries

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -448,7 +448,7 @@ export const supabaseApi = {
     const { data, error } = await supabase
       .from('blog_posts')
       .select(
-        'id,title,description,category,image_url,slug,read_time,published,featured_post,created_at'
+        'id,title,description,category,image_url,slug,read_time,published,featured_post,meta_title,meta_description,created_at,updated_at'
       )
       .order('created_at', { ascending: false });
 
@@ -481,7 +481,9 @@ export const supabaseApi = {
   async getBlogPostBySlug(slug: string) {
     const { data, error } = await supabase
       .from('blog_posts')
-      .select('*')
+      .select(
+        'id,title,description,category,content,image_url,slug,read_time,published,featured_post,meta_title,meta_description,tags,created_at,updated_at'
+      )
       .eq('slug', slug)
       .single();
     

--- a/src/lib/supabaseLazy.ts
+++ b/src/lib/supabaseLazy.ts
@@ -266,7 +266,7 @@ async function loadSupabaseClient() {
           const { data, error } = await client
             .from('blog_posts')
             .select(
-              'id,title,description,category,image_url,slug,read_time,published,featured_post,created_at'
+              'id,title,description,category,image_url,slug,read_time,published,featured_post,meta_title,meta_description,created_at,updated_at'
             )
             .order('created_at', { ascending: false });
 
@@ -299,7 +299,9 @@ async function loadSupabaseClient() {
         async getBlogPostBySlug(slug: string) {
           const { data, error } = await client
             .from('blog_posts')
-            .select('*')
+            .select(
+              'id,title,description,category,content,image_url,slug,read_time,published,featured_post,meta_title,meta_description,tags,created_at,updated_at'
+            )
             .eq('slug', slug)
             .single();
           


### PR DESCRIPTION
## Summary
- narrow the Supabase blog listing query to summary-friendly fields while keeping metadata available
- ensure the detail query explicitly fetches the HTML content and related metadata for individual posts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3c5045fb8832db71e9790a6986725