### PR TITLE
Add WhatsApp CTA and extend auto-redirect to 30s on success page

### DIFF
--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import MobileLayout from '@/components/MobileLayout';
 import { Button } from '@/components/ui/button';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 
 const Confirmacao = () => {
   const topAnchorRef = useRef<HTMLDivElement | null>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     // Runs once on mount to update page metadata
@@ -17,7 +18,15 @@ const Confirmacao = () => {
         'Confirmação de envio da simulação. Em breve nossa equipe entrará em contato.'
       );
     }
-  }, []);
+
+    const timer = window.setTimeout(() => {
+      navigate('/quem-somos');
+    }, 30000);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [navigate]);
 
   useLayoutEffect(() => {
     const scrollingElement = document.scrollingElement || document.documentElement;
@@ -74,9 +83,22 @@ const Confirmacao = () => {
           Enquanto isso, aproveite para conhecer mais sobre a Libra e nossas soluções clicando
           no botão abaixo.
         </p>
+        <p className="text-sm text-gray-600">Você será redirecionado automaticamente em até 30 segundos.</p>
         <div className="flex flex-col sm:flex-row gap-4 mt-4">
           <Button asChild variant="default" className="px-6">
             <Link to="/quem-somos">Conheça a Libra</Link>
+          </Button>
+          <Button
+            asChild
+            className="px-6 bg-green-600 text-white hover:bg-green-700 focus-visible:ring-green-600"
+          >
+            <a
+              href="https://wa.me/5516997879837?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Iniciar atendimento no WhatsApp
+            </a>
           </Button>
         </div>
       </div>

--- a/src/pages/Sucesso.tsx
+++ b/src/pages/Sucesso.tsx
@@ -18,7 +18,7 @@ const Sucesso = () => {
 
     const timer = setTimeout(() => {
       navigate('/quem-somos');
-    }, 5000);
+    }, 30000);
 
     return () => clearTimeout(timer);
   }, [navigate]);
@@ -29,7 +29,15 @@ const Sucesso = () => {
         <h1 className="text-2xl font-bold text-libra-navy">🎉 Muito obrigado!</h1>
         <p className="text-base text-gray-700">Recebemos sua solicitação e nossos consultores entrarão em contato em breve.</p>
         <p className="text-base text-gray-700">Fique atento aos telefones (16) 3600-7956 ou (16) 99636-0424.</p>
-        <p className="text-sm text-gray-600 mt-4">Você será redirecionado em instantes...</p>
+        <a
+          className="inline-flex items-center justify-center gap-2 rounded-full bg-green-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
+          href="https://wa.me/5516997879837?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Iniciar atendimento no WhatsApp
+        </a>
+        <p className="text-sm text-gray-600 mt-4">Você será redirecionado automaticamente em até 30 segundos...</p>
       </div>
     </MobileLayout>
   );


### PR DESCRIPTION
### Motivation
- Allow users to start atendimento via WhatsApp directly from the success/thank-you page and make the redirect timing consistent with the new CTA.

### Description
- Added a styled WhatsApp CTA button that links to the provided `wa.me` URL and opens in a new tab.
- Increased the automatic redirect timeout from `5000` ms to `30000` ms and updated the on-page messaging to indicate a 30 second redirect.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite reported the app as ready (local and network URLs), which succeeded.
- Ran a Playwright script to visit `http://127.0.0.1:4173/sucesso` and captured a screenshot at `artifacts/sucesso-whatsapp.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69820679bf8c832daf44acc9dd7da756)