### PR TITLE
fix(mobile): prevent Android bottom white strip on simulation form pages

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -333,8 +333,18 @@
 
   body {
     @apply bg-background text-foreground overflow-x-hidden;
-    scrollbar-gutter: stable both-axis;
     font-feature-settings: "rlig" 1, "calt" 1;
+  }
+
+  /*
+   * Evita "faixa branca" no rodapé em navegadores mobile (Android),
+   * onde a reserva forçada de gutter pode reduzir a área útil vertical.
+   * Mantemos o gutter estável apenas em dispositivos desktop.
+   */
+  @media (hover: hover) and (pointer: fine) {
+    body {
+      scrollbar-gutter: stable both-edges;
+    }
   }
   
   /* Melhorar a acessibilidade de foco */

--- a/src/styles/critical-inline.css
+++ b/src/styles/critical-inline.css
@@ -10,8 +10,13 @@ body {
   font-family: 'Comfortaa', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-weight: 300;
   background: #ffffff;
-  scrollbar-gutter: stable both-axis;
   overflow-x: hidden;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  body {
+    scrollbar-gutter: stable both-edges;
+  }
 }
 
 html {


### PR DESCRIPTION
### Motivation
- Corrige a faixa branca que aparecia na parte inferior em Android ao interagir com o formulário, causada pela propriedade global de `scrollbar-gutter` que reserva espaço vertical e reduz a área útil da viewport.

### Description
- Remove a aplicação global de `scrollbar-gutter: stable both-axis` do `body` e adiciona um `@media (hover: hover) and (pointer: fine)` que aplica `scrollbar-gutter: stable both-edges` apenas para ambientes desktop, mudando os ficheiros `src/index.css` e `src/styles/critical-inline.css` para evitar o comportamento em dispositivos móveis.

### Testing
- Executado o teste unitário da página de simulação com `npm run test -- src/pages/__tests__/Simulacao.test.tsx`, que resultou em 1 arquivo de teste com 3 testes passando (✅ todos os testes passaram).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55da6470c832d9e80cadf552af02f)