### PR TITLE
Remove botão de WhatsApp após envio da simulação

### DIFF
--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import MobileLayout from '@/components/MobileLayout';
-import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 
@@ -79,24 +78,7 @@ const Confirmacao = () => {
         <p className="text-base text-gray-700">
           Fique atento ao telefone (16) 36007956 para nosso contato.
         </p>
-        <p className="text-base text-gray-700">
-          Enquanto isso, se preferir, clique no botão abaixo para iniciar seu atendimento no WhatsApp.
-        </p>
         <p className="text-sm text-gray-600">Você será redirecionado automaticamente em até 30 segundos.</p>
-        <div className="flex flex-col sm:flex-row gap-4 mt-4">
-          <Button
-            asChild
-            className="px-6 bg-green-600 text-white hover:bg-green-700 focus-visible:ring-green-600"
-          >
-            <a
-              href="https://wa.me/5516997879837?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
-              rel="noreferrer"
-              target="_blank"
-            >
-              Iniciar atendimento no WhatsApp
-            </a>
-          </Button>
-        </div>
       </div>
     </MobileLayout>
   );

--- a/src/pages/Sucesso.tsx
+++ b/src/pages/Sucesso.tsx
@@ -29,14 +29,6 @@ const Sucesso = () => {
         <h1 className="text-2xl font-bold text-libra-navy">🎉 Muito obrigado!</h1>
         <p className="text-base text-gray-700">Recebemos sua solicitação e nossos consultores entrarão em contato em breve.</p>
         <p className="text-base text-gray-700">Fique atento aos telefones (16) 3600-7956 ou (16) 99636-0424.</p>
-        <a
-          className="inline-flex items-center justify-center gap-2 rounded-full bg-green-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
-          href="https://wa.me/5516997879837?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Iniciar atendimento no WhatsApp
-        </a>
         <p className="text-sm text-gray-600 mt-4">Você será redirecionado automaticamente em até 30 segundos...</p>
       </div>
     </MobileLayout>


### PR DESCRIPTION
### Motivation
- Depois da submissão da simulação não deve haver um CTA que redirecione automaticamente para o WhatsApp; o fluxo deve permanecer apenas com a mensagem de confirmação e o redirecionamento automático para a página "Quem Somos".

### Description
- Remove o botão/link "Iniciar atendimento no WhatsApp" das páginas `src/pages/Confirmacao.tsx` e `src/pages/Sucesso.tsx` e a mensagem associada na `Confirmacao` que indicava o CTA.
- Remove o import não utilizado de `Button` em `src/pages/Confirmacao.tsx` e mantém o comportamento de redirecionamento automático de 30 segundos.

### Testing
- Executado `npm run typecheck` e o comando terminou sem erros.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc6a086f88832d94ca35087d047db2)