### PR TITLE
Increase testimonial carousel auto-advance interval to 15 seconds

### DIFF
--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -127,7 +127,7 @@ const Testimonials: React.FC = () => {
   useEffect(() => {
     const interval = setInterval(() => {
       setCurrentTestimonial((prev) => (prev + 1) % testimonials.length);
-    }, 5000); // Troca a cada 5 segundos
+    }, 15000); // Troca a cada 15 segundos
     
     return () => clearInterval(interval);
   }, []);


### PR DESCRIPTION
### Motivation
- Increase the visibility/readability of testimonials by slowing the auto-advance interval from 5 seconds to 15 seconds.

### Description
- Change the carousel auto-advance interval in `src/components/Testimonials.tsx` from `5000` to `15000` and update the inline comment to reflect the new 15 second timing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e601cf88832da189b0af8f92a16f)