### PR TITLE
Surface campaign details in admin simulations

### DIFF
--- a/database/sql/supabase-add-simulacao-tracking-columns.sql
+++ b/database/sql/supabase-add-simulacao-tracking-columns.sql
@@ -1,0 +1,24 @@
+-- Adiciona colunas de tracking na tabela de simulações
+alter table if exists public.simulacoes
+  add column if not exists utm_source text;
+
+alter table if exists public.simulacoes
+  add column if not exists utm_medium text;
+
+alter table if exists public.simulacoes
+  add column if not exists utm_campaign text;
+
+alter table if exists public.simulacoes
+  add column if not exists utm_term text;
+
+alter table if exists public.simulacoes
+  add column if not exists utm_content text;
+
+alter table if exists public.simulacoes
+  add column if not exists landing_page text;
+
+alter table if exists public.simulacoes
+  add column if not exists referrer text;
+
+alter table if exists public.simulacoes
+  add column if not exists time_on_site integer;

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -219,7 +219,11 @@ const ContactForm: React.FC<ContactFormProps> = ({
         utm_term: journey?.utm_term ?? null,
         utm_content: journey?.utm_content ?? null,
         landing_page: journey?.landing_page ?? null,
-        referrer: journey?.referrer ?? null
+        referrer: journey?.referrer ?? null,
+        time_on_site:
+          typeof journey?.time_on_site === 'number'
+            ? Math.max(0, Math.floor(journey.time_on_site))
+            : null
 
       });
 

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -183,7 +183,11 @@ const SimulationForm: React.FC = () => {
         utmTerm: journey ? journey.utm_term ?? null : undefined,
         utmContent: journey ? journey.utm_content ?? null : undefined,
         landingPage: journey?.landing_page ?? fallbackLandingPage,
-        referrer: journey ? journey.referrer ?? null : fallbackReferrer
+        referrer: journey ? journey.referrer ?? null : fallbackReferrer,
+        timeOnSite:
+          typeof journey?.time_on_site === 'number'
+            ? Math.max(0, Math.floor(journey.time_on_site))
+            : undefined
       };
 
 

--- a/src/components/UTMDetails.tsx
+++ b/src/components/UTMDetails.tsx
@@ -9,12 +9,138 @@ interface UTMDetailsProps {
   visitor: SessionGroupWithJourney;
 }
 
+interface NormalizedUtmData {
+  source: string | null;
+  medium: string | null;
+  campaign: string | null;
+  term: string | null;
+  content: string | null;
+  adGroup: string | null;
+  ad: string | null;
+  landingPage: string | null;
+  referrer: string | null;
+  timeOnSite: number | null;
+}
+
+const cleanUtmValue = (value?: string | null): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const normalized = trimmed.replace(/[+]/g, ' ');
+  try {
+    const decoded = decodeURIComponent(normalized);
+    return decoded.replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+  } catch {
+    return normalized.replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+  }
+};
+
+const formatDuration = (seconds: number): string => {
+  const totalSeconds = Number.isFinite(seconds) ? Math.max(0, Math.floor(seconds)) : 0;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const remainingSeconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+  return `${remainingSeconds}s`;
+};
+
 const UTMDetails: React.FC<UTMDetailsProps> = ({ visitor }) => {
   const [open, setOpen] = React.useState(false);
 
-  const summary = [visitor.utm_source, visitor.utm_medium, visitor.utm_campaign]
-    .filter(Boolean)
-    .join(' / ') || '-';
+  const normalized = React.useMemo<NormalizedUtmData>(() => {
+    const simulacoes = visitor.simulacoes || [];
+
+    const pickSimulationValue = <K extends keyof (typeof simulacoes)[number]>(
+      field: K
+    ): (typeof simulacoes)[number][K] | null => {
+      for (const sim of simulacoes) {
+        const value = sim[field];
+        if (value === undefined || value === null) continue;
+        if (typeof value === 'string' && value.trim() === '') continue;
+        if (typeof value === 'number' && !Number.isFinite(value)) continue;
+        return value;
+      }
+      return null;
+    };
+
+    const landingPage = visitor.landing_page ?? (pickSimulationValue('landing_page') as string | null);
+    const referrer = visitor.referrer ?? (pickSimulationValue('referrer') as string | null);
+    const timeOnSiteValue = (() => {
+      if (typeof visitor.time_on_site === 'number' && Number.isFinite(visitor.time_on_site)) {
+        return visitor.time_on_site;
+      }
+      const fromSim = pickSimulationValue('time_on_site');
+      return typeof fromSim === 'number' && Number.isFinite(fromSim) ? fromSim : null;
+    })();
+
+    const candidateUrls = [landingPage, ...simulacoes.map(sim => sim.landing_page)]
+      .filter(Boolean)
+      .map(url => String(url));
+
+    const searchParams = (() => {
+      for (const url of candidateUrls) {
+        try {
+          const parsed = new URL(url);
+          if (parsed.search && parsed.searchParams.toString().length > 0) {
+            return parsed.searchParams;
+          }
+        } catch {
+          // Ignorar URLs inválidas
+        }
+      }
+      return null;
+    })();
+
+    const getParam = (...keys: string[]) => {
+      if (!searchParams) return null;
+      for (const key of keys) {
+        const value = searchParams.get(key);
+        if (value) return value;
+      }
+      return null;
+    };
+
+    const utmSource =
+      visitor.utm_source ?? (pickSimulationValue('utm_source') as string | null) ?? getParam('utm_source', 'source');
+    const utmMedium =
+      visitor.utm_medium ?? (pickSimulationValue('utm_medium') as string | null) ?? getParam('utm_medium', 'medium');
+    const utmCampaign =
+      visitor.utm_campaign ??
+      (pickSimulationValue('utm_campaign') as string | null) ??
+      getParam('utm_campaign', 'campaign');
+    const utmTerm =
+      visitor.utm_term ??
+      (pickSimulationValue('utm_term') as string | null) ??
+      getParam('utm_term', 'keyword', 'term');
+    const utmContent =
+      visitor.utm_content ??
+      (pickSimulationValue('utm_content') as string | null) ??
+      getParam('utm_content', 'content');
+
+    const adGroupRaw =
+      getParam('utm_adgroup', 'adgroup', 'utm_adset', 'adset', 'ad_group', 'utm_adgroup_id') ?? utmTerm;
+    const adRaw = getParam('utm_ad', 'ad', 'creative', 'utm_creative', 'utm_ad_id', 'utm_creative_id') ?? utmContent;
+
+    return {
+      source: cleanUtmValue(utmSource),
+      medium: cleanUtmValue(utmMedium),
+      campaign: cleanUtmValue(utmCampaign),
+      term: cleanUtmValue(utmTerm),
+      content: cleanUtmValue(utmContent),
+      adGroup: cleanUtmValue(adGroupRaw),
+      ad: cleanUtmValue(adRaw),
+      landingPage: landingPage ?? null,
+      referrer: referrer ?? null,
+      timeOnSite: timeOnSiteValue
+    };
+  }, [visitor]);
 
   const shortenUrl = (url: string) => {
     try {
@@ -25,19 +151,37 @@ const UTMDetails: React.FC<UTMDetailsProps> = ({ visitor }) => {
     }
   };
 
+  const originLabel = [normalized.source, normalized.medium].filter(Boolean).join(' / ') || '-';
+  const campaignLabel = normalized.campaign || '-';
+  const adGroupLabel = normalized.adGroup || normalized.term || '-';
+  const adLabel = normalized.ad || normalized.content || '-';
+
   return (
     <Collapsible
       open={open}
       onOpenChange={setOpen}
-      className="text-xs overflow-hidden max-w-[220px]"
+      className="text-xs overflow-hidden max-w-[240px]"
     >
-      <div className="flex items-center gap-1">
-        <div className="truncate">{summary}</div>
+      <div className="flex items-start gap-2">
+        <div className="space-y-1 text-[11px] leading-tight">
+          <div>
+            <strong>Origem:</strong> {originLabel}
+          </div>
+          <div>
+            <strong>Campanha:</strong> {campaignLabel}
+          </div>
+          <div>
+            <strong>Grupo:</strong> {adGroupLabel}
+          </div>
+          <div>
+            <strong>Anúncio:</strong> {adLabel}
+          </div>
+        </div>
         <CollapsibleTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="h-5 w-5 p-0"
+            className="h-5 w-5 p-0 mt-0.5 flex-shrink-0"
             aria-label={open ? 'Esconder detalhes UTM' : 'Mostrar detalhes UTM'}
           >
             <ChevronDown
@@ -46,40 +190,45 @@ const UTMDetails: React.FC<UTMDetailsProps> = ({ visitor }) => {
           </Button>
         </CollapsibleTrigger>
       </div>
-      <CollapsibleContent className="mt-1 space-y-1">
-        {visitor.utm_term && (
+      <CollapsibleContent className="mt-2 space-y-1 text-[11px] leading-tight">
+        {normalized.term && (
           <div>
-            <strong>utm_term:</strong> {visitor.utm_term}
+            <strong>utm_term:</strong> {normalized.term}
           </div>
         )}
-        {visitor.utm_content && (
+        {normalized.content && (
           <div>
-            <strong>utm_content:</strong> {visitor.utm_content}
+            <strong>utm_content:</strong> {normalized.content}
           </div>
         )}
-        {visitor.landing_page && (
+        {typeof normalized.timeOnSite === 'number' && (
+          <div>
+            <strong>tempo_no_site:</strong> {formatDuration(normalized.timeOnSite)}
+          </div>
+        )}
+        {normalized.landingPage && (
           <div>
             <strong>landing_page:</strong>{' '}
             <a
-              href={visitor.landing_page}
+              href={normalized.landingPage}
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 hover:underline break-all"
             >
-              {shortenUrl(visitor.landing_page)}
+              {shortenUrl(normalized.landingPage)}
             </a>
           </div>
         )}
-        {visitor.referrer && (
+        {normalized.referrer && (
           <div>
             <strong>referrer:</strong>{' '}
             <a
-              href={visitor.referrer}
+              href={normalized.referrer}
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 hover:underline break-all"
             >
-              {shortenUrl(visitor.referrer)}
+              {shortenUrl(normalized.referrer)}
             </a>
           </div>
         )}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -19,6 +19,11 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+import {
+  SIMULATION_PLACEHOLDER_EMAIL,
+  SIMULATION_PLACEHOLDER_NAME,
+  SIMULATION_PLACEHOLDER_PHONE
+} from '@/constants/simulationPlaceholders';
 
 // Configurações do Supabase - obtidas de variáveis de ambiente
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
@@ -53,6 +58,14 @@ export interface SimulacaoData {
   parcela_inicial?: number | null;
   parcela_final?: number | null;
   imovel_proprio?: 'proprio' | 'terceiro' | null;
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+  utm_term?: string | null;
+  utm_content?: string | null;
+  landing_page?: string | null;
+  referrer?: string | null;
+  time_on_site?: number | null;
   ip_address?: string | null;
   user_agent?: string | null;
   status?: string | null;
@@ -141,6 +154,7 @@ export interface UserJourneySummary {
   utm_content?: string | null;
   landing_page?: string | null;
   referrer?: string | null;
+  time_on_site?: number | null;
   status?: string | null;
 }
 
@@ -285,12 +299,38 @@ export const supabaseApi = {
     let query = supabase
       .from('simulacoes')
       .select(
-        'id,nome_completo,email,status,created_at,valor_emprestimo,valor_imovel,parcelas,session_id,visitor_id'
+        [
+          'id',
+          'nome_completo',
+          'email',
+          'telefone',
+          'status',
+          'created_at',
+          'valor_emprestimo',
+          'valor_imovel',
+          'parcelas',
+          'tipo_amortizacao',
+          'session_id',
+          'visitor_id',
+          'utm_source',
+          'utm_medium',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'landing_page',
+          'referrer',
+          'time_on_site'
+        ].join(',')
       )
       .not('nome_completo', 'is', null)
       .neq('nome_completo', '')
+      .neq('nome_completo', SIMULATION_PLACEHOLDER_NAME)
       .not('email', 'is', null)
       .neq('email', '')
+      .neq('email', SIMULATION_PLACEHOLDER_EMAIL)
+      .not('telefone', 'is', null)
+      .neq('telefone', '')
+      .neq('telefone', SIMULATION_PLACEHOLDER_PHONE)
       .neq('status', 'novo')
       .order('created_at', { ascending: false })
       .range(from, to);
@@ -414,26 +454,26 @@ export const supabaseApi = {
 
   async getUserJourneysBySessionIds(
     sessionIds: string[]
-  ): Promise<UserJourneySummary[]> {
+  ): Promise<UserJourneyData[]> {
     const { data, error } = await supabase
       .from('user_journey')
       .select('*')
       .in('session_id', sessionIds);
 
     if (error) throw error;
-    return (data || []) as UserJourneySummary[];
+    return (data || []) as UserJourneyData[];
   },
 
   async getUserJourneysByVisitorIds(
     visitorIds: string[]
-  ): Promise<UserJourneySummary[]> {
+  ): Promise<UserJourneyData[]> {
     const { data, error } = await supabase
       .from('user_journey')
       .select('*')
       .in('visitor_id', visitorIds);
 
     if (error) throw error;
-    return (data || []) as UserJourneySummary[];
+    return (data || []) as UserJourneyData[];
   },
 
   // Analytics

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -682,7 +682,7 @@ const AdminDashboard: React.FC = () => {
                   <TableHeader>
                     <TableRow>
                       <TableHead>Data</TableHead>
-                      <TableHead>Origem</TableHead>
+                      <TableHead>Campanha & Origem</TableHead>
                       <TableHead>Nome</TableHead>
                       <TableHead>Contato</TableHead>
                       <TableHead>Valores</TableHead>

--- a/src/services/__tests__/localSimulationService.test.ts
+++ b/src/services/__tests__/localSimulationService.test.ts
@@ -133,21 +133,24 @@ describe('LocalSimulationService', () => {
       tipoAmortizacao: 'SAC',
       userAgent: 'jest',
       ipAddress: '127.0.0.1',
-      isRuralProperty: false
+      isRuralProperty: false,
+      timeOnSite: 245
     });
 
     expect(supabaseApiMock.createSimulacao).toHaveBeenCalledTimes(1);
     expect(supabaseApiMock.createSimulacao).toHaveBeenCalledWith(expect.objectContaining({
       nome_completo: 'Maria Silva',
       email: 'maria@example.com',
-      telefone: '11987654321'
+      telefone: '11987654321',
+      time_on_site: 245
     }));
     expect(supabaseApiMock.updateUserJourney).toHaveBeenCalledWith(
       'session-valid',
       expect.objectContaining({
         nome_completo: 'Maria Silva',
         email: 'maria@example.com',
-        telefone: '11987654321'
+        telefone: '11987654321',
+        time_on_site: 245
       })
     );
     expect(result.userJourneyId).toBe('supabase-123');
@@ -178,7 +181,8 @@ describe('LocalSimulationService', () => {
       utmTerm: 'simulacao',
       utmContent: 'banner',
       landingPage: 'https://libra.com.br/landing',
-      referrer: 'https://google.com'
+      referrer: 'https://google.com',
+      timeOnSite: 360
     });
 
     expect(supabaseApiMock.updateUserJourney).toHaveBeenCalledWith(
@@ -190,7 +194,8 @@ describe('LocalSimulationService', () => {
         utm_term: 'simulacao',
         utm_content: 'banner',
         landing_page: 'https://libra.com.br/landing',
-        referrer: 'https://google.com'
+        referrer: 'https://google.com',
+        time_on_site: 360
       })
     );
   });

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -25,6 +25,7 @@ import {
   supabaseApi,
   SimulacaoData,
   supabase,
+  UserJourneyData,
   UserJourneySimulacaoData,
   type Database
 } from '@/lib/supabase';
@@ -52,6 +53,7 @@ export interface SimulationInput {
   utmContent?: string | null;
   landingPage?: string | null;
   referrer?: string | null;
+  timeOnSite?: number | null;
 }
 
 export interface SimulationResult {
@@ -88,6 +90,7 @@ export interface ContactFormInput {
   utm_content?: string | null;
   landing_page?: string | null;
   referrer?: string | null;
+  time_on_site?: number | null;
 }
 
 export interface SessionGroupWithJourney {
@@ -101,9 +104,53 @@ export interface SessionGroupWithJourney {
   utm_content?: string | null;
   landing_page?: string | null;
   referrer?: string | null;
+  time_on_site?: number | null;
   journey_status?: string | null;
   primary_session_id?: string | null;
 }
+
+const countJourneySignals = (journey?: Partial<UserJourneyData> | null): number => {
+  if (!journey) return 0;
+  const trackedKeys: (keyof UserJourneyData)[] = [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'landing_page',
+    'referrer',
+    'time_on_site'
+  ];
+  return trackedKeys.reduce((count, key) => {
+    const value = journey[key];
+    if (value === undefined || value === null) {
+      return count;
+    }
+    if (typeof value === 'string' && value.trim() === '') {
+      return count;
+    }
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      return count;
+    }
+    return count + 1;
+  }, 0);
+};
+
+const pickBetterJourney = (
+  current: UserJourneyData | undefined,
+  candidate: UserJourneyData | undefined
+): UserJourneyData | undefined => {
+  if (!candidate) {
+    return current;
+  }
+  if (!current) {
+    return candidate;
+  }
+
+  return countJourneySignals(candidate) >= countJourneySignals(current)
+    ? candidate
+    : current;
+};
 
 // Classe principal do serviço local
 export class LocalSimulationService {
@@ -265,6 +312,17 @@ export class LocalSimulationService {
             imovel_proprio: 'proprio',
             user_agent: input.userAgent || null,
             ip_address: input.ipAddress || null,
+            utm_source: input.utmSource ?? null,
+            utm_medium: input.utmMedium ?? null,
+            utm_campaign: input.utmCampaign ?? null,
+            utm_term: input.utmTerm ?? null,
+            utm_content: input.utmContent ?? null,
+            landing_page: input.landingPage ?? null,
+            referrer: input.referrer ?? null,
+            time_on_site:
+              typeof input.timeOnSite === 'number' && Number.isFinite(input.timeOnSite)
+                ? Math.max(0, Math.floor(input.timeOnSite))
+                : null,
             status: 'novo'
           };
 
@@ -330,6 +388,9 @@ export class LocalSimulationService {
           }
           if (input.landingPage !== undefined && input.landingPage !== null) {
             journeyUpdate.landing_page = input.landingPage;
+          }
+          if (typeof input.timeOnSite === 'number' && Number.isFinite(input.timeOnSite)) {
+            journeyUpdate.time_on_site = Math.max(0, Math.floor(input.timeOnSite));
           }
 
           const sanitizedJourneyUpdate = Object.fromEntries(
@@ -541,14 +602,44 @@ export class LocalSimulationService {
         try {
           if (input.simulationId) {
             // Validar e preparar dados para atualização
-            const updateData = {
+            const normalizedTimeOnSite =
+              typeof input.time_on_site === 'number' && Number.isFinite(input.time_on_site)
+                ? Math.max(0, Math.floor(input.time_on_site))
+                : undefined;
+
+            const updateData: Partial<SimulacaoData> = {
               nome_completo: input.nomeCompleto.trim(),
               email: input.email.trim().toLowerCase(),
               telefone: sanitizedPhone, // Limpar telefone
               imovel_proprio: input.imovelProprio as 'proprio' | 'terceiro', // Garantir tipo correto
               status: 'interessado', // Status após contato para compatibilidade com AdminDashboard
-              visitor_id: input.visitorId
+              visitor_id: input.visitorId ?? simulationData?.visitor_id ?? null
             };
+
+            if (input.utm_source !== undefined) {
+              updateData.utm_source = input.utm_source;
+            }
+            if (input.utm_medium !== undefined) {
+              updateData.utm_medium = input.utm_medium;
+            }
+            if (input.utm_campaign !== undefined) {
+              updateData.utm_campaign = input.utm_campaign;
+            }
+            if (input.utm_term !== undefined) {
+              updateData.utm_term = input.utm_term;
+            }
+            if (input.utm_content !== undefined) {
+              updateData.utm_content = input.utm_content;
+            }
+            if (input.landing_page !== undefined) {
+              updateData.landing_page = input.landing_page;
+            }
+            if (input.referrer !== undefined) {
+              updateData.referrer = input.referrer;
+            }
+            if (input.time_on_site !== undefined) {
+              updateData.time_on_site = normalizedTimeOnSite ?? null;
+            }
 
             journeyStatus = updateData.status || null;
 
@@ -634,6 +725,31 @@ export class LocalSimulationService {
                   throw new Error('Dados da simulação não encontrados no localStorage');
                 }
 
+                const fullInput: SimulationInput | undefined = localSimulation.fullInput;
+                const resolvedTimeOnSite =
+                  normalizedTimeOnSite ??
+                  (typeof fullInput?.timeOnSite === 'number' && Number.isFinite(fullInput.timeOnSite)
+                    ? Math.max(0, Math.floor(fullInput.timeOnSite))
+                    : simulationData?.time_on_site ?? null);
+
+                const resolvedUtmSource =
+                  updateData.utm_source ?? fullInput?.utmSource ?? simulationData?.utm_source ?? null;
+                const resolvedUtmMedium =
+                  updateData.utm_medium ?? fullInput?.utmMedium ?? simulationData?.utm_medium ?? null;
+                const resolvedUtmCampaign =
+                  updateData.utm_campaign ?? fullInput?.utmCampaign ?? simulationData?.utm_campaign ?? null;
+                const resolvedUtmTerm =
+                  updateData.utm_term ?? fullInput?.utmTerm ?? simulationData?.utm_term ?? null;
+                const resolvedUtmContent =
+                  updateData.utm_content ?? fullInput?.utmContent ?? simulationData?.utm_content ?? null;
+                const resolvedLandingPage =
+                  updateData.landing_page ??
+                  fullInput?.landingPage ??
+                  simulationData?.landing_page ??
+                  null;
+                const resolvedReferrer =
+                  updateData.referrer ?? fullInput?.referrer ?? simulationData?.referrer ?? null;
+
                 const createData = {
                   session_id: input.sessionId,
                   visitor_id: input.visitorId || null,
@@ -651,7 +767,15 @@ export class LocalSimulationService {
                   imovel_proprio: updateData.imovel_proprio,
                   user_agent: '',
                   ip_address: '',
-                  status: updateData.status
+                  status: updateData.status,
+                  utm_source: resolvedUtmSource,
+                  utm_medium: resolvedUtmMedium,
+                  utm_campaign: resolvedUtmCampaign,
+                  utm_term: resolvedUtmTerm,
+                  utm_content: resolvedUtmContent,
+                  landing_page: resolvedLandingPage,
+                  referrer: resolvedReferrer,
+                  time_on_site: resolvedTimeOnSite
                 };
 
                 console.log('💾 Criando nova simulação no Supabase:', createData);
@@ -877,6 +1001,17 @@ export class LocalSimulationService {
           input.referrer,
           existingJourney?.referrer
         );
+        const timeOnSiteValue =
+          typeof input.time_on_site === 'number' && Number.isFinite(input.time_on_site)
+            ? Math.max(0, Math.floor(input.time_on_site))
+            : input.time_on_site === null
+              ? null
+              : resolveNumber(
+                  undefined,
+                  fallbackSimulation?.time_on_site,
+                  simulationData?.time_on_site,
+                  existingJourney?.time_on_site
+                );
 
         const journeyUpdatePayload: Partial<UserJourneyData> = {
           nome_completo: normalizedNome,
@@ -898,6 +1033,10 @@ export class LocalSimulationService {
           landing_page: landingPageValue,
           referrer: referrerValue
         };
+
+        if (timeOnSiteValue !== undefined) {
+          journeyUpdatePayload.time_on_site = timeOnSiteValue;
+        }
 
         const sanitizedJourneyUpdatePayload = Object.fromEntries(
           Object.entries(journeyUpdatePayload).filter(([, value]) => value !== undefined)
@@ -924,6 +1063,7 @@ export class LocalSimulationService {
               existingJourney?.landing_page ??
               null,
             referrer: referrerValue ?? null,
+            time_on_site: timeOnSiteValue ?? null,
             ...sanitizedJourneyUpdatePayload
           };
 
@@ -1049,7 +1189,7 @@ export class LocalSimulationService {
 
       const grouped = new Map<string, SimulacaoData[]>();
       const sessionIds = new Set<string>();
-      const visitorOnlyIds = new Set<string>();
+      const visitorIds = new Set<string>();
 
       for (const sim of simulacoes) {
         const key = sim.visitor_id || sim.session_id;
@@ -1061,20 +1201,38 @@ export class LocalSimulationService {
 
         if (sim.session_id) {
           sessionIds.add(sim.session_id);
-        } else if (sim.visitor_id) {
-          visitorOnlyIds.add(sim.visitor_id);
+        }
+        if (sim.visitor_id) {
+          visitorIds.add(sim.visitor_id);
         }
       }
 
-      let journeys: UserJourneyData[] = [];
+      const journeyMap = new Map<string, UserJourneyData>();
+      const mergeJourney = (
+        key: string | null | undefined,
+        journey: UserJourneyData | null | undefined
+      ) => {
+        if (!key || !journey) return;
+        const current = journeyMap.get(key);
+        const better = pickBetterJourney(current, journey);
+        if (better) {
+          journeyMap.set(key, better);
+        }
+      };
+
       if (visitorIds.size > 0) {
-        journeys = journeys.concat(
-          await this.fetchJourneysInChunks(
-            Array.from(visitorIds),
-            ids => supabaseApi.getUserJourneysByVisitorIds(ids)
-          )
+        const journeysByVisitor = await this.fetchJourneysInChunks(
+          Array.from(visitorIds),
+          ids => supabaseApi.getUserJourneysByVisitorIds(ids)
         );
+
+        for (const journey of journeysByVisitor) {
+          if (!journey) continue;
+          mergeJourney(journey.visitor_id ?? undefined, journey as UserJourneyData);
+          mergeJourney(journey.session_id ?? undefined, journey as UserJourneyData);
+        }
       }
+
       if (sessionIds.size > 0) {
         const journeysBySession = await this.fetchJourneysInChunks(
           Array.from(sessionIds),
@@ -1083,21 +1241,9 @@ export class LocalSimulationService {
 
         for (const journey of journeysBySession) {
           if (!journey) continue;
-
-          if (journey.session_id) {
-            journeyMap.set(journey.session_id, journey);
-          }
-          if (journey.visitor_id) {
-            journeyMap.set(journey.visitor_id, journey);
-            visitorOnlyIds.delete(journey.visitor_id);
-          }
+          mergeJourney(journey.session_id ?? undefined, journey as UserJourneyData);
+          mergeJourney(journey.visitor_id ?? undefined, journey as UserJourneyData);
         }
-      }
-
-      const journeyMap = new Map<string, UserJourneyData>();
-      for (const j of journeys) {
-        const key = j?.visitor_id || j?.session_id;
-        if (key) journeyMap.set(key, j);
       }
 
       const result: SessionGroupWithJourney[] = [];
@@ -1110,23 +1256,61 @@ export class LocalSimulationService {
         );
 
         const primarySim = sims[0];
-        const journeyKey =
-          (primarySim.session_id && journeyMap.has(primarySim.session_id)
-            ? primarySim.session_id
-            : primarySim.visitor_id) || key;
-        const journey = journeyMap.get(journeyKey) || null;
+        const journey =
+          (primarySim.visitor_id
+            ? journeyMap.get(primarySim.visitor_id)
+            : undefined) ||
+          (primarySim.session_id
+            ? journeyMap.get(primarySim.session_id)
+            : undefined) ||
+          journeyMap.get(key) ||
+          null;
+
+        const pickSimulationValue = <K extends keyof SimulacaoData>(
+          field: K
+        ): SimulacaoData[K] | null => {
+          for (const simulation of sims) {
+            const value = simulation[field];
+            if (value === undefined || value === null) continue;
+            if (typeof value === 'string' && value.trim() === '') continue;
+            if (typeof value === 'number' && !Number.isFinite(value)) continue;
+            return value;
+          }
+          return null;
+        };
+
+        const resolvedUtmSource = journey?.utm_source ?? pickSimulationValue('utm_source');
+        const resolvedUtmMedium = journey?.utm_medium ?? pickSimulationValue('utm_medium');
+        const resolvedUtmCampaign = journey?.utm_campaign ?? pickSimulationValue('utm_campaign');
+        const resolvedUtmTerm = journey?.utm_term ?? pickSimulationValue('utm_term');
+        const resolvedUtmContent = journey?.utm_content ?? pickSimulationValue('utm_content');
+        const resolvedLandingPage =
+          journey?.landing_page ?? (pickSimulationValue('landing_page') as string | null);
+        const resolvedReferrer =
+          journey?.referrer ?? (pickSimulationValue('referrer') as string | null);
+        const resolvedTimeOnSite = (() => {
+          const journeyValue = journey?.time_on_site;
+          if (typeof journeyValue === 'number' && Number.isFinite(journeyValue)) {
+            return journeyValue;
+          }
+          const simulationValue = pickSimulationValue('time_on_site');
+          return typeof simulationValue === 'number' && Number.isFinite(simulationValue)
+            ? simulationValue
+            : null;
+        })();
 
         result.push({
           visitor_id: key,
           simulacoes: sims,
           total_simulacoes: sims.length,
-          utm_source: journey?.utm_source ?? null,
-          utm_medium: journey?.utm_medium ?? null,
-          utm_campaign: journey?.utm_campaign ?? null,
-          utm_term: journey?.utm_term ?? null,
-          utm_content: journey?.utm_content ?? null,
-          landing_page: journey?.landing_page ?? null,
-          referrer: journey?.referrer ?? null,
+          utm_source: (resolvedUtmSource as string | null) ?? null,
+          utm_medium: (resolvedUtmMedium as string | null) ?? null,
+          utm_campaign: (resolvedUtmCampaign as string | null) ?? null,
+          utm_term: (resolvedUtmTerm as string | null) ?? null,
+          utm_content: (resolvedUtmContent as string | null) ?? null,
+          landing_page: resolvedLandingPage ?? null,
+          referrer: resolvedReferrer ?? null,
+          time_on_site: resolvedTimeOnSite,
           journey_status: journey?.status ?? null,
           primary_session_id: primarySim.session_id ?? null
         });

--- a/src/services/simulationService.ts
+++ b/src/services/simulationService.ts
@@ -47,6 +47,7 @@ export interface SimulationInput {
   utmContent?: string | null;
   landingPage?: string | null;
   referrer?: string | null;
+  timeOnSite?: number | null;
 }
 
 export interface SimulationResult {
@@ -128,6 +129,17 @@ export class SimulationService {
         parcela_inicial: processedResult.primeiraParcela,
         parcela_final: processedResult.ultimaParcela || processedResult.valor,
         imovel_proprio: 'proprio',
+        utm_source: input.utmSource ?? null,
+        utm_medium: input.utmMedium ?? null,
+        utm_campaign: input.utmCampaign ?? null,
+        utm_term: input.utmTerm ?? null,
+        utm_content: input.utmContent ?? null,
+        landing_page: input.landingPage ?? null,
+        referrer: input.referrer ?? null,
+        time_on_site:
+          typeof input.timeOnSite === 'number' && Number.isFinite(input.timeOnSite)
+            ? Math.max(0, Math.floor(input.timeOnSite))
+            : null,
         ip_address: input.ipAddress || null,
         user_agent: input.userAgent || null,
         status: 'novo'
@@ -175,6 +187,9 @@ export class SimulationService {
       }
       if (input.landingPage !== undefined && input.landingPage !== null) {
         journeyUpdate.landing_page = input.landingPage;
+      }
+      if (typeof input.timeOnSite === 'number' && Number.isFinite(input.timeOnSite)) {
+        journeyUpdate.time_on_site = Math.max(0, Math.floor(input.timeOnSite));
       }
 
       const sanitizedJourneyUpdate = Object.fromEntries(


### PR DESCRIPTION
## Summary
- fetch complete UTM metadata from Supabase while ignoring placeholder simulation records
- merge journey and simulation tracking data so grouped sessions retain campaign, referrer, and time-on-site info
- surface campaign, ad group, and ad details in the admin UTM panel with cleaned labels

## Testing
- npm run test -- src/services/__tests__/localSimulationService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_690c8f8ed29c832d8d62ceec796f2a7c