### PR TITLE
Update WhatsApp contact number and add WhatsApp CTA to simulation result

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,7 @@ const App = () => {
                 } />
                 {devRoutes}
                 <Route path="/confirmacao" element={<Confirmacao />} />
+                <Route path="/confirmação" element={<Confirmacao />} />
                 <Route path="/atendimento" element={<Atendimento />} />
                 <Route path="/sucesso" element={<Sucesso />} />
                 <Route path="*" element={<NotFound />} />

--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -89,7 +89,7 @@ const Confirmacao = () => {
             className="px-6 bg-green-600 text-white hover:bg-green-700 focus-visible:ring-green-600"
           >
             <a
-              href="https://wa.me/5516997879837?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
+              href="https://wa.me/5516997207767?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
               rel="noreferrer"
               target="_blank"
             >

--- a/src/pages/SimulacaoWizard.tsx
+++ b/src/pages/SimulacaoWizard.tsx
@@ -218,6 +218,14 @@ const SimulacaoWizard = () => {
                 <p className="text-green-700">
                   Obrigado, {simulationResult.name}! Entraremos em contato pelo WhatsApp {simulationResult.phone} em até 24 horas úteis.
                 </p>
+                <a
+                  className="mt-4 inline-flex items-center justify-center gap-2 rounded-full bg-green-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
+                  href="https://wa.me/5516997207767?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Iniciar atendimento no WhatsApp
+                </a>
                 <div className="mt-4 p-3 bg-green-100 rounded">
                   <h4 className="font-semibold text-green-800 mb-2">Dados recebidos:</h4>
                   <pre className="text-xs text-green-700 overflow-auto">

--- a/src/pages/Sucesso.tsx
+++ b/src/pages/Sucesso.tsx
@@ -31,7 +31,7 @@ const Sucesso = () => {
         <p className="text-base text-gray-700">Fique atento aos telefones (16) 3600-7956 ou (16) 99636-0424.</p>
         <a
           className="inline-flex items-center justify-center gap-2 rounded-full bg-green-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
-          href="https://wa.me/5516997879837?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
+          href="https://wa.me/5516997207767?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
           rel="noreferrer"
           target="_blank"
         >


### PR DESCRIPTION
### Motivation
- Standardize the WhatsApp contact used across confirmation and success pages and provide users a direct CTA after a simulation is submitted.

### Description
- Replaced the WhatsApp link on `Confirmacao.tsx` to use `5516997207767` instead of the previous number.
- Replaced the WhatsApp link on `Sucesso.tsx` to use `5516997207767` instead of the previous number.
- Added a visible WhatsApp CTA button to the simulation result block in `SimulacaoWizard.tsx` that opens the same `5516997207767` link in a new tab.
- Kept existing copy and styling for the CTA buttons and preserved the 30-second redirect behavior.

### Testing
- Ran a TypeScript build with `npm run build` to verify compilation succeeded and it completed without errors.
- Ran linter with `npm run lint` to ensure code style rules passed.
- No new unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc6a086f88832d94ca35087d047db2)