### PR TITLE
Add scheduling support to blog posts

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -191,6 +191,8 @@ export interface BlogPostData {
   read_time?: number;
   published: boolean;
   featured_post: boolean;
+  scheduled_at?: string | null;
+  published_at?: string | null;
   meta_title?: string;
   meta_description?: string;
   tags?: string[];
@@ -490,7 +492,7 @@ export const supabaseApi = {
     const { data, error } = await supabase
       .from('blog_posts')
       .select(
-        'id,title,description,category,image_url,slug,read_time,published,featured_post,meta_title,meta_description,created_at,updated_at'
+        'id,title,description,category,image_url,slug,read_time,published,featured_post,scheduled_at,published_at,meta_title,meta_description,created_at,updated_at'
       )
       .order('created_at', { ascending: false });
 
@@ -499,10 +501,13 @@ export const supabaseApi = {
   },
 
   async getPublishedBlogPosts() {
+    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('blog_posts')
       .select('*')
       .eq('published', true)
+      .or(`scheduled_at.lte.${now},scheduled_at.is.null`)
+      .order('scheduled_at', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
     
     if (error) throw error;
@@ -524,7 +529,7 @@ export const supabaseApi = {
     const { data, error } = await supabase
       .from('blog_posts')
       .select(
-        'id,title,description,category,content,image_url,slug,read_time,published,featured_post,meta_title,meta_description,tags,created_at,updated_at'
+        'id,title,description,category,content,image_url,slug,read_time,published,featured_post,scheduled_at,published_at,meta_title,meta_description,tags,created_at,updated_at'
       )
       .eq('slug', slug)
       .single();
@@ -567,11 +572,14 @@ export const supabaseApi = {
   },
 
   async getBlogPostsByCategory(category: string) {
+    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('blog_posts')
       .select('*')
       .eq('category', category)
       .eq('published', true)
+      .or(`scheduled_at.lte.${now},scheduled_at.is.null`)
+      .order('scheduled_at', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
     
     if (error) throw error;
@@ -579,11 +587,14 @@ export const supabaseApi = {
   },
 
   async getFeaturedBlogPosts() {
+    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('blog_posts')
       .select('*')
       .eq('featured_post', true)
       .eq('published', true)
+      .or(`scheduled_at.lte.${now},scheduled_at.is.null`)
+      .order('scheduled_at', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
     
     if (error) throw error;

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -216,6 +216,13 @@ const AdminDashboard: React.FC = () => {
     return text.trim().split(' ').filter(word => word.length > 0).length;
   };
 
+  const formatDateTimeLocal = (value?: string) => {
+    if (!value) return '';
+    const date = new Date(value);
+    const pad = (num: number) => String(num).padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+  };
+
 
 
   // Função para inserir texto no editor
@@ -245,20 +252,37 @@ const AdminDashboard: React.FC = () => {
       alert('Preencha todos os campos obrigatórios');
       return;
     }
-    
+
+    const now = new Date();
+    const scheduledDate = postForm.scheduledAt ? new Date(postForm.scheduledAt) : now;
+    const isAlreadyPublished = editingPost?.published ?? false;
+
+    if (scheduledDate.getTime() < now.getTime() && !isAlreadyPublished) {
+      alert('A data/hora de publicação não pode ser no passado');
+      return;
+    }
+
+    const slug = postForm.slug?.trim() || BlogService.generateSlug(postForm.title);
+    const published = postForm.published ?? false;
+    const featuredPost = postForm.featuredPost ?? false;
+
+    const payload: BlogPost = {
+      ...postForm,
+      slug,
+      published,
+      featuredPost,
+      scheduledAt: scheduledDate.toISOString(),
+      readTime: postForm.readTime || BlogService.calculateReadTime(postForm.content || '')
+    };
+
+    const isPublishedNow = BlogService.isPostPublished(payload, now);
+    payload.publishedAt = published && isPublishedNow ? postForm.publishedAt || now.toISOString() : postForm.publishedAt;
+
     try {
-      if (!postForm.slug) {
-        postForm.slug = BlogService.generateSlug(postForm.title);
-      }
-      
       if (editingPost?.id) {
-        await BlogService.updatePost(editingPost.id, postForm);
+        await BlogService.updatePost(editingPost.id, payload);
       } else {
-        await BlogService.createPost({
-          ...postForm,
-          published: true,
-          featuredPost: false
-        } as BlogPost);
+        await BlogService.createPost(payload);
       }
       
       await loadBlogPosts();
@@ -435,20 +459,31 @@ const AdminDashboard: React.FC = () => {
   
   const getFilteredBlogPosts = () => {
     return blogPosts.filter(post => {
-      const matchStatus = 
+      const now = new Date();
+      const isPublished = BlogService.isPostPublished(post, now);
+      const isScheduled = BlogService.isPostScheduled(post, now);
+      const matchStatus =
         filtroStatusBlog === 'todos' ||
-        (filtroStatusBlog === 'published' && post.published && !post.featuredPost) ||
+        (filtroStatusBlog === 'published' && isPublished && !post.featuredPost) ||
+        (filtroStatusBlog === 'scheduled' && isScheduled) ||
         (filtroStatusBlog === 'draft' && !post.published) ||
-        (filtroStatusBlog === 'featured' && post.featuredPost && post.published) ||
-        (filtroStatusBlog === 'featured_draft' && post.featuredPost && !post.published);
+        (filtroStatusBlog === 'featured' && post.featuredPost && isPublished) ||
+        (filtroStatusBlog === 'featured_scheduled' && post.featuredPost && isScheduled);
       
       const matchTitle = !filtroTituloBlog || 
         post.title.toLowerCase().includes(filtroTituloBlog.toLowerCase()) ||
         post.description.toLowerCase().includes(filtroTituloBlog.toLowerCase());
-      
+
       return matchStatus && matchTitle;
     });
   };
+
+  const now = new Date();
+  const publishedBlogPosts = blogPosts.filter(post => BlogService.isPostPublished(post, now));
+  const scheduledBlogPosts = blogPosts.filter(post => BlogService.isPostScheduled(post, now));
+  const draftBlogPosts = blogPosts.filter(post => !post.published);
+  const featuredPublishedPosts = blogPosts.filter(post => post.featuredPost && BlogService.isPostPublished(post, now));
+  const featuredScheduledPosts = blogPosts.filter(post => post.featuredPost && BlogService.isPostScheduled(post, now));
   
   const exportParceirosToCsv = () => {
     const filteredData = getFilteredParceiros();
@@ -963,13 +998,17 @@ const AdminDashboard: React.FC = () => {
               <h2 className="text-2xl font-bold text-gray-900">Gerenciar Blog</h2>
               <p className="text-gray-600">Criar, editar e gerenciar posts do blog</p>
             </div>
-            <Button 
-              onClick={() => {
-                setEditingPost(null);
-                setPostForm({});
-                setShowPostEditor(true);
-              }}
-              className="bg-libra-blue hover:bg-libra-blue/90 text-white"
+              <Button
+                onClick={() => {
+                  setEditingPost(null);
+                  setPostForm({
+                    published: true,
+                    featuredPost: false,
+                    scheduledAt: new Date().toISOString()
+                  });
+                  setShowPostEditor(true);
+                }}
+                className="bg-libra-blue hover:bg-libra-blue/90 text-white"
             >
               <Plus className="w-4 h-4 mr-2" />
               Novo Post
@@ -1065,9 +1104,24 @@ const AdminDashboard: React.FC = () => {
                     </p>
                   </div>
                   <div className="space-y-3">
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Data e hora de publicação</label>
+                      <Input
+                        type="datetime-local"
+                        min={formatDateTimeLocal(new Date().toISOString())}
+                        value={formatDateTimeLocal(postForm.scheduledAt)}
+                        onChange={(e) => setPostForm({
+                          ...postForm,
+                          scheduledAt: e.target.value ? new Date(e.target.value).toISOString() : undefined
+                        })}
+                      />
+                      <p className="text-xs text-gray-500 mt-1">
+                        Defina quando o post deve ser publicado. Datas passadas não são permitidas para novos agendamentos.
+                      </p>
+                    </div>
                     <div className="flex items-center space-x-2">
-                      <input 
-                        type="checkbox" 
+                      <input
+                        type="checkbox"
                         id="published"
                         checked={postForm.published || false}
                         onChange={(e) => setPostForm({...postForm, published: e.target.checked})}
@@ -1308,8 +1362,10 @@ Escreva seu conteúdo aqui...
                     <SelectContent>
                       <SelectItem value="todos">Todos</SelectItem>
                       <SelectItem value="published">Publicados</SelectItem>
+                      <SelectItem value="scheduled">Agendados</SelectItem>
                       <SelectItem value="draft">Rascunhos</SelectItem>
                       <SelectItem value="featured">Em Destaque</SelectItem>
+                      <SelectItem value="featured_scheduled">Destaques Agendados</SelectItem>
                     </SelectContent>
                   </Select>
                   
@@ -1331,90 +1387,109 @@ Escreva seu conteúdo aqui...
                     </div>
                   </div>
                 ) : getFilteredBlogPosts().length > 0 ? (
-                  getFilteredBlogPosts().map((post) => (
-                    <div key={post.id} className="border rounded-lg p-4 hover:shadow-md transition-shadow">
-                      <div className="flex items-start justify-between">
-                        <div className="flex items-start gap-4 flex-1">
-                          <img
-                            src={post.imageUrl}
-                            alt={post.title}
-                            className="w-20 h-20 object-cover rounded-lg border"
-                            width={80}
-                            height={80}
-                            onError={(e) => {
-                              (e.target as HTMLImageElement).src = 'https://placehold.co/80x80?text=Image';
-                            }}
-                          />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-start justify-between gap-4">
-                              <div className="flex-1">
-                                <h3 className="font-semibold text-lg text-gray-900 truncate">
-                                  {post.title}
-                                </h3>
-                                <p className="text-sm text-gray-600 mt-1 line-clamp-2">
-                                  {post.description}
-                                </p>
-                                <div className="flex items-center gap-4 mt-2">
-                                  <span className="text-xs px-2 py-1 bg-gray-100 rounded-full">
-                                    {post.category}
-                                  </span>
-                                  <span className="text-xs text-gray-500">
-                                    📖 {post.readTime} min
-                                  </span>
-                                  <span className="text-xs text-gray-500">
-                                    🕒 {post.createdAt ? new Date(post.createdAt).toLocaleDateString('pt-BR') : 'Data não informada'}
-                                  </span>
-                                </div>
-                                <div className="flex items-center gap-2 mt-2">
-                                  <Badge 
-                                    variant={post.published ? "default" : "secondary"}
-                                    className="text-xs"
-                                  >
-                                    {post.published ? '✅ Publicado' : '📝 Rascunho'}
-                                  </Badge>
-                                  {post.featuredPost && (
-                                    <Badge variant="outline" className="text-xs">
-                                      ⭐ Destaque
+                  getFilteredBlogPosts().map((post) => {
+                    const isScheduled = BlogService.isPostScheduled(post, now);
+                    const isPublishedPost = BlogService.isPostPublished(post, now);
+                    const scheduledDate = BlogService.getScheduledDate(post);
+
+                    return (
+                      <div key={post.id} className="border rounded-lg p-4 hover:shadow-md transition-shadow">
+                        <div className="flex items-start justify-between">
+                          <div className="flex items-start gap-4 flex-1">
+                            <img
+                              src={post.imageUrl}
+                              alt={post.title}
+                              className="w-20 h-20 object-cover rounded-lg border"
+                              width={80}
+                              height={80}
+                              onError={(e) => {
+                                (e.target as HTMLImageElement).src = 'https://placehold.co/80x80?text=Image';
+                              }}
+                            />
+                            <div className="flex-1 min-w-0">
+                              <div className="flex items-start justify-between gap-4">
+                                <div className="flex-1">
+                                  <h3 className="font-semibold text-lg text-gray-900 truncate">
+                                    {post.title}
+                                  </h3>
+                                  <p className="text-sm text-gray-600 mt-1 line-clamp-2">
+                                    {post.description}
+                                  </p>
+                                  <div className="flex items-center gap-4 mt-2 flex-wrap">
+                                    <span className="text-xs px-2 py-1 bg-gray-100 rounded-full">
+                                      {post.category}
+                                    </span>
+                                    <span className="text-xs text-gray-500">
+                                      📖 {post.readTime} min
+                                    </span>
+                                    <span className="text-xs text-gray-500">
+                                      🕒 {post.createdAt ? new Date(post.createdAt).toLocaleDateString('pt-BR') : 'Data não informada'}
+                                    </span>
+                                    {isScheduled && (
+                                      <span className="text-xs text-blue-600">
+                                        Agendado para {scheduledDate.toLocaleString('pt-BR')}
+                                      </span>
+                                    )}
+                                  </div>
+                                  <div className="flex items-center gap-2 mt-2 flex-wrap">
+                                    <Badge
+                                      variant={isPublishedPost ? "default" : isScheduled ? "outline" : "secondary"}
+                                      className="text-xs"
+                                    >
+                                      {isPublishedPost ? '✅ Publicado' : isScheduled ? '⏳ Agendado' : '📝 Rascunho'}
                                     </Badge>
-                                  )}
+                                    {isPublishedPost && post.publishedAt && (
+                                      <Badge variant="outline" className="text-xs">
+                                        Publicado em {new Date(post.publishedAt).toLocaleDateString('pt-BR')}
+                                      </Badge>
+                                    )}
+                                    {post.featuredPost && (
+                                      <Badge variant="outline" className="text-xs">
+                                        ⭐ Destaque
+                                      </Badge>
+                                    )}
+                                  </div>
                                 </div>
                               </div>
                             </div>
                           </div>
-                        </div>
-                        <div className="flex flex-col gap-1 ml-4">
-                          <Button 
-                            variant="outline" 
-                            size="sm"
-                            onClick={() => {
-                              setEditingPost(post);
-                              setPostForm(post);
-                              setShowPostEditor(true);
-                            }}
-                          >
-                            <Edit className="w-4 h-4 mr-1" />
-                            Editar
-                          </Button>
-                          <Button 
-                            variant="outline" 
-                            size="sm"
-                            onClick={() => window.open('/blog/' + post.slug, '_blank')}
-                          >
-                            <Eye className="w-4 h-4 mr-1" />
-                            Ver
-                          </Button>
-                          <Button 
-                            variant="destructive" 
-                            size="sm"
-                            onClick={() => handleDeletePost(post.id!)}
-                          >
-                            <Trash2 className="w-4 h-4 mr-1" />
-                            Excluir
-                          </Button>
+                          <div className="flex flex-col gap-1 ml-4">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => {
+                                setEditingPost(post);
+                                setPostForm({
+                                  ...post,
+                                  scheduledAt: post.scheduledAt || post.createdAt || new Date().toISOString()
+                                });
+                                setShowPostEditor(true);
+                              }}
+                            >
+                              <Edit className="w-4 h-4 mr-1" />
+                              Editar
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => window.open('/blog/' + post.slug, '_blank')}
+                            >
+                              <Eye className="w-4 h-4 mr-1" />
+                              Ver
+                            </Button>
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => handleDeletePost(post.id!)}
+                            >
+                              <Trash2 className="w-4 h-4 mr-1" />
+                              Excluir
+                            </Button>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  ))
+                    );
+                  })
                 ) : (
                   <div className="text-center py-12">
                     <div className="text-gray-400 mb-4">
@@ -1429,10 +1504,14 @@ Escreva seu conteúdo aqui...
                         : 'Tente ajustar os filtros ou crie um novo post.'
                       }
                     </p>
-                    <Button 
+                    <Button
                       onClick={() => {
                         setEditingPost(null);
-                        setPostForm({});
+                        setPostForm({
+                          published: true,
+                          featuredPost: false,
+                          scheduledAt: new Date().toISOString()
+                        });
                         setShowPostEditor(true);
                       }}
                       className="bg-libra-blue hover:bg-libra-blue/90 text-white"
@@ -1445,7 +1524,7 @@ Escreva seu conteúdo aqui...
 
                 {getFilteredBlogPosts().length > 0 && (
                   <div className="mt-8 pt-4 border-t">
-                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
                       <div className="text-center">
                         <div className="text-2xl font-bold text-gray-900">
                           {blogPosts.length}
@@ -1454,21 +1533,33 @@ Escreva seu conteúdo aqui...
                       </div>
                       <div className="text-center">
                         <div className="text-2xl font-bold text-green-600">
-                          {blogPosts.filter(p => p.published).length}
+                          {publishedBlogPosts.length}
                         </div>
-                        <div className="text-sm text-gray-500">Publicados</div>
+                        <div className="text-sm text-gray-500">Publicados (ativos)</div>
+                      </div>
+                      <div className="text-center">
+                        <div className="text-2xl font-bold text-blue-600">
+                          {scheduledBlogPosts.length}
+                        </div>
+                        <div className="text-sm text-gray-500">Agendados</div>
                       </div>
                       <div className="text-center">
                         <div className="text-2xl font-bold text-yellow-600">
-                          {blogPosts.filter(p => !p.published).length}
+                          {draftBlogPosts.length}
                         </div>
                         <div className="text-sm text-gray-500">Rascunhos</div>
                       </div>
                       <div className="text-center">
-                        <div className="text-2xl font-bold text-blue-600">
-                          {blogPosts.filter(p => p.featuredPost).length}
+                        <div className="text-2xl font-bold text-purple-600">
+                          {featuredPublishedPosts.length}
                         </div>
-                        <div className="text-sm text-gray-500">Em Destaque</div>
+                        <div className="text-sm text-gray-500">Destaques Publicados</div>
+                      </div>
+                      <div className="text-center">
+                        <div className="text-2xl font-bold text-indigo-600">
+                          {featuredScheduledPosts.length}
+                        </div>
+                        <div className="text-sm text-gray-500">Destaques Agendados</div>
                       </div>
                     </div>
                   </div>

--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -39,7 +39,10 @@ const Confirmacao = () => {
     }
 
     const scrollToTop = () => {
-      topAnchorRef.current?.scrollIntoView({ behavior: 'auto', block: 'start' });
+      const anchor = topAnchorRef.current;
+      if (anchor && typeof anchor.scrollIntoView === 'function') {
+        anchor.scrollIntoView({ behavior: 'auto', block: 'start' });
+      }
     };
 
     // Reforça o reset de scroll em diferentes ciclos de renderização

--- a/src/services/__tests__/blogService.test.ts
+++ b/src/services/__tests__/blogService.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { BlogService, type BlogPost } from '../blogService';
+import { type BlogPostData } from '@/lib/supabase';
+
+describe('BlogService scheduling logic', () => {
+  const basePost: Omit<BlogPost, 'id'> = {
+    title: 'Post base',
+    description: 'Descrição',
+    category: 'home-equity',
+    imageUrl: 'https://example.com/image.jpg',
+    slug: 'post-base',
+    content: 'conteúdo',
+    readTime: 5,
+    published: true,
+    featuredPost: false,
+    scheduledAt: '2023-12-31T10:00:00.000Z',
+    createdAt: '2023-12-01T10:00:00.000Z'
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('filters scheduled posts until their scheduled date', async () => {
+    const posts: BlogPost[] = [
+      { ...basePost, id: '1', title: 'Publicado', slug: 'publicado', publishedAt: '2023-12-31T10:00:00.000Z' },
+      { ...basePost, id: '2', title: 'Agendado', slug: 'agendado', scheduledAt: '2024-02-01T10:00:00.000Z' },
+      { ...basePost, id: '3', title: 'Rascunho', slug: 'rascunho', published: false }
+    ];
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T12:00:00.000Z'));
+    vi.spyOn(BlogService, 'getAllPosts').mockResolvedValue(posts);
+
+    const published = await BlogService.getPublishedPosts();
+    const featured = await BlogService.getFeaturedPosts();
+
+    expect(published.map((p) => p.id)).toEqual(['1']);
+    expect(featured).toHaveLength(0);
+  });
+
+  it('converts supabase payloads with scheduling metadata', () => {
+    const supabasePost: BlogPostData = {
+      id: '10',
+      title: 'Agendado',
+      description: 'Com datas',
+      category: 'home-equity',
+      content: 'conteúdo',
+      image_url: 'https://example.com/img.png',
+      slug: 'agendado',
+      read_time: 8,
+      published: true,
+      featured_post: false,
+      scheduled_at: '2024-05-01T10:00:00.000Z',
+      published_at: '2024-05-02T10:00:00.000Z',
+      meta_title: 'Meta',
+      meta_description: 'Meta desc',
+      tags: ['tag'],
+      created_at: '2024-04-01T10:00:00.000Z',
+      updated_at: '2024-04-02T10:00:00.000Z'
+    };
+
+    const post = BlogService.convertSupabaseToBlogPost(supabasePost);
+
+    expect(post.scheduledAt).toBe(supabasePost.scheduled_at);
+    expect(post.publishedAt).toBe(supabasePost.published_at || undefined);
+  });
+
+  it('prepares supabase payload for scheduled posts without premature publication', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+
+    const scheduledDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    const post: BlogPost = {
+      ...basePost,
+      id: '11',
+      slug: 'futuro',
+      scheduledAt: scheduledDate,
+      publishedAt: undefined
+    };
+
+    const payload = BlogService.convertBlogPostToSupabase(post);
+
+    expect(payload.scheduled_at).toBe(scheduledDate);
+    expect(payload.published_at).toBeNull();
+    expect(payload.published).toBe(true);
+  });
+});

--- a/src/services/blogService.ts
+++ b/src/services/blogService.ts
@@ -18,6 +18,8 @@ export interface BlogPost {
   readTime: number;
   published: boolean;
   featuredPost: boolean;
+  scheduledAt?: string;
+  publishedAt?: string;
   metaTitle?: string;
   metaDescription?: string;
   tags?: string[];
@@ -162,6 +164,8 @@ const EXISTING_POSTS: BlogPost[] = [
     readTime: 8,
     published: true,
     featuredPost: true,
+    scheduledAt: '2024-03-25T00:00:00.000Z',
+    publishedAt: '2024-03-25T00:00:00.000Z',
     createdAt: '2024-03-25T00:00:00.000Z',
     updatedAt: '2024-03-25T00:00:00.000Z'
   },
@@ -216,6 +220,8 @@ const EXISTING_POSTS: BlogPost[] = [
     readTime: 12,
     published: true,
     featuredPost: false,
+    scheduledAt: '2024-03-24T00:00:00.000Z',
+    publishedAt: '2024-03-24T00:00:00.000Z',
     createdAt: '2024-03-24T00:00:00.000Z',
     updatedAt: '2024-03-24T00:00:00.000Z'
   },
@@ -257,6 +263,8 @@ const EXISTING_POSTS: BlogPost[] = [
     readTime: 10,
     published: true,
     featuredPost: false,
+    scheduledAt: '2024-03-23T00:00:00.000Z',
+    publishedAt: '2024-03-23T00:00:00.000Z',
     createdAt: '2024-03-23T00:00:00.000Z',
     updatedAt: '2024-03-23T00:00:00.000Z'
   },
@@ -280,6 +288,8 @@ const EXISTING_POSTS: BlogPost[] = [
     readTime: 5,
     published: true,
     featuredPost: false,
+    scheduledAt: '2024-03-22T00:00:00.000Z',
+    publishedAt: '2024-03-22T00:00:00.000Z',
     createdAt: '2024-03-22T00:00:00.000Z',
     updatedAt: '2024-03-22T00:00:00.000Z'
   },
@@ -300,6 +310,8 @@ const EXISTING_POSTS: BlogPost[] = [
     readTime: 8,
     published: true,
     featuredPost: false,
+    scheduledAt: '2024-03-21T00:00:00.000Z',
+    publishedAt: '2024-03-21T00:00:00.000Z',
     createdAt: '2024-03-21T00:00:00.000Z',
     updatedAt: '2024-03-21T00:00:00.000Z'
   },
@@ -423,6 +435,8 @@ const EXISTING_POSTS: BlogPost[] = [
     readTime: 15,
     published: true,
     featuredPost: true,
+    scheduledAt: '2024-04-22T00:00:00.000Z',
+    publishedAt: '2024-04-22T00:00:00.000Z',
     createdAt: '2024-04-22T00:00:00.000Z',
     updatedAt: '2024-04-22T00:00:00.000Z'
   }
@@ -470,6 +484,8 @@ export class BlogService {
       readTime: supabasePost.read_time || 5,
       published: supabasePost.published,
       featuredPost: supabasePost.featured_post,
+      scheduledAt: supabasePost.scheduled_at || supabasePost.published_at || supabasePost.created_at,
+      publishedAt: supabasePost.published_at || undefined,
       metaTitle: supabasePost.meta_title,
       metaDescription: supabasePost.meta_description,
       tags: supabasePost.tags,
@@ -482,6 +498,9 @@ export class BlogService {
    * Converter BlogPost para formato Supabase
    */
   static convertBlogPostToSupabase(post: BlogPost): Omit<BlogPostData, 'id' | 'created_at' | 'updated_at'> {
+    const scheduledAt = post.scheduledAt || post.createdAt || new Date().toISOString();
+    const shouldMarkPublished = post.published && new Date(scheduledAt).getTime() <= Date.now();
+
     return {
       title: post.title,
       description: post.description,
@@ -490,12 +509,26 @@ export class BlogService {
       image_url: post.imageUrl,
       slug: post.slug,
       read_time: post.readTime,
-      published: post.published,
-      featured_post: post.featuredPost,
+      published: post.published ?? false,
+      featured_post: post.featuredPost ?? false,
+      scheduled_at: scheduledAt,
+      published_at: shouldMarkPublished ? post.publishedAt || scheduledAt : post.publishedAt || null,
       meta_title: post.metaTitle,
       meta_description: post.metaDescription,
       tags: post.tags
     };
+  }
+
+  static getScheduledDate(post: BlogPost): Date {
+    return new Date(post.scheduledAt || post.createdAt || new Date().toISOString());
+  }
+
+  static isPostPublished(post: BlogPost, referenceDate: Date = new Date()): boolean {
+    return post.published && this.getScheduledDate(post).getTime() <= referenceDate.getTime();
+  }
+
+  static isPostScheduled(post: BlogPost, referenceDate: Date = new Date()): boolean {
+    return post.published && this.getScheduledDate(post).getTime() > referenceDate.getTime();
   }
 
   /**
@@ -776,6 +809,8 @@ export class BlogService {
         id: `local-${Date.now()}`,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
+        scheduledAt: postData.scheduledAt || new Date().toISOString(),
+        publishedAt: postData.published ? postData.publishedAt || new Date().toISOString() : undefined,
         readTime: postData.readTime || this.calculateReadTime(postData.content)
       };
 
@@ -893,7 +928,7 @@ export class BlogService {
    */
   static async getPostsByCategory(category: BlogCategory): Promise<BlogPost[]> {
     const posts = await this.getAllPosts();
-    return posts.filter(post => post.category === category && post.published);
+    return posts.filter(post => post.category === category && this.isPostPublished(post));
   }
 
   /**
@@ -901,9 +936,9 @@ export class BlogService {
    */
   static async getPublishedPosts(): Promise<BlogPost[]> {
     const posts = await this.getAllPosts();
-    return posts.filter(post => post.published).sort((a, b) => 
-      new Date(b.createdAt || '').getTime() - new Date(a.createdAt || '').getTime()
-    );
+    return posts
+      .filter(post => this.isPostPublished(post))
+      .sort((a, b) => this.getScheduledDate(b).getTime() - this.getScheduledDate(a).getTime());
   }
 
   /**
@@ -911,7 +946,7 @@ export class BlogService {
    */
   static async getFeaturedPosts(): Promise<BlogPost[]> {
     const posts = await this.getAllPosts();
-    return posts.filter(post => post.published && post.featuredPost);
+    return posts.filter(post => this.isPostPublished(post) && post.featuredPost);
   }
 
   /**
@@ -1007,9 +1042,10 @@ export class BlogService {
    */
   static async getBlogStats() {
     const posts = await this.getAllPosts();
-    const published = posts.filter(p => p.published);
+    const published = posts.filter(p => this.isPostPublished(p));
+    const scheduled = posts.filter(p => this.isPostScheduled(p));
     const drafts = posts.filter(p => !p.published);
-    const featured = posts.filter(p => p.featuredPost && p.published);
+    const featured = posts.filter(p => p.featuredPost && this.isPostPublished(p));
     
     const categoryCounts = BLOG_CATEGORIES.map(cat => ({
       category: cat.name,
@@ -1019,6 +1055,7 @@ export class BlogService {
     return {
       total: posts.length,
       published: published.length,
+      scheduled: scheduled.length,
       drafts: drafts.length,
       featured: featured.length,
       categoryCounts


### PR DESCRIPTION
## Summary
- add scheduling metadata to the Supabase blog schema and conversions
- update admin blog management to schedule publications and show scheduled vs. published status/counts
- add unit tests covering scheduled post visibility and conversion handling

## Testing
- npm test *(fails: `OptimizedYouTube > calls player methods on click` expectation unrelated to these changes)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bf9e1f6ec832dbd2230eff9091244)