### PR TITLE
Refine phone normalization for contact submissions

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -16,40 +16,42 @@ import { formatPhone, validatePhone } from '@/utils/validations';
 interface SanitizedPhoneResult {
   sanitized: string;
   ddiRemoved: boolean;
-  addedNine: boolean;
+  trimmedToEightDigits: boolean;
 }
 
 const sanitizePhoneInput = (value: string): SanitizedPhoneResult => {
   let digitsOnly = value.replace(/\D/g, '');
   let ddiRemoved = false;
-  let addedNine = false;
+  let trimmedToEightDigits = false;
 
-  if (digitsOnly.length > 11 && digitsOnly.startsWith('55')) {
+  if (!digitsOnly) {
+    return { sanitized: '', ddiRemoved, trimmedToEightDigits };
+  }
+
+  digitsOnly = digitsOnly.replace(/^0+/, '');
+
+  if (digitsOnly.startsWith('55') && digitsOnly.length > 11) {
     digitsOnly = digitsOnly.slice(2);
     ddiRemoved = true;
+    digitsOnly = digitsOnly.replace(/^0+/, '');
   }
 
-  if (digitsOnly.length > 11) {
-    digitsOnly = digitsOnly.slice(0, 11);
+  if (digitsOnly.length <= 2) {
+    return { sanitized: digitsOnly, ddiRemoved, trimmedToEightDigits };
   }
 
-  if (digitsOnly.length > 2) {
-    const ddd = digitsOnly.slice(0, 2);
-    const subscriber = digitsOnly.slice(2);
-    if (subscriber.length === 8) {
-      digitsOnly = `${ddd}9${subscriber}`;
-      addedNine = true;
-    }
-  }
+  const ddd = digitsOnly.slice(0, 2);
+  let subscriber = digitsOnly.slice(2);
 
-  if (digitsOnly.length > 11) {
-    digitsOnly = digitsOnly.slice(0, 11);
+  if (subscriber.length > 8) {
+    subscriber = subscriber.slice(-8);
+    trimmedToEightDigits = true;
   }
 
   return {
-    sanitized: digitsOnly,
+    sanitized: `${ddd}${subscriber}`,
     ddiRemoved,
-    addedNine
+    trimmedToEightDigits
   };
 };
 
@@ -94,7 +96,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
   const [telefoneSanitizado, setTelefoneSanitizado] = useState('');
   const [phoneSanitizationWarnings, setPhoneSanitizationWarnings] = useState({
     extraDDI: false,
-    missingNine: false
+    trimmedSubscriber: false
   });
   const [imovelProprio, setImovelProprio] = useState<'proprio' | 'terceiro' | ''>('');
   const [aceitePrivacidade, setAceitePrivacidade] = useState(false);
@@ -122,12 +124,12 @@ const ContactForm: React.FC<ContactFormProps> = ({
   }, [formComplete]);
 
   const handlePhoneChange = (value: string) => {
-    const { sanitized, ddiRemoved, addedNine } = sanitizePhoneInput(value);
+    const { sanitized, ddiRemoved, trimmedToEightDigits } = sanitizePhoneInput(value);
     setTelefoneSanitizado(sanitized);
     setTelefone(sanitized ? formatPhone(sanitized) : '');
     setPhoneSanitizationWarnings({
       extraDDI: ddiRemoved,
-      missingNine: addedNine
+      trimmedSubscriber: trimmedToEightDigits
     });
   };
 
@@ -247,7 +249,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
       setEmail('');
       setTelefone('');
       setTelefoneSanitizado('');
-      setPhoneSanitizationWarnings({ extraDDI: false, missingNine: false });
+      setPhoneSanitizationWarnings({ extraDDI: false, trimmedSubscriber: false });
       setImovelProprio('');
       setAceitePrivacidade(false);
       
@@ -342,13 +344,13 @@ const ContactForm: React.FC<ContactFormProps> = ({
             required
             aria-required="true"
           />
-          {(phoneSanitizationWarnings.extraDDI || phoneSanitizationWarnings.missingNine) && (
+          {(phoneSanitizationWarnings.extraDDI || phoneSanitizationWarnings.trimmedSubscriber) && (
             <div className="mt-1 text-xs text-yellow-100">
               {phoneSanitizationWarnings.extraDDI && (
-                <p>Removemos o DDI internacional +55 do número informado.</p>
+                <p>Removemos o DDI internacional (por exemplo, +55) do número informado.</p>
               )}
-              {phoneSanitizationWarnings.missingNine && (
-                <p>Adicionamos o dígito 9 obrigatório após o DDD.</p>
+              {phoneSanitizationWarnings.trimmedSubscriber && (
+                <p>Padronizamos o telefone para DDD + 8 dígitos, mantendo apenas os oito últimos dígitos informados.</p>
               )}
             </div>
           )}
@@ -544,13 +546,13 @@ const ContactForm: React.FC<ContactFormProps> = ({
                   required
                   aria-required="true"
                 />
-                {(phoneSanitizationWarnings.extraDDI || phoneSanitizationWarnings.missingNine) && (
+                {(phoneSanitizationWarnings.extraDDI || phoneSanitizationWarnings.trimmedSubscriber) && (
                   <div className="mt-1 text-xs text-yellow-700">
                     {phoneSanitizationWarnings.extraDDI && (
-                      <p>Removemos o DDI internacional +55 do número informado.</p>
+                      <p>Removemos o DDI internacional (por exemplo, +55) do número informado.</p>
                     )}
-                    {phoneSanitizationWarnings.missingNine && (
-                      <p>Adicionamos o dígito 9 obrigatório após o DDD.</p>
+                    {phoneSanitizationWarnings.trimmedSubscriber && (
+                      <p>Padronizamos o telefone para DDD + 8 dígitos, mantendo apenas os oito últimos dígitos informados.</p>
                     )}
                   </div>
                 )}

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -61,7 +61,7 @@ describe('ContactForm', () => {
 
     fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'John Doe' } });
     fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'john@example.com' } });
-    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '11999999999' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '35999625948' } });
     fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
     fireEvent.click(screen.getByRole('checkbox'));
 
@@ -78,7 +78,8 @@ describe('ContactForm', () => {
           utm_content: 'content',
           landing_page: 'https://example.com',
           referrer: 'https://referrer.com',
-          cidade: 'São Paulo'
+          cidade: 'São Paulo',
+          telefone: '3599625948'
         })
       );
     });
@@ -101,7 +102,7 @@ describe('ContactForm', () => {
 
     fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'Jane Doe' } });
     fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'jane@example.com' } });
-    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '11988888888' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '5535999625948' } });
     fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
     fireEvent.click(screen.getByRole('checkbox'));
 
@@ -117,7 +118,8 @@ describe('ContactForm', () => {
           utm_content: null,
           landing_page: null,
           referrer: null,
-          cidade: 'São Paulo'
+          cidade: 'São Paulo',
+          telefone: '3599625948'
         })
       );
     });
@@ -142,8 +144,8 @@ describe('ContactForm', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'maria@example.com' } });
     fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '5511999999999' } });
 
-    expect(screen.getByText('Removemos o DDI internacional +55 do número informado.')).toBeInTheDocument();
-    expect(screen.queryByText('Adicionamos o dígito 9 obrigatório após o DDD.')).not.toBeInTheDocument();
+    expect(screen.getByText('Removemos o DDI internacional (por exemplo, +55) do número informado.')).toBeInTheDocument();
+    expect(screen.getByText('Padronizamos o telefone para DDD + 8 dígitos, mantendo apenas os oito últimos dígitos informados.')).toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
     fireEvent.click(screen.getByRole('checkbox'));
@@ -152,12 +154,50 @@ describe('ContactForm', () => {
 
     await waitFor(() => {
       expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
-        expect.objectContaining({ telefone: '11999999999' })
+        expect.objectContaining({ telefone: '1199999999' })
       );
     });
   });
 
-  it('adds the missing ninth digit after the DDD and warns the user', async () => {
+  it('keeps DDD 55 numbers without international prefix untouched', async () => {
+    mockGetJourneyData.mockReturnValue(undefined);
+
+    const simulationResult = {
+      id: 'local_sim-ddd55',
+      valor: 1000,
+      amortizacao: 'PRICE',
+      parcelas: 12,
+      valorEmprestimo: 50000,
+      valorImovel: 100000,
+      cidade: 'São Paulo'
+    } as any;
+
+    render(<ContactForm simulationResult={simulationResult} />);
+
+    fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'Rafael Costa' } });
+    fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'rafael@example.com' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '55987654321' } });
+
+    expect(
+      screen.queryByText('Removemos o DDI internacional (por exemplo, +55) do número informado.')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Padronizamos o telefone para DDD + 8 dígitos, mantendo apenas os oito últimos dígitos informados.')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Solicitar análise agora/i }));
+
+    await waitFor(() => {
+      expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
+        expect.objectContaining({ telefone: '5587654321' })
+      );
+    });
+  });
+
+  it('trims numbers longer than DDD + 8 dígitos and warns the user', async () => {
     mockGetJourneyData.mockReturnValue(undefined);
 
     const simulationResult = {
@@ -174,9 +214,9 @@ describe('ContactForm', () => {
 
     fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'Carlos Souza' } });
     fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'carlos@example.com' } });
-    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '1188888888' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '35999625948' } });
 
-    expect(screen.getByText('Adicionamos o dígito 9 obrigatório após o DDD.')).toBeInTheDocument();
+    expect(screen.getByText('Padronizamos o telefone para DDD + 8 dígitos, mantendo apenas os oito últimos dígitos informados.')).toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
     fireEvent.click(screen.getByRole('checkbox'));
@@ -185,7 +225,44 @@ describe('ContactForm', () => {
 
     await waitFor(() => {
       expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
-        expect.objectContaining({ telefone: '11988888888' })
+        expect.objectContaining({ telefone: '3599625948' })
+      );
+    });
+  });
+
+  it.each([
+    '+5535999625948',
+    '+55 (35) 9 9962-5948',
+    '+55 35 99962 5948',
+    '55 (35) 99962 5948',
+    '(35) 99962-5948',
+    '3599625948'
+  ])('normalizes "%s" to DDD + 8 digits before submitting', async (inputVariant) => {
+    mockGetJourneyData.mockReturnValue(undefined);
+
+    const simulationResult = {
+      id: 'local_sim-variants',
+      valor: 1000,
+      amortizacao: 'PRICE',
+      parcelas: 12,
+      valorEmprestimo: 50000,
+      valorImovel: 100000,
+      cidade: 'São Paulo'
+    } as any;
+
+    render(<ContactForm simulationResult={simulationResult} />);
+
+    fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'Paula Gomes' } });
+    fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'paula@example.com' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: inputVariant } });
+    fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Solicitar análise agora/i }));
+
+    await waitFor(() => {
+      expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
+        expect.objectContaining({ telefone: '3599625948' })
       );
     });
   });
@@ -207,10 +284,10 @@ describe('ContactForm', () => {
 
     fireEvent.change(screen.getByLabelText(/Nome Completo/i), { target: { value: 'Ana Lima' } });
     fireEvent.change(screen.getByLabelText(/E-mail/i), { target: { value: 'ana@example.com' } });
-    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '11912345678' } });
+    fireEvent.change(screen.getByLabelText(/Telefone/i), { target: { value: '3599625948' } });
 
-    expect(screen.queryByText('Removemos o DDI internacional +55 do número informado.')).not.toBeInTheDocument();
-    expect(screen.queryByText('Adicionamos o dígito 9 obrigatório após o DDD.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Removemos o DDI internacional (por exemplo, +55) do número informado.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Padronizamos o telefone para DDD + 8 dígitos, mantendo apenas os oito últimos dígitos informados.')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText(/Imóvel Próprio/i));
     fireEvent.click(screen.getByRole('checkbox'));
@@ -219,7 +296,7 @@ describe('ContactForm', () => {
 
     await waitFor(() => {
       expect(LocalSimulationService.processContact).toHaveBeenCalledWith(
-        expect.objectContaining({ telefone: '11912345678' })
+        expect.objectContaining({ telefone: '3599625948' })
       );
     });
   });


### PR DESCRIPTION
## Summary
- tighten the contact form phone sanitization to drop optional prefixes, protect DDD 55 numbers, and always keep only the DDD plus the last eight digits
- expand the contact form test suite with scenarios covering the supported phone formats and Brazilian DDD 55 numbers

## Testing
- npx vitest run src/components/__tests__/ContactForm.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e3fe8a088c832da6d0708392d04cfc