### PR TITLE
Fix blog sync for non-UUID local posts

### DIFF
--- a/src/components/SupabaseDiagnostics.tsx
+++ b/src/components/SupabaseDiagnostics.tsx
@@ -21,6 +21,11 @@ const formatErrorMessage = (error: unknown): string => {
   }
 };
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const isValidUuid = (value?: string) => Boolean(value && UUID_REGEX.test(value));
+
 const SupabaseDiagnostics: React.FC = () => {
   const [results, setResults] = useState<DiagnosticResult[]>([]);
   const [isRunning, setIsRunning] = useState(false);
@@ -199,7 +204,9 @@ const SupabaseDiagnostics: React.FC = () => {
           setSyncStatus(`Sincronizando: ${post.title}`);
           
           // Verificar se já existe no Supabase
-          const existing = await supabaseApi.getBlogPostById(post.id).catch(() => null);
+          const existing = isValidUuid(post.id)
+            ? await supabaseApi.getBlogPostById(post.id).catch(() => null)
+            : await supabaseApi.getBlogPostBySlug(post.slug).catch(() => null);
           
           if (!existing) {
             // Criar no Supabase

--- a/src/services/blogService.ts
+++ b/src/services/blogService.ts
@@ -445,6 +445,8 @@ const EXISTING_POSTS: BlogPost[] = [
 export class BlogService {
   private static readonly STORAGE_KEY = 'libra_blog_posts';
   private static readonly CONFIG_KEY = 'libra_simulation_config';
+  private static readonly UUID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
   /**
    * Gerar slug a partir do título
@@ -529,6 +531,10 @@ export class BlogService {
 
   static isPostScheduled(post: BlogPost, referenceDate: Date = new Date()): boolean {
     return post.published && this.getScheduledDate(post).getTime() > referenceDate.getTime();
+  }
+
+  private static isValidUuid(value?: string): boolean {
+    return Boolean(value && this.UUID_REGEX.test(value));
   }
 
   /**
@@ -709,7 +715,9 @@ export class BlogService {
       for (const post of localPosts) {
         try {
           // Verificar se post já existe no Supabase
-          const existing = await supabaseApi.getBlogPostById(post.id!).catch(() => null);
+          const existing = this.isValidUuid(post.id)
+            ? await supabaseApi.getBlogPostById(post.id!).catch(() => null)
+            : await supabaseApi.getBlogPostBySlug(post.slug).catch(() => null);
           
           if (!existing) {
             // Criar no Supabase


### PR DESCRIPTION
### Motivation
- Local blog posts stored with non-UUID IDs (for example `local-<timestamp>`) caused Supabase lookup-by-id calls to fail during synchronization and diagnostics, preventing proper sync of local posts to Supabase.

### Description
- Added a UUID regex and `isValidUuid` helper to `src/services/blogService.ts` and to `src/components/SupabaseDiagnostics.tsx` to detect whether a stored `id` is a valid UUID.
- Updated `BlogService.syncLocalToSupabase` to use `getBlogPostById` when `id` is a valid UUID and fall back to `getBlogPostBySlug` when it is not, avoiding invalid ID queries and enabling sync of locally-created posts.
- Applied the same ID validation + slug fallback in the diagnostics sync routine in `SupabaseDiagnostics` so the diagnostics tool no longer fails when local posts use non-UUID IDs.
- Kept existing logging and error handling to report synced posts and any sync errors.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f9cc8410832d96e92a7a543a4773)