### PR TITLE
Refresh blog list after prerender hydration and remove scheduling fields

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -8,6 +8,8 @@ import { useNavigate, Link } from 'react-router-dom';
 import { BlogService, type BlogPost } from '@/services/blogService';
 import { useIsMobile } from '@/hooks/use-mobile';
 
+const FALLBACK_IMAGE_URL = 'https://placehold.co/1280x720?text=Blog+Image';
+
 const BlogSection: React.FC = () => {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
@@ -143,7 +145,7 @@ const BlogSection: React.FC = () => {
                   {/* Imagem do post */}
                   <div className="aspect-video overflow-hidden rounded-t-lg bg-white">
                     <img
-                      src={post.imageUrl}
+                      src={post.imageUrl || FALLBACK_IMAGE_URL}
                       alt={post.metaTitle ?? post.title}
                       className="w-full h-full object-cover object-center group-hover:scale-105 transition-transform duration-300"
                       width={1280}
@@ -151,7 +153,10 @@ const BlogSection: React.FC = () => {
                       loading="lazy"
                       onError={(e) => {
                         const target = e.target as HTMLImageElement;
-                        target.src = 'https://placehold.co/1280x720?text=Blog+Image';
+                        if (target.dataset.fallback !== 'true') {
+                          target.src = FALLBACK_IMAGE_URL;
+                          target.dataset.fallback = 'true';
+                        }
                       }}
                     />
                   </div>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -191,8 +191,6 @@ export interface BlogPostData {
   read_time?: number;
   published: boolean;
   featured_post: boolean;
-  scheduled_at?: string | null;
-  published_at?: string | null;
   meta_title?: string;
   meta_description?: string;
   tags?: string[];
@@ -493,7 +491,7 @@ export const supabaseApi = {
     const { data, error } = await supabase
       .from('blog_posts')
       .select(
-        'id,title,description,category,image_url,slug,read_time,published,featured_post,scheduled_at,published_at,meta_title,meta_description,created_at,updated_at'
+        'id,title,description,category,image_url,slug,read_time,published,featured_post,meta_title,meta_description,created_at,updated_at'
       )
       .order('created_at', { ascending: false });
 
@@ -502,13 +500,10 @@ export const supabaseApi = {
   },
 
   async getPublishedBlogPosts() {
-    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('blog_posts')
       .select('*')
       .eq('published', true)
-      .or(`scheduled_at.lte.${now},scheduled_at.is.null`)
-      .order('scheduled_at', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
     
     if (error) throw error;
@@ -530,7 +525,7 @@ export const supabaseApi = {
     const { data, error } = await supabase
       .from('blog_posts')
       .select(
-        'id,title,description,category,content,image_url,slug,read_time,published,featured_post,scheduled_at,published_at,meta_title,meta_description,tags,created_at,updated_at'
+        'id,title,description,category,content,image_url,slug,read_time,published,featured_post,meta_title,meta_description,tags,created_at,updated_at'
       )
       .eq('slug', slug)
       .single();
@@ -573,14 +568,11 @@ export const supabaseApi = {
   },
 
   async getBlogPostsByCategory(category: string) {
-    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('blog_posts')
       .select('*')
       .eq('category', category)
       .eq('published', true)
-      .or(`scheduled_at.lte.${now},scheduled_at.is.null`)
-      .order('scheduled_at', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
     
     if (error) throw error;
@@ -588,14 +580,11 @@ export const supabaseApi = {
   },
 
   async getFeaturedBlogPosts() {
-    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('blog_posts')
       .select('*')
       .eq('featured_post', true)
       .eq('published', true)
-      .or(`scheduled_at.lte.${now},scheduled_at.is.null`)
-      .order('scheduled_at', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
     
     if (error) throw error;

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -121,10 +121,9 @@ const Blog: React.FC<BlogProps> = ({ initialPosts = [] }) => {
       }
     };
     if (resolvedInitialPosts.length === 0) {
-      loadPosts();
-    } else {
-      setLoading(false);
+      setLoading(true);
     }
+    loadPosts();
   }, [initialPosts, resolvedInitialPosts.length]);
 
   useEffect(() => {

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -81,13 +81,13 @@ const CATEGORIES = [
 
 interface BlogProps { initialPosts?: BlogPost[]; }
 
-const Blog: React.FC<BlogProps> = ({ initialPosts = [] }) => {
+const Blog: React.FC<BlogProps> = ({ initialPosts }) => {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const resolvedInitialPosts = useMemo(() => {
-    if (initialPosts.length > 0) {
+    if (initialPosts?.length) {
       return initialPosts;
     }
 
@@ -126,7 +126,7 @@ const Blog: React.FC<BlogProps> = ({ initialPosts = [] }) => {
       setLoading(true);
     }
     loadPosts();
-  }, [initialPosts, resolvedInitialPosts.length]);
+  }, [resolvedInitialPosts.length]);
 
   useEffect(() => {
     setPosts(resolvedInitialPosts);

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -26,6 +26,8 @@ import Seo from '@/components/Seo';
 // Usar o tipo do BlogService
 type BlogPost = BlogPostType;
 
+const FALLBACK_IMAGE_URL = 'https://placehold.co/1280x720?text=Blog+Image';
+
 const CATEGORIES = [
   {
     id: 'home-equity',
@@ -269,7 +271,7 @@ const Blog: React.FC<BlogProps> = ({ initialPosts = [] }) => {
                     <article>
                       <div className="aspect-video overflow-hidden rounded-t-xl bg-white">
                         <img
-                          src={post.imageUrl}
+                          src={post.imageUrl || FALLBACK_IMAGE_URL}
                           alt={post.metaTitle ?? post.title}
                           className="w-full h-full object-cover object-center group-hover:scale-105 transition-transform duration-300"
                           width={1280}
@@ -277,7 +279,10 @@ const Blog: React.FC<BlogProps> = ({ initialPosts = [] }) => {
                           loading="lazy"
                           onError={(e) => {
                             const target = e.target as HTMLImageElement;
-                            target.src = 'https://placehold.co/1280x720?text=Blog+Image';
+                            if (target.dataset.fallback !== 'true') {
+                              target.src = FALLBACK_IMAGE_URL;
+                              target.dataset.fallback = 'true';
+                            }
                           }}
                         />
                       </div>

--- a/src/services/__tests__/blogService.test.ts
+++ b/src/services/__tests__/blogService.test.ts
@@ -52,8 +52,6 @@ describe('BlogService scheduling logic', () => {
       read_time: 8,
       published: true,
       featured_post: false,
-      scheduled_at: '2024-05-01T10:00:00.000Z',
-      published_at: '2024-05-02T10:00:00.000Z',
       meta_title: 'Meta',
       meta_description: 'Meta desc',
       tags: ['tag'],
@@ -63,8 +61,8 @@ describe('BlogService scheduling logic', () => {
 
     const post = BlogService.convertSupabaseToBlogPost(supabasePost);
 
-    expect(post.scheduledAt).toBe(supabasePost.scheduled_at);
-    expect(post.publishedAt).toBe(supabasePost.published_at || undefined);
+    expect(post.scheduledAt).toBe(supabasePost.created_at);
+    expect(post.publishedAt).toBe(supabasePost.created_at);
   });
 
   it('prepares supabase payload for scheduled posts without premature publication', () => {
@@ -82,8 +80,6 @@ describe('BlogService scheduling logic', () => {
 
     const payload = BlogService.convertBlogPostToSupabase(post);
 
-    expect(payload.scheduled_at).toBe(scheduledDate);
-    expect(payload.published_at).toBeNull();
     expect(payload.published).toBe(true);
   });
 });

--- a/src/services/blogService.ts
+++ b/src/services/blogService.ts
@@ -484,8 +484,8 @@ export class BlogService {
       readTime: supabasePost.read_time || 5,
       published: supabasePost.published,
       featuredPost: supabasePost.featured_post,
-      scheduledAt: supabasePost.scheduled_at || supabasePost.published_at || supabasePost.created_at,
-      publishedAt: supabasePost.published_at || undefined,
+      scheduledAt: supabasePost.created_at,
+      publishedAt: supabasePost.published ? supabasePost.created_at : undefined,
       metaTitle: supabasePost.meta_title,
       metaDescription: supabasePost.meta_description,
       tags: supabasePost.tags,
@@ -498,9 +498,6 @@ export class BlogService {
    * Converter BlogPost para formato Supabase
    */
   static convertBlogPostToSupabase(post: BlogPost): Omit<BlogPostData, 'id' | 'created_at' | 'updated_at'> {
-    const scheduledAt = post.scheduledAt || post.createdAt || new Date().toISOString();
-    const shouldMarkPublished = post.published && new Date(scheduledAt).getTime() <= Date.now();
-
     return {
       title: post.title,
       description: post.description,
@@ -511,8 +508,6 @@ export class BlogService {
       read_time: post.readTime,
       published: post.published ?? false,
       featured_post: post.featuredPost ?? false,
-      scheduled_at: scheduledAt,
-      published_at: shouldMarkPublished ? post.publishedAt || scheduledAt : post.publishedAt || null,
       meta_title: post.metaTitle,
       meta_description: post.metaDescription,
       tags: post.tags


### PR DESCRIPTION
### Motivation
- The blog page was sometimes stuck on the prerender snapshot (fallback `BLOG_POSTS`) and did not refresh client-side, causing `/blog` to show fewer posts than the Home widgets that fetch posts on the client.  
- The Supabase schema in use does not expose `scheduled_at`/`published_at`, so queries and type mappings that relied on those fields were brittle and could break queries.  
- Simplify the client-side behavior to always refresh published posts after hydration and align mappings to existing `created_at` timestamps to avoid scheduling-related regressions.

### Description
- Updated `src/pages/Blog.tsx` to always call `BlogService.getPublishedPosts()` on the client after hydration and to only show the loading spinner when there are no initial posts (keeps SSR snapshot but refreshes it).  
- Removed `scheduled_at`/`published_at` usage from Supabase helpers in `src/lib/supabase.ts` by deleting those fields from `BlogPostData` and from `select`/filter logic, and unified ordering by `created_at`.  
- Adjusted `src/services/blogService.ts` conversion logic so `convertSupabaseToBlogPost` uses `created_at` for `scheduledAt`/`publishedAt` and `publishedAt` is present only if the row is `published`, and removed scheduling fields from `convertBlogPostToSupabase`.  
- Updated unit tests in `src/services/__tests__/blogService.test.ts` to reflect the simplified payload/mapping and new expected behavior.

### Testing
- Updated unit tests: `src/services/__tests__/blogService.test.ts` were modified to match the new mapping and payload shape.  
- No automated test run was performed as part of this change (`not run`). CI or a local test run should be executed to validate the updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69850cfec5d0832da295da41e3ab61e9)