### PR TITLE
Exibir telefone na tabela de simulações

### DIFF
--- a/src/lib/supabaseLazy.ts
+++ b/src/lib/supabaseLazy.ts
@@ -126,12 +126,14 @@ async function loadSupabaseClient() {
           let query = client
             .from('simulacoes')
             .select(
-              'id,nome_completo,email,status,created_at,valor_emprestimo,valor_imovel,parcelas,session_id,visitor_id'
+              'id,nome_completo,email,telefone,status,created_at,valor_emprestimo,valor_imovel,parcelas,session_id,visitor_id'
             )
             .not('nome_completo', 'is', null)
             .neq('nome_completo', '')
             .not('email', 'is', null)
             .neq('email', '')
+            .not('telefone', 'is', null)
+            .neq('telefone', '')
             .neq('status', 'novo')
             .order('created_at', { ascending: false })
             .range(from, to);

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -713,6 +713,9 @@ const AdminDashboard: React.FC = () => {
                         </TableCell>
                         <TableCell className="text-sm">
                           <div>{simulacao.email}</div>
+                          {simulacao.telefone && (
+                            <div className="text-xs text-gray-500">{formatPhone(simulacao.telefone)}</div>
+                          )}
                           <div className="text-gray-500 text-xs break-all">
                             Sessão: {visitor.primary_session_id || 'N/D'}
                           </div>


### PR DESCRIPTION
## Summary
- mostrar telefone junto ao e-mail na coluna de contato das simulações
- garantir que a consulta lazy do Supabase também selecione o telefone e não retorne registros sem o campo

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bfa5f7360832da39ba9f00c292b74)