### PR TITLE
Fix footer rendering on home page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,6 +12,7 @@ import ImageOptimizer from '@/components/ImageOptimizer';
 // Lazy loading dos componentes pesados - com threshold otimizado
 const FAQ = lazy(() => import('@/components/FAQ'));
 const BlogSection = lazy(() => import('@/components/BlogSection'));
+const Footer = lazy(() => import('@/components/Footer'));
 
 interface LazySectionProps {
   load: () => Promise<{ default: React.ComponentType<unknown> }>;
@@ -175,7 +176,9 @@ const Index: React.FC = () => {
       </Suspense>
       </main>
 
-      <LazySection load={() => import('@/components/Footer')} />
+      <Suspense fallback={null}>
+        <Footer />
+      </Suspense>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- ensure the home page renders the footer by lazily importing it with Suspense

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690ca5e6ec08832d8fc0ec94151bfd6a