### PR TITLE
Limit admin simulations to 100 and clarify ordering

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -332,6 +332,7 @@ export const supabaseApi = {
       .neq('telefone', '')
       .neq('telefone', SIMULATION_PLACEHOLDER_PHONE)
       .neq('status', 'novo')
+      // AdminDashboard depende das simulações mais recentes primeiro
       .order('created_at', { ascending: false })
       .range(from, to);
 

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -125,6 +125,8 @@ const AdminDashboard: React.FC = () => {
     em_analise: 0
   });
 
+  const SIMULACOES_LIMIT = 100;
+
   // Verificar autenticação ao carregar
   useEffect(() => {
     const checkAuth = async () => {
@@ -336,7 +338,7 @@ const AdminDashboard: React.FC = () => {
     setLoading(true);
     try {
       const data = await LocalSimulationService.getSimulacoesAgrupadas({
-        limit: 1000,
+        limit: SIMULACOES_LIMIT,
         status: filtroStatus !== 'todos' ? filtroStatus : undefined,
         searchTerm: filtroNome.trim() ? filtroNome : undefined
       });


### PR DESCRIPTION
## Summary
- reduce AdminDashboard simulation fetch to configurable 100 item limit
- document and reinforce descending created_at ordering in Supabase simulation query

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bfa61a548832dbd6511816f4c6502)