### PR TITLE
Corrige decodificação de entidades HTML no renderizador de Markdown do blog

### DIFF
--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -4,8 +4,11 @@ import DOMPurify from 'dompurify';
 export const renderMarkdown = (content: string): string => {
   if (!content) return '';
 
+  const hasEncodedTags = /&lt;\/?[a-z][\s\S]*&gt;/i.test(content);
+  const normalizedContent = hasEncodedTags ? decodeHtmlEntities(content) : content;
+
   // Parse markdown to HTML and sanitize
-  const parsed = marked.parse(content);
+  const parsed = marked.parse(normalizedContent);
   const sanitized = DOMPurify.sanitize(parsed);
 
   // Inject Tailwind classes into allowed elements
@@ -32,6 +35,12 @@ export const renderMarkdown = (content: string): string => {
   addClass('li', 'mb-2 text-gray-700');
 
   return div.innerHTML;
+};
+
+const decodeHtmlEntities = (value: string): string => {
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = value;
+  return textarea.value;
 };
 
 export default renderMarkdown;


### PR DESCRIPTION
### Motivation
- Corrigir problema onde posts do blog chegavam com tags HTML escapadas (ex.: `&lt;h2&gt;`) e apareciam como texto bruto em vez de serem renderizados corretamente.

### Description
- Em `src/utils/markdown.ts` detecta conteúdo com tags HTML codificadas, decodifica as entidades com a nova função `decodeHtmlEntities`, e então passa o conteúdo normalizado para `marked.parse` antes da sanitização com `DOMPurify`.

### Testing
- Nenhum teste automatizado foi executado como parte desta alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d2c85d44832d9db56c8f178c7590)