### PR TITLE
Add WhatsApp contact button to success page

### DIFF
--- a/src/pages/Sucesso.tsx
+++ b/src/pages/Sucesso.tsx
@@ -4,6 +4,8 @@ import MobileLayout from '@/components/MobileLayout';
 
 const Sucesso = () => {
   const navigate = useNavigate();
+  const whatsappLink =
+    'https://wa.me/5516997879837?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!';
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -29,14 +31,18 @@ const Sucesso = () => {
         <h1 className="text-2xl font-bold text-libra-navy">🎉 Muito obrigado!</h1>
         <p className="text-base text-gray-700">Recebemos sua solicitação e nossos consultores entrarão em contato em breve.</p>
         <p className="text-base text-gray-700">Fique atento aos telefones (16) 3600-7956 ou (16) 99636-0424.</p>
-        <a
-          className="inline-flex items-center justify-center gap-2 rounded-full bg-green-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
-          href="https://wa.me/5516997879837?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Iniciar atendimento no WhatsApp
-        </a>
+        <div className="flex flex-col items-center gap-3">
+          <p className="text-sm text-gray-600">Se preferir, fale conosco agora mesmo pelo WhatsApp.</p>
+          <a
+            aria-label="Conversar com a Libra Crédito no WhatsApp"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-green-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
+            href={whatsappLink}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Falar no WhatsApp
+          </a>
+        </div>
         <p className="text-sm text-gray-600 mt-4">Você será redirecionado automaticamente em até 30 segundos...</p>
       </div>
     </MobileLayout>


### PR DESCRIPTION
### Motivation

- Provide an immediate way for users to start a conversation after submitting the form by adding a WhatsApp call-to-action on the thank-you page.
- Reuse a single WhatsApp URL constant to avoid duplication and make future updates easier.
- Improve accessibility by adding a clear `aria-label` to the WhatsApp link.

### Description

- Introduced a `whatsappLink` constant in `src/pages/Sucesso.tsx` with the prefilled WhatsApp URL.
- Replaced the previous inline anchor with a small CTA block containing a helper sentence and a labeled anchor that opens WhatsApp in a new tab.
- Preserved existing styling while adding an `aria-label` for better screen reader support.
- Kept the automatic redirect messaging and 30s timer behavior unchanged.

### Testing

- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 5173` and the Vite server reported ready, which succeeded.
- Ran a Playwright script that opened `http://localhost:5173/sucesso` and saved a screenshot to `artifacts/sucesso-whatsapp.png`, which completed successfully.
- Performed a code search for the `Sucesso` page to verify the changes in `src/pages/Sucesso.tsx`, which returned the updated file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69851f0d0160832db42ee85971eda02e)