### PR TITLE
Fix blog queries to match Supabase schema

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -191,8 +191,6 @@ export interface BlogPostData {
   read_time?: number;
   published: boolean;
   featured_post: boolean;
-  scheduled_at?: string | null;
-  published_at?: string | null;
   meta_title?: string;
   meta_description?: string;
   tags?: string[];
@@ -493,7 +491,7 @@ export const supabaseApi = {
     const { data, error } = await supabase
       .from('blog_posts')
       .select(
-        'id,title,description,category,image_url,slug,read_time,published,featured_post,scheduled_at,published_at,meta_title,meta_description,created_at,updated_at'
+        'id,title,description,category,image_url,slug,read_time,published,featured_post,meta_title,meta_description,created_at,updated_at'
       )
       .order('created_at', { ascending: false });
 
@@ -502,13 +500,10 @@ export const supabaseApi = {
   },
 
   async getPublishedBlogPosts() {
-    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('blog_posts')
       .select('*')
       .eq('published', true)
-      .or(`scheduled_at.lte.${now},scheduled_at.is.null`)
-      .order('scheduled_at', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
     
     if (error) throw error;
@@ -530,7 +525,7 @@ export const supabaseApi = {
     const { data, error } = await supabase
       .from('blog_posts')
       .select(
-        'id,title,description,category,content,image_url,slug,read_time,published,featured_post,scheduled_at,published_at,meta_title,meta_description,tags,created_at,updated_at'
+        'id,title,description,category,content,image_url,slug,read_time,published,featured_post,meta_title,meta_description,tags,created_at,updated_at'
       )
       .eq('slug', slug)
       .single();
@@ -573,14 +568,11 @@ export const supabaseApi = {
   },
 
   async getBlogPostsByCategory(category: string) {
-    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('blog_posts')
       .select('*')
       .eq('category', category)
       .eq('published', true)
-      .or(`scheduled_at.lte.${now},scheduled_at.is.null`)
-      .order('scheduled_at', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
     
     if (error) throw error;
@@ -588,14 +580,11 @@ export const supabaseApi = {
   },
 
   async getFeaturedBlogPosts() {
-    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('blog_posts')
       .select('*')
       .eq('featured_post', true)
       .eq('published', true)
-      .or(`scheduled_at.lte.${now},scheduled_at.is.null`)
-      .order('scheduled_at', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
     
     if (error) throw error;

--- a/src/services/__tests__/blogService.test.ts
+++ b/src/services/__tests__/blogService.test.ts
@@ -52,8 +52,6 @@ describe('BlogService scheduling logic', () => {
       read_time: 8,
       published: true,
       featured_post: false,
-      scheduled_at: '2024-05-01T10:00:00.000Z',
-      published_at: '2024-05-02T10:00:00.000Z',
       meta_title: 'Meta',
       meta_description: 'Meta desc',
       tags: ['tag'],
@@ -63,8 +61,8 @@ describe('BlogService scheduling logic', () => {
 
     const post = BlogService.convertSupabaseToBlogPost(supabasePost);
 
-    expect(post.scheduledAt).toBe(supabasePost.scheduled_at);
-    expect(post.publishedAt).toBe(supabasePost.published_at || undefined);
+    expect(post.scheduledAt).toBe(supabasePost.created_at);
+    expect(post.publishedAt).toBe(supabasePost.created_at);
   });
 
   it('prepares supabase payload for scheduled posts without premature publication', () => {
@@ -82,8 +80,6 @@ describe('BlogService scheduling logic', () => {
 
     const payload = BlogService.convertBlogPostToSupabase(post);
 
-    expect(payload.scheduled_at).toBe(scheduledDate);
-    expect(payload.published_at).toBeNull();
     expect(payload.published).toBe(true);
   });
 });

--- a/src/services/blogService.ts
+++ b/src/services/blogService.ts
@@ -484,8 +484,8 @@ export class BlogService {
       readTime: supabasePost.read_time || 5,
       published: supabasePost.published,
       featuredPost: supabasePost.featured_post,
-      scheduledAt: supabasePost.scheduled_at || supabasePost.published_at || supabasePost.created_at,
-      publishedAt: supabasePost.published_at || undefined,
+      scheduledAt: supabasePost.created_at,
+      publishedAt: supabasePost.published ? supabasePost.created_at : undefined,
       metaTitle: supabasePost.meta_title,
       metaDescription: supabasePost.meta_description,
       tags: supabasePost.tags,
@@ -498,9 +498,6 @@ export class BlogService {
    * Converter BlogPost para formato Supabase
    */
   static convertBlogPostToSupabase(post: BlogPost): Omit<BlogPostData, 'id' | 'created_at' | 'updated_at'> {
-    const scheduledAt = post.scheduledAt || post.createdAt || new Date().toISOString();
-    const shouldMarkPublished = post.published && new Date(scheduledAt).getTime() <= Date.now();
-
     return {
       title: post.title,
       description: post.description,
@@ -511,8 +508,6 @@ export class BlogService {
       read_time: post.readTime,
       published: post.published ?? false,
       featured_post: post.featuredPost ?? false,
-      scheduled_at: scheduledAt,
-      published_at: shouldMarkPublished ? post.publishedAt || scheduledAt : post.publishedAt || null,
       meta_title: post.metaTitle,
       meta_description: post.metaDescription,
       tags: post.tags


### PR DESCRIPTION
### Motivation
- O carregamento do blog estava falhando porque o código consultava/ordenava pelos campos `scheduled_at` e `published_at`, que não existem no esquema atual de `blog_posts`, causando erros nas queries ao Supabase.
- Alinhar os tipos e mapeamentos do cliente com o schema atual evita que consultas quebrem e mantém comportamento previsível de publicação/ordenacao.
- Simplificar o mapeamento para usar timestamps existentes (`created_at`) reduz perda de informação e evita lógica de agendamento dependente de colunas ausentes.

### Description
- Removi os campos `scheduled_at` e `published_at` do tipo `BlogPostData` e das `select`/`order`/`or` usadas em `src/lib/supabase.ts` para as consultas de blog.
- Ajustei `convertSupabaseToBlogPost` em `src/services/blogService.ts` para usar `created_at` como `scheduledAt`/`publishedAt` quando as colunas de agendamento não existem, e removi a lógica de `scheduled_at`/`published_at` de `convertBlogPostToSupabase`.
- Atualizei os testes unitários em `src/services/__tests__/blogService.test.ts` para refletir o payload simplificado e o novo comportamento esperado.

### Testing
- Nenhum teste automatizado foi executado durante este patch; o arquivo de teste `src/services/__tests__/blogService.test.ts` foi atualizado e deve ser executado em CI/local para validação.
- As alterações foram limitadas a `src/lib/supabase.ts`, `src/services/blogService.ts` e `src/services/__tests__/blogService.test.ts` e foram commitadas com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69850cfec5d0832da295da41e3ab61e9)