### PR TITLE
Improve simulation reliability and webhook delivery resilience

### DIFF
--- a/docs/simulacao-auditoria.md
+++ b/docs/simulacao-auditoria.md
@@ -1,0 +1,53 @@
+# Auditoria técnica — Página de Simulação, Webhooks e Automações
+
+## Escopo revisado
+- Fluxo de simulação (UI): `src/components/SimulationForm.tsx`
+- Fluxo de conclusão/contato: `src/components/ContactForm.tsx`
+- Regras de negócio + persistência: `src/services/localSimulationService.ts`
+- Transporte de webhook: `src/services/webhookService.ts`
+
+## Sintomas reportados
+1. Lentidão ao simular.
+2. Lentidão ao concluir.
+3. Casos em que o webhook não chega.
+
+## Principais achados
+
+### 1) Latência no fechamento do lead (conclusão)
+O método `LocalSimulationService.processContact` executava operações de rede síncronas em sequência e aguardava também o disparo de webhooks no mesmo fluxo da UX.
+
+**Impacto:** o usuário podia perceber demora antes da navegação para confirmação, principalmente com APIs lentas/intermitentes.
+
+### 2) Entrega de webhook com chance de perda silenciosa
+Mesmo com retries em memória no `WebhookService`, falhas de webhook eram apenas logadas e não havia fila persistente dedicada para reentrega posterior.
+
+**Impacto:** em falhas transitórias (timeout, 5xx, rede), havia risco de automação não ser acionada.
+
+### 3) Estratégia de retry pouco seletiva
+A lógica antiga repetia para qualquer erro HTTP, inclusive 4xx não transitório.
+
+**Impacto:** retrabalho desnecessário, mais tempo de espera e sem ganho de confiabilidade real.
+
+## Melhorias implementadas nesta revisão
+
+1. **Disparo assíncrono de webhook (não bloqueante da UX)** no fluxo de simulação e de contato.
+2. **Fila local de webhooks pendentes** (`localStorage`) com reprocessamento automático.
+3. **Tentativas limitadas com descarte controlado** para evitar loops infinitos.
+4. **Retry seletivo por status transitório** (408, 429, 5xx) no `WebhookService`.
+5. **Timeout/retries mais agressivos para responsividade** (redução de timeout padrão e retries).
+6. **`keepalive` no fetch** para melhorar chance de envio em navegação/troca de rota.
+
+## Próximos passos recomendados (arquitetura)
+
+1. **Mover automações para backend/edge function**: o front deveria apenas gravar evento e retornar rápido.
+2. **Implementar fila server-side (DLQ + retries exponenciais)** para garantir entrega “at least once”.
+3. **Idempotência no receptor do webhook** usando `eventId` para evitar duplicidade.
+4. **Observabilidade mínima**: taxa de sucesso por webhook, tempo de processamento e alertas por falha.
+5. **SLA por etapa**: separar SLA de UX (rápido) do SLA de automação (eventual, confiável).
+
+## Resultado esperado com as mudanças atuais
+- Menor tempo percebido na conclusão.
+- Menor chance de perda definitiva de webhook em falhas transitórias.
+- Retentativas mais inteligentes e menos custosas.
+
+> Observação: “nunca falhar” exige processamento robusto no backend. No front-end, só é possível reduzir bastante o risco, não eliminá-lo completamente.

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -110,6 +110,14 @@ export interface SessionGroupWithJourney {
   primary_session_id?: string | null;
 }
 
+interface PendingWebhookEntry {
+  id: string;
+  createdAt: string;
+  target: 'primary' | 'secondary';
+  payload: Parameters<typeof WebhookService.sendSimulationData>[0];
+  attempt: number;
+}
+
 const countJourneySignals = (journey?: Partial<UserJourneyData> | null): number => {
   if (!journey) return 0;
   const trackedKeys: (keyof UserJourneyData)[] = [
@@ -155,6 +163,8 @@ const pickBetterJourney = (
 
 // Classe principal do serviço local
 export class LocalSimulationService {
+  private static readonly WEBHOOK_QUEUE_KEY = 'libra_pending_webhooks';
+  private static readonly WEBHOOK_MAX_ATTEMPTS = 5;
 
   /**
    * Busca jornadas em lotes para evitar erros de URL muito longas no Supabase
@@ -433,52 +443,33 @@ export class LocalSimulationService {
       // 8. Armazenar localmente como backup
       this.saveSimulationLocally(result, input);
 
-      // 9. Disparar webhook de simulação para iniciar automações imediatamente
-      // Falhas são não-críticas e não devem interromper o fluxo principal da simulação.
-      try {
-        const simulationWebhookPayload = {
-          simulationId: result.userJourneyId || result.id,
-          sessionId: input.sessionId,
-          nomeCompleto: input.nomeCompleto,
-          email: input.email,
-          telefone: input.telefone.replace(/\D/g, ''),
-          cidade: input.cidade,
-          valorEmprestimo: input.valorEmprestimo,
-          valorImovel: input.valorImovel,
-          parcelas: input.parcelas,
-          tipoAmortizacao: input.tipoAmortizacao,
-          valorParcela: result.valor,
-          primeiraParcela: result.primeiraParcela || result.valor,
-          ultimaParcela: result.ultimaParcela || result.valor,
-          status: 'simulacao_realizada'
-        };
+      // 9. Disparar webhook de simulação sem bloquear o retorno para a interface
+      const simulationWebhookPayload = {
+        eventType: 'simulation' as const,
+        simulationId: result.userJourneyId || result.id,
+        sessionId: input.sessionId,
+        nomeCompleto: input.nomeCompleto,
+        email: input.email,
+        telefone: input.telefone.replace(/\D/g, ''),
+        cidade: input.cidade,
+        valorEmprestimo: input.valorEmprestimo,
+        valorImovel: input.valorImovel,
+        parcelas: input.parcelas,
+        tipoAmortizacao: input.tipoAmortizacao,
+        valorParcela: result.valor,
+        primeiraParcela: result.primeiraParcela || result.valor,
+        ultimaParcela: result.ultimaParcela || result.valor,
+        status: 'simulacao_realizada'
+      };
 
-        console.log('🪝 Enviando webhook de simulação:', {
-          simulationId: simulationWebhookPayload.simulationId,
-          sessionId: simulationWebhookPayload.sessionId
+      console.log('🪝 Agendando webhook de simulação:', {
+        simulationId: simulationWebhookPayload.simulationId,
+        sessionId: simulationWebhookPayload.sessionId
+      });
+      void this.dispatchWebhooksReliably(simulationWebhookPayload, 'simulação')
+        .catch(error => {
+          console.error('⚠️ Falha inesperada no agendamento do webhook de simulação:', error);
         });
-
-        const webhookCalls = [WebhookService.sendSimulationData(simulationWebhookPayload)];
-        const secondaryUrl = getSecondaryWebhookUrl();
-
-        if (secondaryUrl) {
-          webhookCalls.push(
-            WebhookService.sendSimulationData(simulationWebhookPayload, { url: secondaryUrl })
-          );
-        }
-
-        const [primaryResult, secondaryResult] = await Promise.all(webhookCalls);
-
-        if (!primaryResult.success) {
-          console.warn('⚠️ Falha no webhook principal de simulação (não crítico):', primaryResult.message);
-        }
-
-        if (secondaryUrl && !secondaryResult?.success) {
-          console.warn('⚠️ Falha no webhook secundário de simulação (não crítico):', secondaryResult?.message);
-        }
-      } catch (webhookError) {
-        console.error('⚠️ Erro ao disparar webhook de simulação (não crítico):', webhookError);
-      }
 
       console.log('✅ Simulação local realizada com sucesso:', result);
       return result;
@@ -1136,8 +1127,7 @@ export class LocalSimulationService {
 
       console.log('✅ Contato processado com sucesso');
 
-      // Disparar webhook principal/secundário após o contato ser processado com sucesso.
-      // Falhas de webhook são não-críticas e não devem interromper a experiência do usuário.
+      // Disparar webhook principal/secundário sem bloquear a navegação de sucesso.
       try {
         const normalizedNome = input.nomeCompleto.trim();
         const normalizedEmail = input.email.trim().toLowerCase();
@@ -1186,6 +1176,7 @@ export class LocalSimulationService {
         ).toUpperCase();
 
         const webhookPayload = {
+          eventType: 'contact' as const,
           simulationId: fallbackSimulation?.id || input.simulationId,
           sessionId: input.sessionId,
           nomeCompleto: normalizedNome,
@@ -1204,28 +1195,14 @@ export class LocalSimulationService {
           status: journeyStatus || fallbackSimulation?.status || 'interessado'
         };
 
-        console.log('🪝 Enviando dados para webhook após contato:', {
+        console.log('🪝 Agendando dados para webhook após contato:', {
           simulationId: webhookPayload.simulationId,
           email: webhookPayload.email
         });
-
-        const webhookCalls = [WebhookService.sendSimulationData(webhookPayload)];
-        const secondaryUrl = getSecondaryWebhookUrl();
-        if (secondaryUrl) {
-          webhookCalls.push(
-            WebhookService.sendSimulationData(webhookPayload, { url: secondaryUrl })
-          );
-        }
-
-        const [primaryResult, secondaryResult] = await Promise.all(webhookCalls);
-
-        if (!primaryResult.success) {
-          console.warn('⚠️ Falha no webhook principal (não crítico):', primaryResult.message);
-        }
-
-        if (secondaryUrl && !secondaryResult?.success) {
-          console.warn('⚠️ Falha no webhook secundário (não crítico):', secondaryResult?.message);
-        }
+        void this.dispatchWebhooksReliably(webhookPayload, 'contato')
+          .catch(error => {
+            console.error('⚠️ Falha inesperada no agendamento do webhook de contato:', error);
+          });
       } catch (webhookError) {
         console.error('⚠️ Erro ao disparar webhook de contato (não crítico):', webhookError);
       }
@@ -1558,6 +1535,114 @@ export class LocalSimulationService {
     } catch (error) {
       console.warn('⚠️ Erro ao remover contato localmente:', error);
     }
+  }
+
+  private static getPendingWebhookQueue(): PendingWebhookEntry[] {
+    try {
+      const raw = localStorage.getItem(this.WEBHOOK_QUEUE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      console.warn('⚠️ Erro ao carregar fila de webhooks:', error);
+      return [];
+    }
+  }
+
+  private static savePendingWebhookQueue(entries: PendingWebhookEntry[]): void {
+    try {
+      if (!entries.length) {
+        localStorage.removeItem(this.WEBHOOK_QUEUE_KEY);
+        return;
+      }
+      localStorage.setItem(this.WEBHOOK_QUEUE_KEY, JSON.stringify(entries.slice(0, 200)));
+    } catch (error) {
+      console.warn('⚠️ Erro ao salvar fila de webhooks:', error);
+    }
+  }
+
+  private static enqueueWebhookFailure(
+    target: PendingWebhookEntry['target'],
+    payload: Parameters<typeof WebhookService.sendSimulationData>[0],
+    attempt: number
+  ): void {
+    if (attempt >= this.WEBHOOK_MAX_ATTEMPTS) {
+      console.error('❌ Webhook descartado após máximo de tentativas:', {
+        target,
+        simulationId: payload.simulationId
+      });
+      return;
+    }
+
+    const queue = this.getPendingWebhookQueue();
+    queue.push({
+      id: `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      createdAt: new Date().toISOString(),
+      target,
+      payload,
+      attempt
+    });
+    this.savePendingWebhookQueue(queue);
+    console.warn('📥 Webhook adicionado à fila de retentativa:', {
+      target,
+      simulationId: payload.simulationId,
+      attempt
+    });
+  }
+
+  private static async dispatchWebhooksReliably(
+    payload: Parameters<typeof WebhookService.sendSimulationData>[0],
+    context: string
+  ): Promise<void> {
+    await this.flushPendingWebhooks();
+
+    const secondaryUrl = getSecondaryWebhookUrl();
+    const [primaryResult, secondaryResult] = await Promise.all([
+      WebhookService.sendSimulationData(payload),
+      secondaryUrl
+        ? WebhookService.sendSimulationData(payload, { url: secondaryUrl })
+        : Promise.resolve(undefined)
+    ]);
+
+    if (!primaryResult.success) {
+      console.warn(`⚠️ Falha no webhook principal de ${context}:`, primaryResult.message);
+      this.enqueueWebhookFailure('primary', payload, 1);
+    }
+
+    if (secondaryUrl && secondaryResult && !secondaryResult.success) {
+      console.warn(`⚠️ Falha no webhook secundário de ${context}:`, secondaryResult.message);
+      this.enqueueWebhookFailure('secondary', payload, 1);
+    }
+  }
+
+  private static async flushPendingWebhooks(): Promise<void> {
+    const queue = this.getPendingWebhookQueue();
+    if (!queue.length) return;
+
+    const remaining: PendingWebhookEntry[] = [];
+    for (const entry of queue) {
+      try {
+        const secondaryUrl = getSecondaryWebhookUrl();
+        if (entry.target === 'secondary' && !secondaryUrl) {
+          continue;
+        }
+
+        const result = await WebhookService.sendSimulationData(entry.payload, {
+          ...(entry.target === 'secondary' && secondaryUrl ? { url: secondaryUrl } : {})
+        });
+
+        if (!result.success) {
+          remaining.push({ ...entry, attempt: entry.attempt + 1 });
+        }
+      } catch (error) {
+        console.warn('⚠️ Erro ao reprocessar webhook pendente:', error);
+        remaining.push({ ...entry, attempt: entry.attempt + 1 });
+      }
+    }
+
+    this.savePendingWebhookQueue(
+      remaining.filter(entry => entry.attempt <= this.WEBHOOK_MAX_ATTEMPTS)
+    );
   }
 
   /**

--- a/src/services/webhookService.ts
+++ b/src/services/webhookService.ts
@@ -22,6 +22,8 @@
 import { resolveWebhookUrl, type WebhookUrl } from '@/lib/env';
 
 export interface WebhookPayload {
+  eventId?: string;
+  eventType?: 'simulation' | 'contact';
   // Dados da simulação
   simulationId: string;
   sessionId: string;
@@ -59,6 +61,7 @@ export interface WebhookConfig {
   url: WebhookUrl;
   timeout?: number;
   retries?: number;
+  retryOnClientError?: boolean;
   headers?: Record<string, string>;
 }
 
@@ -71,9 +74,9 @@ export interface WebhookResult {
 }
 
 export class WebhookService {
-  private static readonly DEFAULT_TIMEOUT = 10000; // 10 segundos
-  private static readonly DEFAULT_RETRIES = 3;
-  private static readonly RETRY_DELAY = 1000; // 1 segundo
+  private static readonly DEFAULT_TIMEOUT = 5000; // 5 segundos
+  private static readonly DEFAULT_RETRIES = 2;
+  private static readonly RETRY_DELAY = 400; // 0,4 segundo
   
   /**
    * Enviar dados da simulação para webhook
@@ -99,6 +102,8 @@ export class WebhookService {
     // Preparar payload completo
     const payload: WebhookPayload = {
       ...simulationData,
+      eventId: simulationData.eventId || crypto.randomUUID(),
+      eventType: simulationData.eventType || 'contact',
       timestamp: new Date().toISOString(),
       source: 'libra-credito-landing',
       simulationId: simulationData.simulationId || '',
@@ -137,12 +142,19 @@ export class WebhookService {
           return result;
         }
         
+        const shouldRetry =
+          this.isRetryableStatus(result.statusCode) || Boolean(config?.retryOnClientError);
+
+        if (!shouldRetry) {
+          return result;
+        }
+
         lastError = result;
         
         // Se não é o último attempt, aguardar antes de tentar novamente
         if (attempt < maxRetries) {
           console.log(`⏳ Tentativa ${attempt} falhou, aguardando ${this.RETRY_DELAY}ms...`);
-          await this.delay(this.RETRY_DELAY * attempt); // Backoff exponencial
+          await this.delay(this.RETRY_DELAY * 2 ** (attempt - 1)); // Backoff exponencial
         }
         
       } catch (error) {
@@ -156,7 +168,7 @@ export class WebhookService {
         console.error(`❌ Erro na tentativa ${attempt}:`, error);
         
         if (attempt < maxRetries) {
-          await this.delay(this.RETRY_DELAY * attempt);
+          await this.delay(this.RETRY_DELAY * 2 ** (attempt - 1));
         }
       }
     }
@@ -195,6 +207,7 @@ export class WebhookService {
         method: 'POST',
         headers,
         body: JSON.stringify(payload),
+        keepalive: true,
         signal: controller.signal
       });
       
@@ -288,6 +301,11 @@ export class WebhookService {
    */
   private static delay(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  private static isRetryableStatus(statusCode?: number): boolean {
+    if (!statusCode) return true;
+    return statusCode === 408 || statusCode === 429 || statusCode >= 500;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Users reported slower perceived experience when running simulations and when completing contact forms, and intermittent missing webhooks that broke automations. 
- The goal was to reduce UX latency on simulation/contact completion and make webhook delivery far more resilient from the client side.

### Description
- Make webhook dispatch non-blocking for the UX by scheduling sends from `LocalSimulationService` instead of awaiting them inline in `performSimulation` and `processContact` (changes in `src/services/localSimulationService.ts`).
- Add a persistent retry queue backed by `localStorage` with enqueue/flush logic, max attempts and controlled backoff to reprocess failed webhook deliveries (`dispatchWebhooksReliably`, `flushPendingWebhooks`, queue helpers in `src/services/localSimulationService.ts`).
- Harden `WebhookService` (`src/services/webhookService.ts`) by adding `eventId`/`eventType` metadata, shortening default `timeout`/`retries`, adding selective retry logic for transient statuses (408, 429, 5xx), exponential backoff, and `keepalive` on `fetch` to improve delivery during navigation.
- Add a technical audit document describing findings, rationale and recommended next steps (created `docs/simulacao-auditoria.md`).

### Testing
- Ran type checking with `npm run typecheck` and it completed without errors. (success)
- Executed unit tests for the local simulation service with `npm run test -- src/services/__tests__/localSimulationService.test.ts` and all tests passed. (5 tests passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d798ddefc4832d956987006b464a74)