### PR TITLE
Dispara webhook imediatamente após conclusão da simulação

### DIFF
--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -433,6 +433,53 @@ export class LocalSimulationService {
       // 8. Armazenar localmente como backup
       this.saveSimulationLocally(result, input);
 
+      // 9. Disparar webhook de simulação para iniciar automações imediatamente
+      // Falhas são não-críticas e não devem interromper o fluxo principal da simulação.
+      try {
+        const simulationWebhookPayload = {
+          simulationId: result.userJourneyId || result.id,
+          sessionId: input.sessionId,
+          nomeCompleto: input.nomeCompleto,
+          email: input.email,
+          telefone: input.telefone.replace(/\D/g, ''),
+          cidade: input.cidade,
+          valorEmprestimo: input.valorEmprestimo,
+          valorImovel: input.valorImovel,
+          parcelas: input.parcelas,
+          tipoAmortizacao: input.tipoAmortizacao,
+          valorParcela: result.valor,
+          primeiraParcela: result.primeiraParcela || result.valor,
+          ultimaParcela: result.ultimaParcela || result.valor,
+          status: 'simulacao_realizada'
+        };
+
+        console.log('🪝 Enviando webhook de simulação:', {
+          simulationId: simulationWebhookPayload.simulationId,
+          sessionId: simulationWebhookPayload.sessionId
+        });
+
+        const webhookCalls = [WebhookService.sendSimulationData(simulationWebhookPayload)];
+        const secondaryUrl = getSecondaryWebhookUrl();
+
+        if (secondaryUrl) {
+          webhookCalls.push(
+            WebhookService.sendSimulationData(simulationWebhookPayload, { url: secondaryUrl })
+          );
+        }
+
+        const [primaryResult, secondaryResult] = await Promise.all(webhookCalls);
+
+        if (!primaryResult.success) {
+          console.warn('⚠️ Falha no webhook principal de simulação (não crítico):', primaryResult.message);
+        }
+
+        if (secondaryUrl && !secondaryResult?.success) {
+          console.warn('⚠️ Falha no webhook secundário de simulação (não crítico):', secondaryResult?.message);
+        }
+      } catch (webhookError) {
+        console.error('⚠️ Erro ao disparar webhook de simulação (não crítico):', webhookError);
+      }
+
       console.log('✅ Simulação local realizada com sucesso:', result);
       return result;
 


### PR DESCRIPTION
### Motivation
- Algumas automações (ex.: agentes externos) só eram iniciadas quando o usuário enviava o formulário de contato, então simulações feitas apenas até o resultado não disparavam o webhook necessário.

### Description
- Adiciona envio de webhook logo após a simulação local ser concluída em `src/services/localSimulationService.ts` para iniciar automações sem depender do envio de contato.
- O payload enviado inclui `simulationId`, `sessionId`, `nomeCompleto`, `email`, `telefone`, `cidade`, `valorEmprestimo`, `valorImovel`, `parcelas`, `tipoAmortizacao`, `valorParcela`, `primeiraParcela`, `ultimaParcela` e `status: 'simulacao_realizada'`.
- Mantém o envio ao webhook secundário quando configurado e trata falhas como não-críticas, apenas logando avisos para não impactar a experiência do usuário.
- Preserva o fluxo de webhook existente no pós-contato, portanto em casos com envio de contato haverá dois eventos (simulação + contato).

### Testing
- Executado `npm run -s typecheck` e a verificação de tipos concluiu com sucesso.
- Executado `npm run -s test -- src/services/__tests__/localSimulationService.test.ts` e todos os testes relacionados passaram (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ca734a44832dbc20ff8f43a0bb0d)