### PR TITLE
Optimize hero media loading for core web vitals

### DIFF
--- a/src/components/ImageOptimizer.tsx
+++ b/src/components/ImageOptimizer.tsx
@@ -73,6 +73,8 @@ interface ImageOptimizerProps {
   height?: number;
   widths?: number[];
   sizes?: string;
+  decoding?: 'sync' | 'async' | 'auto';
+  fetchPriority?: 'high' | 'low' | 'auto';
 }
 
 const ImageOptimizer: React.FC<ImageOptimizerProps> = ({
@@ -86,12 +88,16 @@ const ImageOptimizer: React.FC<ImageOptimizerProps> = ({
   width,
   height,
   widths,
-  sizes
+  sizes,
+  decoding,
+  fetchPriority,
 }) => {
   const srcSet = widths?.map((w) => `${src}?width=${w} ${w}w`).join(', ');
   const allClasses = `${className} ${imgClassName}`;
   const hasWidthClass = /\bw-\S+/.test(allClasses);
   const hasHeightClass = /\bh-\S+/.test(allClasses);
+  const resolvedDecoding = decoding ?? (priority ? 'sync' : 'async');
+  const resolvedFetchPriority = fetchPriority ?? (priority ? 'high' : undefined);
 
   const imageElement = (
     <img
@@ -106,9 +112,10 @@ const ImageOptimizer: React.FC<ImageOptimizerProps> = ({
       )}
       width={width}
       height={height}
-      decoding="async"
+      decoding={resolvedDecoding}
       srcSet={srcSet}
       sizes={sizes}
+      fetchPriority={resolvedFetchPriority}
     />
   );
 

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -4,7 +4,14 @@ import { type FC, type MouseEvent, useEffect } from 'react';
 let youtubeApiPromise: Promise<void> | null = null;
 
 const loadYouTubeApi = (): Promise<void> => {
-  const w = window as any;
+  if (typeof window === 'undefined') {
+    return Promise.resolve();
+  }
+
+  const w = window as typeof window & {
+    YT?: { Player?: unknown };
+    onYouTubeIframeAPIReady?: () => void;
+  };
 
   if (w.YT && w.YT.Player) {
     return Promise.resolve();
@@ -55,14 +62,59 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
   const fetchPriorityAttr = fetchPriority ?? (priority ? 'high' : undefined);
 
   useEffect(() => {
-    loadYouTubeApi();
-  }, []);
+    if (!priority || typeof window === 'undefined') {
+      return;
+    }
 
-  const loadVideo = (e: MouseEvent<HTMLButtonElement>) => {
+    let cancelled = false;
+    const win = window as typeof window & {
+      requestIdleCallback?: (
+        callback: IdleRequestCallback,
+        options?: IdleRequestOptions,
+      ) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+
+    const load = () => {
+      if (!cancelled) {
+        void loadYouTubeApi();
+      }
+    };
+
+    if (win.requestIdleCallback) {
+      const handle = win.requestIdleCallback(load, { timeout: 2000 });
+      return () => {
+        cancelled = true;
+        win.cancelIdleCallback?.(handle);
+      };
+    }
+
+    const timeoutId = window.setTimeout(load, 1200);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [priority]);
+
+  const loadVideo = async (e: MouseEvent<HTMLButtonElement>) => {
     const container = e.currentTarget.parentElement as HTMLElement | null;
-    if (!container) return;
+    if (!container || typeof window === 'undefined') return;
 
-    const w = window as any;
+    const fallbackUrl = `https://www.youtube.com/watch?v=${videoId}`;
+    const w = window as typeof window & {
+      YT?: { Player?: new (...args: any[]) => any };
+    };
+
+    try {
+      await loadYouTubeApi();
+    } catch (error) {
+      console.error('Erro ao carregar a API do YouTube', error);
+    }
+
+    if (!w.YT || !w.YT.Player) {
+      window.open(fallbackUrl, '_blank', 'noopener');
+      return;
+    }
 
     container.innerHTML = '';
     const div = document.createElement('div');
@@ -88,7 +140,9 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
     <div className={`hero-video relative w-full h-full overflow-hidden bg-gray-200 ${className}`}>
       <button
         className="w-full h-full cursor-pointer relative flex items-center justify-center group"
-        onClick={loadVideo}
+        onClick={(event) => {
+          void loadVideo(event);
+        }}
         aria-label={`Reproduzir vídeo: ${title}`}
         type="button"
       >

--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -1,7 +1,10 @@
 import React, { Suspense, useState } from 'react';
-import { Calculator, CheckCircle, Users, Headphones } from 'lucide-react';
-const TrendingUp = React.lazy(() =>
-  import('lucide-react').then((m) => ({ default: m.TrendingUp }))
+import Calculator from 'lucide-react/dist/esm/icons/calculator';
+import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
+import Users from 'lucide-react/dist/esm/icons/users';
+import Headphones from 'lucide-react/dist/esm/icons/headphones';
+const TrendingUp = React.lazy(
+  () => import('lucide-react/dist/esm/icons/trending-up')
 );
 import { Button } from '@/components/ui/button';
 import { useIsMobile } from '@/hooks/use-mobile';

--- a/src/components/UTMDetails.tsx
+++ b/src/components/UTMDetails.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from './ui/collapsible';
 import { Button } from './ui/button';
-import { ChevronDown } from 'lucide-react';
+import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down';
 import type { SessionGroupWithJourney } from '@/services/localSimulationService';
 import { cn } from '@/lib/utils';
 


### PR DESCRIPTION
## Summary
- defer the YouTube iframe API until idle time/user interaction and add a graceful fallback for the hero video embed
- prioritize above-the-fold thumbnails by exposing fetch priority/decoding controls in ImageOptimizer
- shrink the JS bundle by switching lucide icon imports to per-icon modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690c9bb41a0c832d9f6c2c2d681cc60b