### PR TITLE
Detect duplicate leads from Ploomes and notify user; persist CRM integration status

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -195,7 +195,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
 
       const journey = getJourneyData();
 
-      await LocalSimulationService.processContact({
+      const contactResult = await LocalSimulationService.processContact({
         simulationId: simulationResult.id,
         sessionId,
         visitorId,
@@ -226,6 +226,13 @@ const ContactForm: React.FC<ContactFormProps> = ({
             : null
 
       });
+
+      if (contactResult.duplicateLead) {
+        alert(
+          '⚠️ Identificamos uma solicitação recente com este e-mail no CRM (janela de 7 dias).\n\n' +
+          'Sua solicitação foi recebida e nosso time seguirá com o atendimento da proposta já existente.'
+        );
+      }
 
       // Redirecionar diretamente para a página de confirmação com resumo
       const summary = {

--- a/src/services/__tests__/localSimulationService.test.ts
+++ b/src/services/__tests__/localSimulationService.test.ts
@@ -78,7 +78,7 @@ describe('LocalSimulationService', () => {
     (global as any).localStorage = new LocalStorageMock();
     (global as any).fetch = vi.fn(async () => ({
       ok: true,
-      json: async () => ({}),
+      json: async () => ({ status: true, msg: 'ok' }),
       status: 200,
       statusText: 'OK',
       headers: { entries: () => [] }

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -502,7 +502,7 @@ export class LocalSimulationService {
       referrer?: string | null;
     },
     options: { isRetry?: boolean } = {}
-  ): Promise<{success: boolean, message: string}> {
+  ): Promise<{success: boolean, message: string, duplicateLead?: boolean, crmMessage?: string}> {
     try {
       console.log('📧 Processando contato com integração:', input);
       
@@ -663,7 +663,25 @@ export class LocalSimulationService {
       }
 
       const ploomesResult = await ploomesResponse.json();
-      console.log('✅ Sucesso na API Ploomes:', ploomesResult);
+      const ploomesMessage =
+        typeof ploomesResult?.msg === 'string' ? ploomesResult.msg : 'Resposta inválida da API Ploomes';
+      const ploomesStatus = Boolean(ploomesResult?.status);
+      const ploomesDuplicidade =
+        !ploomesStatus &&
+        ploomesMessage.toLowerCase().includes('já existe') &&
+        ploomesMessage.toLowerCase().includes('7 dias');
+      const ploomesCrmMessage = ploomesMessage;
+
+      if (!ploomesStatus && !ploomesDuplicidade) {
+        console.error('❌ API Ploomes recusou o cadastro:', ploomesResult);
+        throw new Error(`API Ploomes recusou o cadastro: ${ploomesMessage}`);
+      }
+
+      if (ploomesDuplicidade) {
+        console.warn('⚠️ Lead duplicado no Ploomes (janela de 7 dias):', ploomesMessage);
+      } else {
+        console.log('✅ Sucesso na API Ploomes:', ploomesResult);
+      }
 
       // Salvar/Atualizar contato no Supabase com dados completos (com retry)
       const maxSupabaseRetries = 3;
@@ -685,7 +703,8 @@ export class LocalSimulationService {
               telefone: sanitizedPhone, // Limpar telefone
               imovel_proprio: input.imovelProprio as 'proprio' | 'terceiro', // Garantir tipo correto
               status: 'interessado', // Status após contato para compatibilidade com AdminDashboard
-              visitor_id: input.visitorId ?? simulationData?.visitor_id ?? null
+              visitor_id: input.visitorId ?? simulationData?.visitor_id ?? null,
+              integrado_crm: ploomesStatus
             };
 
             if (input.utm_source !== undefined) {
@@ -1245,9 +1264,20 @@ export class LocalSimulationService {
         await this.resendPendingContacts();
       }
 
+      if (ploomesDuplicidade) {
+        return {
+          success: true,
+          message: 'Recebemos seus dados, mas já existe uma solicitação com este e-mail no CRM nos últimos 7 dias.',
+          duplicateLead: true,
+          crmMessage: ploomesCrmMessage
+        };
+      }
+
       return {
         success: true,
-        message: 'Dados enviados com sucesso! Nossa equipe entrará em contato em breve.'
+        message: 'Dados enviados com sucesso! Nossa equipe entrará em contato em breve.',
+        duplicateLead: false,
+        crmMessage: ploomesCrmMessage
       };
 
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Improve robustness of the Ploomes integration by properly interpreting the API response and handling duplicate leads detected within the 7-day window. 
- Surface a clear user-facing message when a duplicate lead is identified so users know their request is already in the CRM.
- Persist CRM integration status on the Supabase record for better downstream visibility.

### Description
- Parse `status` and `msg` from the Ploomes response and treat non-OK responses as failures unless they match a 7-day duplicate pattern; log and handle each case accordingly in `processContact`.
- Detect duplicate leads by checking the Ploomes message for strings like "já existe" and "7 dias" and add a `duplicateLead` flag and `crmMessage` to the `processContact` return value.
- Set `integrado_crm` on the Supabase update payload based on whether the contact was successfully integrated to the CRM (`ploomesStatus`).
- Return early with a specific success payload when a duplicate is detected, and keep normal success semantics otherwise in `processContact` (now returns `{ success, message, duplicateLead?, crmMessage? }`).
- Update `ContactForm` to capture the `processContact` result and show an alert to the user when `duplicateLead` is true.
- Update unit test mocking for the external `fetch` to return a realistic Ploomes response (`{ status: true, msg: 'ok' }`) in `localSimulationService.test.ts`.

### Testing
- Ran unit tests for the local simulation service with `vitest`, including `src/services/__tests__/localSimulationService.test.ts`, and they completed successfully.
- Verified that the updated `processContact` signature and return shapes are exercised by the tests and that the new fetch mock response is accepted by the parsing logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1a1ed01c832d96e4f055cd7f97ec)