### PR TITLE
Restore removed module scripts, add accented confirmation route, update WhatsApp links and harden scroll logic

### DIFF
--- a/scripts/extract-critical.mjs
+++ b/scripts/extract-critical.mjs
@@ -6,6 +6,15 @@ const critters = new Critters({
 });
 
 const html = await readFile('dist/index.html', 'utf8');
-const processed = await critters.process(html);
-await writeFile('dist/index.html', processed);
+const moduleScripts = html.match(/<script[^>]*type="module"[^>]*><\/script>/g) ?? [];
 
+let processed = await critters.process(html);
+
+// O Critters pode remover indevidamente o script de entrada em alguns cenários.
+// Se isso acontecer, restauramos os scripts module originais para garantir o boot da aplicação SPA.
+if (moduleScripts.length > 0 && !/type="module"/.test(processed)) {
+  const scriptsToRestore = moduleScripts.join('\n');
+  processed = processed.replace('</body>', `${scriptsToRestore}\n</body>`);
+}
+
+await writeFile('dist/index.html', processed);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,7 @@ const App = () => {
                 } />
                 {devRoutes}
                 <Route path="/confirmacao" element={<Confirmacao />} />
+                <Route path="/confirmação" element={<Confirmacao />} />
                 <Route path="/atendimento" element={<Atendimento />} />
                 <Route path="/sucesso" element={<Sucesso />} />
                 <Route path="*" element={<NotFound />} />

--- a/src/pages/Confirmacao.tsx
+++ b/src/pages/Confirmacao.tsx
@@ -30,16 +30,26 @@ const Confirmacao = () => {
 
   useLayoutEffect(() => {
     const scrollingElement = document.scrollingElement || document.documentElement;
-    scrollingElement?.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    if (scrollingElement && typeof scrollingElement.scrollTo === 'function') {
+      scrollingElement.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    } else {
+      window.scrollTo(0, 0);
+    }
 
     const mainContent = document.getElementById('main-content');
     if (mainContent) {
       // Garante que o usuário comece no topo da página de confirmação
-      mainContent.scrollTo({ top: 0, left: 0, behavior: 'auto' });
-      mainContent.parentElement?.scrollTo?.({ top: 0, left: 0, behavior: 'auto' });
+      if (typeof mainContent.scrollTo === 'function') {
+        mainContent.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+      }
+      if (mainContent.parentElement && typeof mainContent.parentElement.scrollTo === 'function') {
+        mainContent.parentElement.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+      }
     }
 
-    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    if (typeof window.scrollTo === 'function') {
+      window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    }
   }, []);
 
   useEffect(() => {
@@ -89,7 +99,7 @@ const Confirmacao = () => {
             className="px-6 bg-green-600 text-white hover:bg-green-700 focus-visible:ring-green-600"
           >
             <a
-              href="https://wa.me/5516997879837?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
+              href="https://wa.me/5516997207767?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
               rel="noreferrer"
               target="_blank"
             >

--- a/src/pages/SimulacaoWizard.tsx
+++ b/src/pages/SimulacaoWizard.tsx
@@ -218,6 +218,14 @@ const SimulacaoWizard = () => {
                 <p className="text-green-700">
                   Obrigado, {simulationResult.name}! Entraremos em contato pelo WhatsApp {simulationResult.phone} em até 24 horas úteis.
                 </p>
+                <a
+                  className="mt-4 inline-flex items-center justify-center gap-2 rounded-full bg-green-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
+                  href="https://wa.me/5516997207767?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Iniciar atendimento no WhatsApp
+                </a>
                 <div className="mt-4 p-3 bg-green-100 rounded">
                   <h4 className="font-semibold text-green-800 mb-2">Dados recebidos:</h4>
                   <pre className="text-xs text-green-700 overflow-auto">

--- a/src/pages/Sucesso.tsx
+++ b/src/pages/Sucesso.tsx
@@ -31,7 +31,7 @@ const Sucesso = () => {
         <p className="text-base text-gray-700">Fique atento aos telefones (16) 3600-7956 ou (16) 99636-0424.</p>
         <a
           className="inline-flex items-center justify-center gap-2 rounded-full bg-green-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
-          href="https://wa.me/5516997879837?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
+          href="https://wa.me/5516997207767?text=Ol%C3%A1%20Libra%20Cr%C3%A9dito%2C%20quero%20iniciar%20meu%20atendimento!"
           rel="noreferrer"
           target="_blank"
         >


### PR DESCRIPTION
### Motivation
- Prevent the Critters CSS inliner from removing the app's `type="module"` entry script so the SPA can boot reliably.
- Provide an accented URL variant (`/confirmação`) that maps to the confirmation page for users who hit the accented path.
- Update the WhatsApp contact number and add a quick action in the wizard result so users can start atendimento directly.
- Make scroll-reset code defensive to avoid runtime errors in environments where `scrollTo` or `scrollIntoView` may be absent.

### Description
- `scripts/extract-critical.mjs`: capture existing `<script ... type="module">` tags before running `critters.process`, and if Critters removed them restore the original module scripts before writing `dist/index.html`.
- `src/App.tsx`: add a duplicate route that maps `"/confirmação"` to the existing `Confirmacao` component.
- `src/pages/Confirmacao.tsx`: make scroll resets defensive by checking presence and type of `scrollTo`/`scrollIntoView` before calling them and update the WhatsApp `href` to the new number.
- `src/pages/SimulacaoWizard.tsx` and `src/pages/Sucesso.tsx`: update the WhatsApp `href` to the new number and add a WhatsApp call-to-action button in the wizard success panel.

### Testing
- Ran the TypeScript compiler (`tsc`) to validate types and the codebase; compilation succeeded.
- Executed a production build (`npm run build`) to validate `scripts/extract-critical.mjs` behavior and output files; the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc6a086f88832d94ca35087d047db2)