### PR TITLE
Reset MobileLayout scroll position on route change

### DIFF
--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useViewportHeight } from '@/hooks/useViewportHeight';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
@@ -15,6 +16,58 @@ const MobileLayout: React.FC<MobileLayoutProps> = ({
   showFooter = true
 }) => {
   useViewportHeight();
+  const location = useLocation();
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const mainContentRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    const rootElement = document.scrollingElement || document.documentElement || document.body;
+
+    const scrollTargets: HTMLElement[] = [
+      scrollContainerRef.current ?? undefined,
+      mainContentRef.current ?? undefined,
+      mainContentRef.current?.parentElement instanceof HTMLElement
+        ? mainContentRef.current.parentElement
+        : undefined,
+      rootElement instanceof HTMLElement ? rootElement : undefined
+    ]
+      .filter((element): element is HTMLElement => Boolean(element))
+      .reduce<HTMLElement[]>((accumulator, element) => {
+        if (!accumulator.includes(element)) {
+          accumulator.push(element);
+        }
+        return accumulator;
+      }, []);
+
+    const resetScrollPositions = () => {
+      scrollTargets.forEach((element) => {
+        if (typeof element.scrollTo === 'function') {
+          element.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+        } else {
+          element.scrollTop = 0;
+          element.scrollLeft = 0;
+        }
+      });
+
+      if (typeof window.scrollTo === 'function') {
+        window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+      }
+    };
+
+    resetScrollPositions();
+
+    const rafId = window.requestAnimationFrame(resetScrollPositions);
+    const timeoutId = window.setTimeout(resetScrollPositions, 200);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(timeoutId);
+    };
+  }, [location.pathname, location.search, location.hash, location.key]);
 
   return (
     <div className="flex flex-col" style={{ minHeight: 'calc(var(--vh) * 100)' }}>
@@ -32,9 +85,10 @@ const MobileLayout: React.FC<MobileLayoutProps> = ({
       {/* Header - Simplificado em mobile */}
       {showHeader && <Header />}
 
-      <div className="flex flex-col flex-1 overflow-y-auto">
+      <div ref={scrollContainerRef} className="flex flex-col flex-1 overflow-y-auto">
         {/* Main Content */}
         <main
+          ref={mainContentRef}
           id="main-content"
           data-has-header={showHeader ? 'true' : 'false'}
           className={`flex-1 overflow-y-auto ${showHeader ? 'pt-header' : ''}`}

--- a/src/pages/__tests__/Confirmacao.test.tsx
+++ b/src/pages/__tests__/Confirmacao.test.tsx
@@ -75,13 +75,12 @@ describe('Confirmacao page', () => {
     expect(
       screen.getByRole('link', { name: /Conheça a Libra/i })
     ).toBeInTheDocument();
-    const atendenteLink = screen.getByRole('link', {
-      name: /Falar com a Atendente/i,
-    });
-    expect(atendenteLink).toHaveAttribute(
-      'href',
-      'https://wa.me/5516997338791'
-    );
+    expect(
+      screen.getByRole('link', { name: /Conheça a Libra/i })
+    ).toHaveAttribute('href', '/quem-somos');
+    expect(
+      screen.getByText(/Fique atento ao telefone/i)
+    ).toBeInTheDocument();
   });
 
   it('scrolls to top on mount', () => {


### PR DESCRIPTION
## Summary
- reset the MobileLayout scroll containers whenever the route changes so confirmation loads at the top
- update the confirmation page test to reflect the current CTA copy

## Testing
- npm test -- Confirmacao

------
https://chatgpt.com/codex/tasks/task_e_68fa6b43e170832dac2355598a6f4830