### PR TITLE
feat: detect SECURITY DEFINER views in Supabase diagnostics and SQL scripts

### DIFF
--- a/database/sql/supabase-migration-complete.sql
+++ b/database/sql/supabase-migration-complete.sql
@@ -398,6 +398,31 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION public.get_security_definer_views()
+RETURNS TABLE (
+    view_schema TEXT,
+    view_name TEXT,
+    reloptions TEXT[]
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+    SELECT 
+        n.nspname as view_schema,
+        c.relname as view_name,
+        c.reloptions
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'v'
+    AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND EXISTS (
+        SELECT 1
+        FROM unnest(COALESCE(c.reloptions, ARRAY[]::TEXT[])) option_value
+        WHERE option_value ILIKE 'security_definer=%'
+    );
+$$;
+
 -- =====================================================
 -- 16. VIEW PARA DASHBOARD COMPLETO (SEGURA)
 -- =====================================================

--- a/database/sql/supabase-security-fixes.sql
+++ b/database/sql/supabase-security-fixes.sql
@@ -303,7 +303,38 @@ END
 $$;
 
 -- =====================================================
--- 7. ADICIONAR COMENTÁRIOS DE SEGURANÇA
+-- 7. FUNÇÃO PARA DETECTAR VIEWS COM SECURITY DEFINER
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.get_security_definer_views()
+RETURNS TABLE (
+    view_schema TEXT,
+    view_name TEXT,
+    reloptions TEXT[]
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+    SELECT 
+        n.nspname as view_schema,
+        c.relname as view_name,
+        c.reloptions
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'v'
+    AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND EXISTS (
+        SELECT 1
+        FROM unnest(COALESCE(c.reloptions, ARRAY[]::TEXT[])) option_value
+        WHERE option_value ILIKE 'security_definer=%'
+    );
+$$;
+
+COMMENT ON FUNCTION public.get_security_definer_views() IS 'Lista views definidas com SECURITY DEFINER para diagnóstico de permissões';
+
+-- =====================================================
+-- 8. ADICIONAR COMENTÁRIOS DE SEGURANÇA
 -- =====================================================
 
 COMMENT ON FUNCTION public.update_updated_at_column() IS 'Função segura para atualizar timestamp com search_path fixo';
@@ -314,7 +345,7 @@ COMMENT ON FUNCTION public.cleanup_old_data() IS 'Função segura para limpeza d
 COMMENT ON TABLE public.data_cleanup_log IS 'Tabela de log de limpeza com RLS habilitado';
 
 -- =====================================================
--- 8. VERIFICAÇÃO FINAL DE SEGURANÇA
+-- 9. VERIFICAÇÃO FINAL DE SEGURANÇA
 -- =====================================================
 
 -- Verificar se RLS está habilitado em todas as tabelas públicas

--- a/database/sql/supabase-setup-complete.sql
+++ b/database/sql/supabase-setup-complete.sql
@@ -376,6 +376,31 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION public.get_security_definer_views()
+RETURNS TABLE (
+    view_schema TEXT,
+    view_name TEXT,
+    reloptions TEXT[]
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+    SELECT 
+        n.nspname as view_schema,
+        c.relname as view_name,
+        c.reloptions
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'v'
+    AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND EXISTS (
+        SELECT 1
+        FROM unnest(COALESCE(c.reloptions, ARRAY[]::TEXT[])) option_value
+        WHERE option_value ILIKE 'security_definer=%'
+    );
+$$;
+
 -- =====================================================
 -- 16. TABELA DE LOG DE LIMPEZA
 -- =====================================================

--- a/src/components/SupabaseDiagnostics.tsx
+++ b/src/components/SupabaseDiagnostics.tsx
@@ -73,7 +73,35 @@ const SupabaseDiagnostics: React.FC = () => {
         });
       }
 
-      // 3. Teste do Storage (bucket blog-images)
+      // 3. Verificar views com SECURITY DEFINER
+      setSyncStatus('Verificando views com SECURITY DEFINER...');
+      try {
+        const views = await supabaseApi.getSecurityDefinerViews();
+
+        if (views.length > 0) {
+          addResult({
+            test: 'Views com SECURITY DEFINER',
+            status: 'warning',
+            message: `⚠️ ${views.length} view(s) com SECURITY DEFINER detectadas`,
+            details: views
+          });
+        } else {
+          addResult({
+            test: 'Views com SECURITY DEFINER',
+            status: 'success',
+            message: '✅ Nenhuma view com SECURITY DEFINER encontrada'
+          });
+        }
+      } catch (error) {
+        addResult({
+          test: 'Views com SECURITY DEFINER',
+          status: 'warning',
+          message: `Aviso: ${formatErrorMessage(error)}`,
+          details: error
+        });
+      }
+
+      // 4. Teste do Storage (bucket blog-images)
       setSyncStatus('Verificando Supabase Storage...');
       try {
         const { data: buckets, error } = await supabase.storage.listBuckets();
@@ -127,7 +155,7 @@ const SupabaseDiagnostics: React.FC = () => {
         });
       }
 
-      // 4. Teste de criação de post
+      // 5. Teste de criação de post
       setSyncStatus('Testando criação de post...');
       try {
         const now = new Date().toISOString();
@@ -358,6 +386,9 @@ const SupabaseDiagnostics: React.FC = () => {
           <ul className="list-disc list-inside space-y-1">
             <li>Conexão básica com Supabase</li>
             <li>Acesso à tabela blog_posts</li>
+            <li>
+              Views com <code>SECURITY DEFINER</code> (permissões do criador e RLS)
+            </li>
             <li>Configuração do Storage bucket</li>
             <li>Permissões de CRUD</li>
             <li>Sincronização de dados locais</li>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -200,6 +200,12 @@ export interface BlogPostData {
   updated_at?: string;
 }
 
+export interface SecurityDefinerView {
+  view_schema: string;
+  view_name: string;
+  reloptions?: string[] | null;
+}
+
 // Schema do banco para TypeScript
 export interface Database {
   public: {
@@ -486,6 +492,13 @@ export const supabaseApi = {
     
     if (error) throw error;
     return data;
+  },
+
+  async getSecurityDefinerViews(): Promise<SecurityDefinerView[]> {
+    const { data, error } = await supabase.rpc('get_security_definer_views');
+
+    if (error) throw error;
+    return (data ?? []) as SecurityDefinerView[];
   },
 
   // Blog Posts


### PR DESCRIPTION
### Motivation
- Surface views created with `SECURITY DEFINER` so admins can see objects that run with the view creator's permissions (which affects RLS and permission modeling).
- Add a small, reusable SQL helper to list `SECURITY DEFINER` views so the diagnostics UI and security scripts can detect these cases automatically.

### Description
- Added a SQL helper function `public.get_security_definer_views()` to `database/sql/supabase-security-fixes.sql`, `database/sql/supabase-migration-complete.sql`, and `database/sql/supabase-setup-complete.sql` that returns views with `security_definer` reloptions.
- Exposed a typed API in the client with a new `SecurityDefinerView` interface and `supabaseApi.getSecurityDefinerViews()` in `src/lib/supabase.ts` to call the SQL helper.
- Updated the admin diagnostics UI in `src/components/SupabaseDiagnostics.tsx` to call `getSecurityDefinerViews()`, show a warning when views are found, and add the check to the diagnostics checklist.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server came up successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:4173/admin` and captured a screenshot of the Diagnostics card (`artifacts/supabase-diagnostics.png`), which completed successfully.
- No unit tests or CI jobs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698506a2febc832d8e1cc3052305655a)