### PR TITLE
Improve blog SSR and SEO metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "marked": "^16.1.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^2.0.5",
         "react-router-dom": "^6.26.2",
         "sharp": "^0.34.3",
         "tailwind-merge": "^2.5.2",
@@ -5575,6 +5576,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -7157,6 +7167,26 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -7496,6 +7526,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "marked": "^16.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^2.0.5",
     "react-router-dom": "^6.26.2",
     "sharp": "^0.34.3",
     "tailwind-merge": "^2.5.2",

--- a/scripts/prerender.tsx
+++ b/scripts/prerender.tsx
@@ -3,8 +3,11 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { FilledContext } from 'react-helmet-async';
 import AppServer from '../src/AppServer';
 import { BLOG_POSTS } from '../src/data/blogPosts';
+import type { BlogPost } from '../src/services/blogService';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,15 +20,204 @@ interface RouteConfig {
   data?: any;
 }
 
+interface SupabaseBlogPostRow {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  content: string | null;
+  image_url: string | null;
+  slug: string;
+  read_time: number | null;
+  published: boolean;
+  featured_post: boolean;
+  meta_title: string | null;
+  meta_description: string | null;
+  tags: string[] | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+type SupabaseDatabase = {
+  public: {
+    Tables: {
+      blog_posts: {
+        Row: SupabaseBlogPostRow;
+      };
+    };
+  };
+};
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY ?? process.env.VITE_SUPABASE_ANON_KEY;
+
+function mapSupabasePost(row: SupabaseBlogPostRow): BlogPost {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    category: row.category,
+    content: row.content ?? '',
+    imageUrl: row.image_url ?? '',
+    slug: row.slug,
+    readTime: row.read_time ?? 0,
+    published: row.published,
+    featuredPost: row.featured_post,
+    metaTitle: row.meta_title ?? undefined,
+    metaDescription: row.meta_description ?? undefined,
+    tags: row.tags ?? undefined,
+    createdAt: row.created_at ?? undefined,
+    updatedAt: row.updated_at ?? undefined,
+  };
+}
+
+let supabaseClient: SupabaseClient<SupabaseDatabase> | null = null;
+
+function getSupabaseClient(): SupabaseClient<SupabaseDatabase> | null {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    return null;
+  }
+
+  if (!supabaseClient) {
+    supabaseClient = createClient<SupabaseDatabase>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { persistSession: false },
+    });
+  }
+
+  return supabaseClient;
+}
+
+async function fetchPublishedPosts(): Promise<BlogPost[]> {
+  const fallbackPosts = BLOG_POSTS.filter((post) => post.published);
+  const client = getSupabaseClient();
+
+  if (!client) {
+    console.warn('Supabase credentials missing. Falling back to static blog posts.');
+    return fallbackPosts;
+  }
+
+  try {
+    const { data, error } = await client
+      .from('blog_posts')
+      .select(
+        [
+          'id',
+          'title',
+          'description',
+          'category',
+          'content',
+          'image_url',
+          'slug',
+          'read_time',
+          'published',
+          'featured_post',
+          'meta_title',
+          'meta_description',
+          'tags',
+          'created_at',
+          'updated_at',
+        ].join(',')
+      )
+      .eq('published', true)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      throw error;
+    }
+
+    if (!data) {
+      return fallbackPosts;
+    }
+
+    return data.map(mapSupabasePost);
+  } catch (error) {
+    console.error('Failed to fetch blog posts from Supabase, using fallback data.', error);
+    return fallbackPosts;
+  }
+}
+
+function injectHelmetData(html: string, helmetContext: FilledContext) {
+  const { helmet } = helmetContext;
+  let processedHtml = html;
+
+  if (helmet) {
+    const title = helmet.title.toString();
+    if (title) {
+      processedHtml = processedHtml.replace(/<title>.*?<\/title>/, title);
+    }
+
+    const htmlAttrs = helmet.htmlAttributes.toString();
+    if (htmlAttrs) {
+      processedHtml = processedHtml.replace(/<html[^>]*>/, `<html ${htmlAttrs}>`);
+    }
+
+    const bodyAttrs = helmet.bodyAttributes.toString();
+    if (bodyAttrs) {
+      processedHtml = processedHtml.replace('<body', `<body ${bodyAttrs}`);
+    }
+
+    const headTags = [
+      helmet.meta.toString(),
+      helmet.link.toString(),
+      helmet.script.toString(),
+      helmet.noscript.toString(),
+      helmet.style.toString(),
+      helmet.base.toString(),
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    if (headTags) {
+      processedHtml = processedHtml.replace('</head>', `${headTags}\n</head>`);
+    }
+  }
+
+  return processedHtml;
+}
+
+function injectInitialData(html: string, data: any) {
+  if (!data) {
+    return html;
+  }
+
+  const serialized = JSON.stringify(data).replace(/</g, '\\u003c');
+  const scriptTag = `<script>window.__INITIAL_DATA__ = ${serialized};</script>`;
+  const mainEntryTag = '<script type="module" src="/src/main.tsx" defer></script>';
+
+  if (html.includes(mainEntryTag)) {
+    return html.replace(mainEntryTag, `${scriptTag}\n    ${mainEntryTag}`);
+  }
+
+  return html.replace('</body>', `${scriptTag}\n</body>`);
+}
+
 async function renderPage(template: string, route: RouteConfig) {
-  const appHtml = renderToString(<AppServer url={route.url} initialData={route.data} />);
+  const helmetContext = {} as FilledContext;
+  const appHtml = renderToString(
+    <AppServer url={route.url} initialData={route.data} helmetContext={helmetContext} />
+  );
+
   let html = template.replace('<div id="root"></div>', `<div id="root">${appHtml}</div>`);
-  if (route.title) {
+  html = injectHelmetData(html, helmetContext);
+
+  const helmet = helmetContext.helmet;
+
+  if (route.title && !helmet?.title.toString()) {
     html = html.replace(/<title>.*?<\/title>/, `<title>${route.title}</title>`);
   }
+
   if (route.description) {
-    html = html.replace(/<meta name="description" content="[^"]*"\s*\/>/, `<meta name="description" content="${route.description}" />`);
+    const helmetMeta = helmet?.meta.toString() ?? '';
+    if (!/name="description"/i.test(helmetMeta)) {
+      html = html.replace(
+        /<meta name="description" content="[^"]*"\s*\/>/,
+        `<meta name="description" content="${route.description}" />`
+      );
+    }
   }
+
+  html = injectInitialData(html, route.data);
+
   const outPath = path.resolve(__dirname, '../dist', route.file);
   await mkdir(path.dirname(outPath), { recursive: true });
   await writeFile(outPath, html);
@@ -35,15 +227,17 @@ async function prerender() {
   const indexPath = path.resolve(__dirname, '../dist/index.html');
   const template = await readFile(indexPath, 'utf-8');
 
+  const posts = await fetchPublishedPosts();
+
   await renderPage(template, { url: '/', file: 'index.html' });
 
-  const posts = BLOG_POSTS.filter(p => p.published);
   await renderPage(template, {
     url: '/blog',
     file: 'blog/index.html',
     title: 'Blog | Libra Crédito | Artigos e Dicas Financeiras',
-    description: 'Confira artigos e dicas sobre capital de giro, consolidação de dívidas e financiamento para reformas. Mantenha-se informado com o blog da Libra Crédito.',
-    data: { posts }
+    description:
+      'Confira artigos e dicas sobre capital de giro, consolidação de dívidas e financiamento para reformas. Mantenha-se informado com o blog da Libra Crédito.',
+    data: { posts },
   });
 
   for (const post of posts) {
@@ -52,7 +246,7 @@ async function prerender() {
       file: `blog/${post.slug}/index.html`,
       title: post.metaTitle || post.title,
       description: post.metaDescription || post.description,
-      data: { post }
+      data: { post },
     });
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import ScrollToTop from '@/components/ScrollToTop';
 import { MobileProvider } from '@/hooks/useMobileContext';
 import LazyGlobalTracker from '@/components/LazyGlobalTracker';
+import { HelmetProvider } from 'react-helmet-async';
 
 // Lazy load TooltipProvider para LCP
 const TooltipProvider = lazy(() => import('@/components/ui/tooltip').then(m => ({ default: m.TooltipProvider })));
@@ -84,50 +85,52 @@ const App = () => {
   }, []);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <MobileProvider>
-        <BrowserRouter>
-          <LazyGlobalTracker />
-          <ScrollToTop />
-          {typeof window !== 'undefined' && <LazyGlobalTracker />}
-          <Suspense fallback={<Loading />}>
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/vantagens" element={
-                <Suspense fallback={<Loading />}>
-                  <TooltipProvider><Vantagens /></TooltipProvider>
-                </Suspense>
-              } />
-              <Route path="/quem-somos" element={<QuemSomos />} />
-              <Route path="/blog" element={<Blog />} />
-              <Route path="/blog/:slug" element={<BlogPost />} />
-              <Route path="/parceiros" element={<Parceiros />} />
-              <Route path="/simulacao" element={
-                <Suspense fallback={<Loading />}>
-                  <TooltipProvider><Simulacao /></TooltipProvider>
-                </Suspense>
-              } />
-              <Route path="/simulacao/sapi" element={<SimulacaoSapi />} />
-              <Route path="/simulacao/local" element={<SimulacaoLocal />} />
-              <Route path="/politica-privacidade" element={<PoliticaPrivacidade />} />
-              <Route path="/politica-cookies" element={<PoliticaCookies />} />
-              <Route path="/admin" element={
-                <Suspense fallback={<Loading />}>
-                  <TooltipProvider><AdminDashboard /></TooltipProvider>
-                </Suspense>
-              } />
-              {devRoutes}
-              <Route path="/confirmacao" element={<Confirmacao />} />
-              <Route path="/atendimento" element={<Atendimento />} />
-              <Route path="/sucesso" element={<Sucesso />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </Suspense>
-        </BrowserRouter>
-        <Toaster />
-        {AnalyticsComponent && <AnalyticsComponent />}
-      </MobileProvider>
-    </QueryClientProvider>
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>
+        <MobileProvider>
+          <BrowserRouter>
+            <LazyGlobalTracker />
+            <ScrollToTop />
+            {typeof window !== 'undefined' && <LazyGlobalTracker />}
+            <Suspense fallback={<Loading />}>
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/vantagens" element={
+                  <Suspense fallback={<Loading />}>
+                    <TooltipProvider><Vantagens /></TooltipProvider>
+                  </Suspense>
+                } />
+                <Route path="/quem-somos" element={<QuemSomos />} />
+                <Route path="/blog" element={<Blog />} />
+                <Route path="/blog/:slug" element={<BlogPost />} />
+                <Route path="/parceiros" element={<Parceiros />} />
+                <Route path="/simulacao" element={
+                  <Suspense fallback={<Loading />}>
+                    <TooltipProvider><Simulacao /></TooltipProvider>
+                  </Suspense>
+                } />
+                <Route path="/simulacao/sapi" element={<SimulacaoSapi />} />
+                <Route path="/simulacao/local" element={<SimulacaoLocal />} />
+                <Route path="/politica-privacidade" element={<PoliticaPrivacidade />} />
+                <Route path="/politica-cookies" element={<PoliticaCookies />} />
+                <Route path="/admin" element={
+                  <Suspense fallback={<Loading />}>
+                    <TooltipProvider><AdminDashboard /></TooltipProvider>
+                  </Suspense>
+                } />
+                {devRoutes}
+                <Route path="/confirmacao" element={<Confirmacao />} />
+                <Route path="/atendimento" element={<Atendimento />} />
+                <Route path="/sucesso" element={<Sucesso />} />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </Suspense>
+          </BrowserRouter>
+          <Toaster />
+          {AnalyticsComponent && <AnalyticsComponent />}
+        </MobileProvider>
+      </QueryClientProvider>
+    </HelmetProvider>
   );
 };
 

--- a/src/AppServer.tsx
+++ b/src/AppServer.tsx
@@ -8,6 +8,7 @@ import { Toaster } from '@/components/ui/toast';
 import { Analytics } from '@vercel/analytics/react';
 import type { BlogPost as BlogPostType } from '@/data/blogPosts';
 import LazyGlobalTracker from '@/components/LazyGlobalTracker';
+import { HelmetProvider, type FilledContext } from 'react-helmet-async';
 
 const TooltipProvider = lazy(() => import('@/components/ui/tooltip').then(m => ({ default: m.TooltipProvider })));
 
@@ -58,59 +59,65 @@ const queryClient = new QueryClient({
 
 interface InitialData { posts?: BlogPostType[]; post?: BlogPostType; }
 
-interface AppServerProps { url: string; initialData?: InitialData; }
+interface AppServerProps {
+  url: string;
+  initialData?: InitialData;
+  helmetContext?: FilledContext;
+}
 
-const AppServer: React.FC<AppServerProps> = ({ url, initialData = {} }) => {
+const AppServer: React.FC<AppServerProps> = ({ url, initialData = {}, helmetContext }) => {
   return (
-    <QueryClientProvider client={queryClient}>
-      <MobileProvider>
-        <StaticRouter location={url}>
-          {typeof window !== 'undefined' && <LazyGlobalTracker />}
-          <ScrollToTop />
-          <Suspense fallback={<Loading />}>
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/vantagens" element={
-                <Suspense fallback={<Loading />}>
-                  <TooltipProvider><Vantagens /></TooltipProvider>
-                </Suspense>
-              } />
-              <Route path="/quem-somos" element={<QuemSomos />} />
-              <Route path="/blog" element={<Blog initialPosts={initialData.posts} />} />
-              <Route path="/blog/:slug" element={<BlogPost initialPost={initialData.post} />} />
-              <Route path="/parceiros" element={<Parceiros />} />
-              <Route path="/simulacao" element={
-                <Suspense fallback={<Loading />}>
-                  <TooltipProvider><Simulacao /></TooltipProvider>
-                </Suspense>
-              } />
-              <Route path="/simulacao/sapi" element={<SimulacaoSapi />} />
-              <Route path="/simulacao/local" element={<SimulacaoLocal />} />
-              <Route path="/politica-privacidade" element={<PoliticaPrivacidade />} />
-              <Route path="/politica-cookies" element={<PoliticaCookies />} />
-              <Route path="/admin" element={
-                <Suspense fallback={<Loading />}>
-                  <TooltipProvider><AdminDashboard /></TooltipProvider>
-                </Suspense>
-              } />
-              <Route path="/test-supabase" element={<SupabaseTestPage />} />
-              <Route path="/test-webhook" element={<TestWebhook />} />
-              <Route path="/mobile-demo" element={<MobileDemo />} />
-              <Route path="/mobile-nav" element={<MobileNavDemo />} />
-              <Route path="/simulacao-wizard" element={<SimulacaoWizard />} />
-              <Route path="/wizard-test" element={<SimpleWizardTest />} />
-              <Route path="/confirmacao" element={<Confirmacao />} />
-              <Route path="/atendimento" element={<Atendimento />} />
-              <Route path="/sucesso" element={<Sucesso />} />
-              <Route path="/home2" element={<Home2 />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </Suspense>
-        </StaticRouter>
-        <Toaster />
-        <Analytics />
-      </MobileProvider>
-    </QueryClientProvider>
+    <HelmetProvider context={helmetContext}>
+      <QueryClientProvider client={queryClient}>
+        <MobileProvider>
+          <StaticRouter location={url}>
+            {typeof window !== 'undefined' && <LazyGlobalTracker />}
+            <ScrollToTop />
+            <Suspense fallback={<Loading />}>
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/vantagens" element={
+                  <Suspense fallback={<Loading />}>
+                    <TooltipProvider><Vantagens /></TooltipProvider>
+                  </Suspense>
+                } />
+                <Route path="/quem-somos" element={<QuemSomos />} />
+                <Route path="/blog" element={<Blog initialPosts={initialData.posts} />} />
+                <Route path="/blog/:slug" element={<BlogPost initialPost={initialData.post} />} />
+                <Route path="/parceiros" element={<Parceiros />} />
+                <Route path="/simulacao" element={
+                  <Suspense fallback={<Loading />}>
+                    <TooltipProvider><Simulacao /></TooltipProvider>
+                  </Suspense>
+                } />
+                <Route path="/simulacao/sapi" element={<SimulacaoSapi />} />
+                <Route path="/simulacao/local" element={<SimulacaoLocal />} />
+                <Route path="/politica-privacidade" element={<PoliticaPrivacidade />} />
+                <Route path="/politica-cookies" element={<PoliticaCookies />} />
+                <Route path="/admin" element={
+                  <Suspense fallback={<Loading />}>
+                    <TooltipProvider><AdminDashboard /></TooltipProvider>
+                  </Suspense>
+                } />
+                <Route path="/test-supabase" element={<SupabaseTestPage />} />
+                <Route path="/test-webhook" element={<TestWebhook />} />
+                <Route path="/mobile-demo" element={<MobileDemo />} />
+                <Route path="/mobile-nav" element={<MobileNavDemo />} />
+                <Route path="/simulacao-wizard" element={<SimulacaoWizard />} />
+                <Route path="/wizard-test" element={<SimpleWizardTest />} />
+                <Route path="/confirmacao" element={<Confirmacao />} />
+                <Route path="/atendimento" element={<Atendimento />} />
+                <Route path="/sucesso" element={<Sucesso />} />
+                <Route path="/home2" element={<Home2 />} />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </Suspense>
+          </StaticRouter>
+          <Toaster />
+          <Analytics />
+        </MobileProvider>
+      </QueryClientProvider>
+    </HelmetProvider>
   );
 };
 

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
 
 /**
  * Props for the {@link Seo} component used to manage page-level metadata.
@@ -32,94 +33,36 @@ const Seo: React.FC<SeoProps> = ({
   jsonLd,
   schemaId,
 }) => {
-  useEffect(() => {
-    if (title) {
-      document.title = title;
-    }
+  const openGraphEntries = Object.entries(openGraph ?? {}).filter(([, value]) => Boolean(value));
+  const twitterEntries = Object.entries(twitter ?? {}).filter(([, value]) => Boolean(value));
 
-    if (description) {
-      const metaDescription = document.querySelector('meta[name="description"]');
-      if (metaDescription) {
-        metaDescription.setAttribute('content', description);
-      }
-    }
+  const jsonLdContent = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : null;
 
-    if (canonicalUrl) {
-      let link = document.querySelector(
-        "link[rel='canonical']"
-      ) as HTMLLinkElement | null;
-      if (!link) {
-        link = document.createElement('link');
-        link.setAttribute('rel', 'canonical');
-        document.head.appendChild(link);
-      }
-      link.setAttribute('href', canonicalUrl);
-    }
+  return (
+    <Helmet>
+      {title && <title>{title}</title>}
+      {description && <meta name="description" content={description} />}
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
 
-    if (openGraph) {
-      Object.entries(openGraph).forEach(([key, value]) => {
-        if (!value) return;
-        const property = `og:${key}`;
-        let meta = document.querySelector(
-          `meta[property='${property}']`
-        ) as HTMLMetaElement | null;
-        if (!meta) {
-          meta = document.createElement('meta');
-          meta.setAttribute('property', property);
-          document.head.appendChild(meta);
-        }
-        meta.setAttribute('content', value);
-      });
-    }
+      {openGraphEntries.map(([key, value]) => (
+        <meta key={`og:${key}`} property={`og:${key}`} content={value} />
+      ))}
 
-    if (twitter) {
-      Object.entries(twitter).forEach(([key, value]) => {
-        if (!value) return;
-        const name = `twitter:${key}`;
-        let meta = document.querySelector(
-          `meta[name='${name}']`
-        ) as HTMLMetaElement | null;
-        if (!meta) {
-          meta = document.createElement('meta');
-          meta.setAttribute('name', name);
-          document.head.appendChild(meta);
-        }
-        meta.setAttribute('content', value);
-      });
-    }
+      {twitterEntries.map(([key, value]) => (
+        <meta key={`twitter:${key}`} name={`twitter:${key}`} content={value} />
+      ))}
 
-    let script: HTMLScriptElement | null = null;
-    const id = schemaId || 'json-ld-schema';
-
-    if (jsonLd) {
-      const existing = document.getElementById(id);
-      if (existing) {
-        existing.remove();
-      }
-      script = document.createElement('script');
-      script.type = 'application/ld+json';
-      script.id = id;
-      script.textContent = JSON.stringify(jsonLd);
-      document.head.appendChild(script);
-    }
-
-    return () => {
-      const existing = document.getElementById(id);
-      if (existing) {
-        existing.remove();
-      }
-    };
-  }, [
-    title,
-    description,
-    canonicalUrl,
-    openGraph,
-    twitter,
-    jsonLd,
-    schemaId,
-  ]);
-
-  return null;
+      {jsonLdContent && (
+        <script
+          type="application/ld+json"
+          id={schemaId}
+          key={schemaId ?? 'json-ld'}
+        >
+          {jsonLdContent}
+        </script>
+      )}
+    </Helmet>
+  );
 };
 
 export default Seo;

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Search from 'lucide-react/dist/esm/icons/search';
 import TrendingUp from 'lucide-react/dist/esm/icons/trending-up';
@@ -84,8 +84,20 @@ const Blog: React.FC<BlogProps> = ({ initialPosts = [] }) => {
   const isMobile = useIsMobile();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [posts, setPosts] = useState<BlogPost[]>(initialPosts);
-  const [loading, setLoading] = useState(initialPosts.length === 0);
+  const resolvedInitialPosts = useMemo(() => {
+    if (initialPosts.length > 0) {
+      return initialPosts;
+    }
+
+    if (typeof window !== 'undefined' && Array.isArray(window.__INITIAL_DATA__?.posts)) {
+      return window.__INITIAL_DATA__?.posts ?? [];
+    }
+
+    return [];
+  }, [initialPosts]);
+
+  const [posts, setPosts] = useState<BlogPost[]>(resolvedInitialPosts);
+  const [loading, setLoading] = useState(resolvedInitialPosts.length === 0);
 
   const blogJsonLd = {
     '@context': 'https://schema.org',
@@ -108,12 +120,22 @@ const Blog: React.FC<BlogProps> = ({ initialPosts = [] }) => {
         setLoading(false);
       }
     };
-    if (initialPosts.length === 0) {
+    if (resolvedInitialPosts.length === 0) {
       loadPosts();
     } else {
       setLoading(false);
     }
-  }, [initialPosts]);
+  }, [initialPosts, resolvedInitialPosts.length]);
+
+  useEffect(() => {
+    setPosts(resolvedInitialPosts);
+  }, [resolvedInitialPosts]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.__INITIAL_DATA__ = undefined;
+    }
+  }, []);
 
   const handleSimular = () => {
     navigate('/simulacao');
@@ -131,6 +153,7 @@ const Blog: React.FC<BlogProps> = ({ initialPosts = [] }) => {
       <Seo
         title="Blog | Libra Crédito | Artigos e Dicas Financeiras"
         description="Confira artigos e dicas sobre capital de giro, consolidação de dívidas e financiamento para reformas. Mantenha-se informado com o blog da Libra Crédito."
+        canonicalUrl="https://libracredito.com.br/blog"
         jsonLd={blogJsonLd}
         schemaId="blog-schema"
       />

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
 import Clock from 'lucide-react/dist/esm/icons/clock';
@@ -17,8 +17,26 @@ interface BlogPostPageProps { initialPost?: BlogPost; }
 
 const BlogPost: React.FC<BlogPostPageProps> = ({ initialPost }) => {
   const { slug } = useParams<{ slug: string }>();
-  const [post, setPost] = useState<BlogPost | null>(initialPost || null);
-  const [loading, setLoading] = useState(!initialPost);
+  const resolvedInitialPost = useMemo(() => {
+    if (initialPost) {
+      return initialPost;
+    }
+
+    if (typeof window !== 'undefined' && window.__INITIAL_DATA__?.post) {
+      return window.__INITIAL_DATA__?.post ?? null;
+    }
+
+    return null;
+  }, [initialPost]);
+
+  const [post, setPost] = useState<BlogPost | null>(resolvedInitialPost);
+  const [loading, setLoading] = useState(!resolvedInitialPost);
+
+  useEffect(() => {
+    if (resolvedInitialPost) {
+      setPost(resolvedInitialPost);
+    }
+  }, [resolvedInitialPost]);
 
   useEffect(() => {
     const loadPost = async () => {
@@ -39,12 +57,18 @@ const BlogPost: React.FC<BlogPostPageProps> = ({ initialPost }) => {
       }
     };
 
-    if (!initialPost || !initialPost.content) {
+    if (!resolvedInitialPost || !resolvedInitialPost.content) {
       loadPost();
     } else {
       setLoading(false);
     }
-  }, [slug, initialPost]);
+  }, [slug, resolvedInitialPost]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.__INITIAL_DATA__ = undefined;
+    }
+  }, []);
 
   if (loading) {
     return (
@@ -84,7 +108,8 @@ const BlogPost: React.FC<BlogPostPageProps> = ({ initialPost }) => {
   const renderContent = (content: string) => renderMarkdown(content);
 
   const origin = typeof window !== 'undefined' ? window.location.origin : 'https://libracredito.com.br';
-  const postUrl = post ? `${origin}/blog/${post.slug}` : '';
+  const canonicalSlug = post?.slug ?? slug ?? '';
+  const postUrl = canonicalSlug ? `${origin}/blog/${canonicalSlug}` : `${origin}/blog`;
   const logoUrl = `${origin}/images/logos/logo-azul.png`;
   const datePublished = post?.createdAt ? new Date(post.createdAt).toISOString() : undefined;
   const dateModified = post?.updatedAt ? new Date(post.updatedAt).toISOString() : undefined;
@@ -95,6 +120,7 @@ const BlogPost: React.FC<BlogPostPageProps> = ({ initialPost }) => {
         <Seo
           title={`${post.metaTitle ?? post.title} | Blog Libra Crédito`}
           description={post.metaDescription ?? post.description}
+          canonicalUrl={postUrl}
           jsonLd={{
             '@context': 'https://schema.org',
             '@type': 'Article',

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,12 @@
+import type { BlogPost } from '@/services/blogService';
+
+declare global {
+  interface Window {
+    __INITIAL_DATA__?: {
+      posts?: BlogPost[];
+      post?: BlogPost;
+    };
+  }
+}
+
+export {};

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,14 @@
       "destination": "/images/$1"
     },
     {
+      "source": "/blog",
+      "destination": "/blog/index.html"
+    },
+    {
+      "source": "/blog/(.*)",
+      "destination": "/blog/$1/index.html"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary
- fetch published blog posts from Supabase during prerender and embed the initial payload for hydration
- switch the SEO layer to react-helmet-async so prerendered pages expose full metadata
- update blog routes to reuse server data on hydration and adjust Vercel rewrites for static blog HTML

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915dd25c6b8832da9ec946d578cd959)