### PR TITLE
Align user journey storage with Supabase schema

### DIFF
--- a/database/sql/supabase-add-user-journey-columns.sql
+++ b/database/sql/supabase-add-user-journey-columns.sql
@@ -1,0 +1,240 @@
+-- =====================================================
+-- ADICIONAR COLUNAS FALTANTES EM USER_JOURNEY - LIBRA CRÉDITO
+-- =====================================================
+-- Este script garante que a tabela user_journey possua as mesmas
+-- colunas utilizadas pelo frontend para rastrear UTMs e dados de contato.
+-- Ele pode ser executado com segurança múltiplas vezes.
+-- =====================================================
+
+-- Permitir landing_page nula para compatibilidade com registros antigos
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'landing_page'
+          AND is_nullable = 'NO'
+    ) THEN
+        ALTER TABLE public.user_journey ALTER COLUMN landing_page DROP NOT NULL;
+        RAISE NOTICE 'Restrição NOT NULL removida de user_journey.landing_page';
+    END IF;
+END
+$$;
+
+-- Adicionar visitor_id (UUID que relaciona sessão e visitante)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'visitor_id'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN visitor_id UUID;
+        RAISE NOTICE 'Coluna visitor_id adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+-- Índice para visitor_id
+CREATE INDEX IF NOT EXISTS idx_user_journey_visitor_id ON public.user_journey(visitor_id);
+
+-- Campos de identificação básicos do lead
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'nome_completo'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN nome_completo TEXT;
+        RAISE NOTICE 'Coluna nome_completo adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'email'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN email TEXT;
+        RAISE NOTICE 'Coluna email adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'telefone'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN telefone TEXT;
+        RAISE NOTICE 'Coluna telefone adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'cidade'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN cidade TEXT;
+        RAISE NOTICE 'Coluna cidade adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+-- Campos financeiros vinculados à simulação
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'valor_emprestimo'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN valor_emprestimo NUMERIC;
+        RAISE NOTICE 'Coluna valor_emprestimo adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'valor_imovel'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN valor_imovel NUMERIC;
+        RAISE NOTICE 'Coluna valor_imovel adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'parcelas'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN parcelas INTEGER;
+        RAISE NOTICE 'Coluna parcelas adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'tipo_amortizacao'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN tipo_amortizacao TEXT;
+        RAISE NOTICE 'Coluna tipo_amortizacao adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'parcela_inicial'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN parcela_inicial NUMERIC;
+        RAISE NOTICE 'Coluna parcela_inicial adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'parcela_final'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN parcela_final NUMERIC;
+        RAISE NOTICE 'Coluna parcela_final adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'imovel_proprio'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN imovel_proprio TEXT;
+        RAISE NOTICE 'Coluna imovel_proprio adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+-- Status e metadados adicionais
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'status'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN status TEXT;
+        RAISE NOTICE 'Coluna status adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user_journey'
+          AND column_name = 'user_agent'
+    ) THEN
+        ALTER TABLE public.user_journey ADD COLUMN user_agent TEXT;
+        RAISE NOTICE 'Coluna user_agent adicionada à tabela user_journey';
+    END IF;
+END
+$$;
+
+-- Comentários descritivos
+COMMENT ON COLUMN public.user_journey.visitor_id IS 'Identificador persistente do visitante (UUID)';
+COMMENT ON COLUMN public.user_journey.nome_completo IS 'Nome informado na jornada';
+COMMENT ON COLUMN public.user_journey.valor_emprestimo IS 'Valor solicitado na simulação associado a esta jornada';
+COMMENT ON COLUMN public.user_journey.tipo_amortizacao IS 'Tipo de amortização selecionado pelo usuário';
+COMMENT ON COLUMN public.user_journey.status IS 'Status de qualificação do lead vinculado à jornada';
+
+-- Resultado final
+SELECT
+    '✅ user_journey sincronizada com o frontend' AS status,
+    COUNT(*) FILTER (WHERE visitor_id IS NOT NULL) AS jornadas_com_visitor,
+    COUNT(*) FILTER (WHERE utm_source IS NOT NULL) AS jornadas_com_utm
+FROM public.user_journey;

--- a/src/hooks/useUserJourney.ts
+++ b/src/hooks/useUserJourney.ts
@@ -267,11 +267,11 @@ export function useUserJourney(): UserJourneyHook {
             ip_address: null
           };
 
-          existingJourney = await supabaseApi.createUserJourney(newJourney);
+          const createdJourney = await supabaseApi.createUserJourney(newJourney);
 
-          existingJourney = {
+          existingJourney = createdJourney ?? {
             ...newJourney,
-            id: createdJourney?.id || null
+            id: undefined
           };
 
           if (process.env.NODE_ENV === 'development') {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -129,6 +129,8 @@ export interface UserJourneyData {
   updated_at?: string;
 }
 
+export type UserJourneySimulacaoData = UserJourneyData;
+
 export interface UserJourneySummary {
   session_id: string | null;
   visitor_id?: string | null;
@@ -328,18 +330,18 @@ export const supabaseApi = {
   // User Journey
   async createUserJourney(
     data: Database['public']['Tables']['user_journey']['Insert']
-  ) {
+  ): Promise<UserJourneyData> {
     const { data: result, error } = await supabase
       .from('user_journey')
       .upsert(data, { onConflict: 'session_id' })
-      .select('id')
+      .select()
       .single();
 
     if (error) throw error;
-    return {
+    return (result ?? {
       ...data,
-      id: result?.id || null
-    } as UserJourneySimulacaoData;
+      id: undefined
+    }) as UserJourneyData;
   },
 
   // Parceiros

--- a/src/lib/supabaseLazy.ts
+++ b/src/lib/supabaseLazy.ts
@@ -8,7 +8,11 @@
  * Reduz ~116KB do bundle inicial
  */
 
-import type { Database, GetSimulacoesOptions } from './supabase';
+import type {
+  Database,
+  GetSimulacoesOptions,
+  UserJourneySimulacaoData
+} from './supabase';
 
 // Cache do cliente para evitar múltiplas inicializações
 let supabaseClient: any = null;
@@ -168,14 +172,14 @@ async function loadSupabaseClient() {
           const { data: result, error } = await client
             .from('user_journey')
             .upsert(data, { onConflict: 'session_id' })
-            .select('id')
+            .select()
             .single();
 
           if (error) throw error;
-          return {
+          return (result ?? {
             ...data,
-            id: result?.id || null
-          } as UserJourneySimulacaoData;
+            id: undefined
+          }) as UserJourneySimulacaoData;
         },
 
         // Parceiros

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -910,7 +910,7 @@ export class LocalSimulationService {
             simulationData?.visitor_id ||
             null;
 
-          const journeyCreationPayload: Database['public']['Tables']['user_journey_simulacoes']['Insert'] = {
+          const journeyCreationPayload: Database['public']['Tables']['user_journey']['Insert'] = {
             session_id: input.sessionId,
             visitor_id: resolvedVisitorId,
             utm_source: utmSourceValue ?? null,
@@ -918,14 +918,18 @@ export class LocalSimulationService {
             utm_campaign: utmCampaignValue ?? null,
             utm_term: utmTermValue ?? null,
             utm_content: utmContentValue ?? null,
-            landing_page: landingPageValue ?? null,
+            landing_page:
+              landingPageValue ??
+              fallbackSimulation?.landing_page ??
+              existingJourney?.landing_page ??
+              null,
             referrer: referrerValue ?? null,
             ...sanitizedJourneyUpdatePayload
           };
 
           try {
             console.log('➕ Criando jornada do usuário no Supabase:', journeyCreationPayload);
-            const createdJourney = await supabaseApi.createUserJourneySimulacao(journeyCreationPayload);
+            const createdJourney = await supabaseApi.createUserJourney(journeyCreationPayload);
             existingJourney = createdJourney || null;
             console.log('✅ Jornada criada no Supabase');
           } catch (journeyCreateError) {


### PR DESCRIPTION
## Summary
- add an idempotent SQL script that aligns the user_journey table with the fields used by the frontend, including visitor metadata and financial columns
- adjust the Supabase clients and hooks to return the full user journey payload and avoid crashes during tracking initialization
- update the local simulation service to create journeys through the new helper and preserve landing page fallbacks

## Testing
- npm test -- src/services/__tests__/localSimulationService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e3a8d51644832d8197ace713539f3f