### PR TITLE
Fix blog content rendering when stored as escaped HTML

### DIFF
--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -4,8 +4,18 @@ import DOMPurify from 'dompurify';
 export const renderMarkdown = (content: string): string => {
   if (!content) return '';
 
+  const decodeHtml = (value: string): string => {
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = value;
+    return textarea.value;
+  };
+
+  const maybeDecoded = decodeHtml(content);
+  const shouldUseDecoded = maybeDecoded !== content && /<\/?[a-z][\s\S]*>/i.test(maybeDecoded);
+  const normalizedContent = shouldUseDecoded ? maybeDecoded : content;
+
   // Parse markdown to HTML and sanitize
-  const parsed = marked.parse(content);
+  const parsed = marked.parse(normalizedContent);
   const sanitized = DOMPurify.sanitize(parsed);
 
   // Inject Tailwind classes into allowed elements


### PR DESCRIPTION
### Motivation
- Posts that arrive with escaped HTML (e.g. `&lt;h2&gt;`) were rendering the tags literally instead of as formatted HTML, breaking blog content display.

### Description
- Add a `decodeHtml` helper to `src/utils/markdown.ts` that decodes HTML entities using a `textarea` element. 
- Detect when decoded content contains HTML tags and normalize the input to the decoded value before parsing. 
- Use the normalized content with `marked.parse(...)` and keep the existing `DOMPurify.sanitize(...)` and Tailwind class injection intact.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and it came up successfully. 
- Ran a Playwright script that opened `http://127.0.0.1:4173/blog/capital-de-giro-agronegocio-fazenda-garantia` and produced a screenshot at `artifacts/blog-post.png`, which completed successfully. 
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d2c85d44832d9db56c8f178c7590)