### PR TITLE
Melhora captura de origem dos leads (UTM / click‑ids / referrer fallback)

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Link, useNavigate } from 'react-router-dom';
 import { LocalSimulationService } from '@/services/localSimulationService';
 import { useUserJourney } from '@/hooks/useUserJourney';
+import { mergeTrafficOrigin, resolveTrafficOrigin } from '@/utils/trafficOrigin';
 import Home from 'lucide-react/dist/esm/icons/home';
 import Building from 'lucide-react/dist/esm/icons/building';
 import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
@@ -194,6 +195,13 @@ const ContactForm: React.FC<ContactFormProps> = ({
       });
 
       const journey = getJourneyData();
+      const trafficOrigin = mergeTrafficOrigin(
+        journey,
+        resolveTrafficOrigin(
+          typeof window !== 'undefined' ? window.location.href : null,
+          typeof document !== 'undefined' ? document.referrer || null : null
+        )
+      );
 
       await LocalSimulationService.processContact({
         simulationId: simulationResult.id,
@@ -213,13 +221,13 @@ const ContactForm: React.FC<ContactFormProps> = ({
         tipoAmortizacao: simulationResult.amortizacao,
         quantidadeParcelas: simulationResult.parcelas,
         aceitaPolitica: aceitePrivacidade,
-        utm_source: journey?.utm_source ?? null,
-        utm_medium: journey?.utm_medium ?? null,
-        utm_campaign: journey?.utm_campaign ?? null,
-        utm_term: journey?.utm_term ?? null,
-        utm_content: journey?.utm_content ?? null,
-        landing_page: journey?.landing_page ?? null,
-        referrer: journey?.referrer ?? null,
+        utm_source: trafficOrigin.utm_source,
+        utm_medium: trafficOrigin.utm_medium,
+        utm_campaign: trafficOrigin.utm_campaign,
+        utm_term: trafficOrigin.utm_term,
+        utm_content: trafficOrigin.utm_content,
+        landing_page: trafficOrigin.landing_page,
+        referrer: trafficOrigin.referrer,
         time_on_site:
           typeof journey?.time_on_site === 'number'
             ? Math.max(0, Math.floor(journey.time_on_site))

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -64,6 +64,7 @@ import { ApiMessageAnalysis } from '@/utils/apiMessageAnalyzer';
 import { analyzeLocalMessage } from '@/utils/localMessageAnalyzer';
 import { formatBRL, norm } from '@/utils/formatters';
 import { toast } from '@/components/ui/use-toast';
+import { mergeTrafficOrigin, resolveTrafficOrigin } from '@/utils/trafficOrigin';
 
 const SimulationForm: React.FC = () => {
   const { sessionId, visitorId, trackSimulation, getJourneyData } = useUserJourney();
@@ -161,6 +162,10 @@ const SimulationForm: React.FC = () => {
         typeof window !== 'undefined' ? window.location.href : undefined;
       const fallbackReferrer =
         typeof document !== 'undefined' ? document.referrer || null : undefined;
+      const trafficOrigin = mergeTrafficOrigin(
+        journey,
+        resolveTrafficOrigin(fallbackLandingPage, fallbackReferrer)
+      );
 
       // Preparar dados para o serviço (sem dados pessoais ainda)
       const simulationInput = {
@@ -177,13 +182,13 @@ const SimulationForm: React.FC = () => {
         userAgent: navigator.userAgent,
         ipAddress: undefined,
         isRuralProperty,
-        utmSource: journey ? journey.utm_source ?? null : undefined,
-        utmMedium: journey ? journey.utm_medium ?? null : undefined,
-        utmCampaign: journey ? journey.utm_campaign ?? null : undefined,
-        utmTerm: journey ? journey.utm_term ?? null : undefined,
-        utmContent: journey ? journey.utm_content ?? null : undefined,
-        landingPage: journey?.landing_page ?? fallbackLandingPage,
-        referrer: journey ? journey.referrer ?? null : fallbackReferrer,
+        utmSource: trafficOrigin.utm_source,
+        utmMedium: trafficOrigin.utm_medium,
+        utmCampaign: trafficOrigin.utm_campaign,
+        utmTerm: trafficOrigin.utm_term,
+        utmContent: trafficOrigin.utm_content,
+        landingPage: trafficOrigin.landing_page,
+        referrer: trafficOrigin.referrer,
         timeOnSite:
           typeof journey?.time_on_site === 'number'
             ? Math.max(0, Math.floor(journey.time_on_site))

--- a/src/components/UTMDetails.tsx
+++ b/src/components/UTMDetails.tsx
@@ -4,6 +4,7 @@ import { Button } from './ui/button';
 import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down';
 import type { SessionGroupWithJourney } from '@/services/localSimulationService';
 import { cn } from '@/lib/utils';
+import { mergeTrafficOrigin, resolveTrafficOrigin } from '@/utils/trafficOrigin';
 
 interface UTMDetailsProps {
   visitor: SessionGroupWithJourney;
@@ -107,22 +108,33 @@ const UTMDetails: React.FC<UTMDetailsProps> = ({ visitor }) => {
       return null;
     };
 
-    const utmSource =
-      visitor.utm_source ?? (pickSimulationValue('utm_source') as string | null) ?? getParam('utm_source', 'source');
-    const utmMedium =
-      visitor.utm_medium ?? (pickSimulationValue('utm_medium') as string | null) ?? getParam('utm_medium', 'medium');
-    const utmCampaign =
-      visitor.utm_campaign ??
-      (pickSimulationValue('utm_campaign') as string | null) ??
-      getParam('utm_campaign', 'campaign');
-    const utmTerm =
-      visitor.utm_term ??
-      (pickSimulationValue('utm_term') as string | null) ??
-      getParam('utm_term', 'keyword', 'term');
-    const utmContent =
-      visitor.utm_content ??
-      (pickSimulationValue('utm_content') as string | null) ??
-      getParam('utm_content', 'content');
+    const trafficOrigin = mergeTrafficOrigin(
+      {
+        utm_source: visitor.utm_source ?? (pickSimulationValue('utm_source') as string | null) ?? getParam('utm_source', 'source'),
+        utm_medium: visitor.utm_medium ?? (pickSimulationValue('utm_medium') as string | null) ?? getParam('utm_medium', 'medium'),
+        utm_campaign:
+          visitor.utm_campaign ??
+          (pickSimulationValue('utm_campaign') as string | null) ??
+          getParam('utm_campaign', 'campaign'),
+        utm_term:
+          visitor.utm_term ??
+          (pickSimulationValue('utm_term') as string | null) ??
+          getParam('utm_term', 'keyword', 'term'),
+        utm_content:
+          visitor.utm_content ??
+          (pickSimulationValue('utm_content') as string | null) ??
+          getParam('utm_content', 'content'),
+        landing_page: landingPage ?? null,
+        referrer: referrer ?? null
+      },
+      resolveTrafficOrigin(landingPage, referrer)
+    );
+
+    const utmSource = trafficOrigin.utm_source;
+    const utmMedium = trafficOrigin.utm_medium;
+    const utmCampaign = trafficOrigin.utm_campaign;
+    const utmTerm = trafficOrigin.utm_term;
+    const utmContent = trafficOrigin.utm_content;
 
     const adGroupRaw =
       getParam('utm_adgroup', 'adgroup', 'utm_adset', 'adset', 'ad_group', 'utm_adgroup_id') ?? utmTerm;

--- a/src/hooks/useUserJourney.ts
+++ b/src/hooks/useUserJourney.ts
@@ -26,6 +26,7 @@ import type {
   PageVisit,
   DeviceInfo
 } from '@/lib/supabase';
+import { mergeTrafficOrigin, resolveTrafficOrigin } from '@/utils/trafficOrigin';
 
 // Lazy loader para evitar carregar Supabase na primeira pintura
 type SupabaseApi = typeof import('@/lib/supabase').supabaseApi;
@@ -68,23 +69,6 @@ function getOrCreateVisitorId(): string {
     localStorage.setItem(VISITOR_STORAGE_KEY, id);
   }
   return id;
-}
-
-// Função para extrair UTMs da URL
-function extractUTMParams(url: string = window.location.href): Record<string, string> {
-  const urlObj = new URL(url);
-  const utms: Record<string, string> = {};
-  
-  const utmParams = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'];
-  
-  utmParams.forEach(param => {
-    const value = urlObj.searchParams.get(param);
-    if (value) {
-      utms[param] = value;
-    }
-  });
-  
-  return utms;
 }
 
 // Função para detectar informações do device
@@ -194,7 +178,7 @@ export function useUserJourney(): UserJourneyHook {
     if (sessionId && isTracking) {
       trackPageVisit();
     }
-  }, [location.pathname, sessionId, isTracking]);
+  }, [location.pathname, location.search, sessionId, isTracking]);
 
   // Obter IP após primeira interação ou quando o navegador estiver ocioso
   useEffect(() => {
@@ -240,7 +224,10 @@ export function useUserJourney(): UserJourneyHook {
       } catch (getError: unknown) {
         // Apenas log em desenvolvimento, não desabilitar o tracking ainda
         if (process.env.NODE_ENV === 'development') {
-          console.warn('Could not fetch existing journey:', getError?.message);
+          console.warn(
+            'Could not fetch existing journey:',
+            getError instanceof Error ? getError.message : getError
+          );
         }
         existingJourney = null; // Continuar para tentar criar nova jornada
       }
@@ -248,19 +235,22 @@ export function useUserJourney(): UserJourneyHook {
       if (!existingJourney) {
         // Tentar criar nova jornada apenas se a consulta anterior funcionou
         try {
-          const utms = extractUTMParams();
+          const trafficOrigin = resolveTrafficOrigin(
+            window.location.href,
+            document.referrer || null
+          );
           const deviceInfo = getDeviceInfo();
 
           const newJourney: UserJourneyData = {
             session_id: sessionId,
             visitor_id: visitorId,
-            utm_source: utms.utm_source || null,
-            utm_medium: utms.utm_medium || null,
-            utm_campaign: utms.utm_campaign || null,
-            utm_term: utms.utm_term || null,
-            utm_content: utms.utm_content || null,
-            referrer: document.referrer || 'direct',
-            landing_page: window.location.href,
+            utm_source: trafficOrigin.utm_source,
+            utm_medium: trafficOrigin.utm_medium,
+            utm_campaign: trafficOrigin.utm_campaign,
+            utm_term: trafficOrigin.utm_term,
+            utm_content: trafficOrigin.utm_content,
+            referrer: trafficOrigin.referrer,
+            landing_page: trafficOrigin.landing_page,
             pages_visited: [],
             time_on_site: 0,
             device_info: deviceInfo,
@@ -284,6 +274,36 @@ export function useUserJourney(): UserJourneyHook {
           }
           setIsTracking(false);
           return;
+        }
+      } else {
+        const trafficOrigin = resolveTrafficOrigin(
+          window.location.href,
+          document.referrer || existingJourney.referrer || null
+        );
+        const mergedTrafficOrigin = mergeTrafficOrigin(existingJourney, trafficOrigin);
+        const missingTrafficOrigin = Object.entries(mergedTrafficOrigin).some(([key, value]) => {
+          const existingValue = existingJourney?.[key as keyof UserJourneyData];
+          return (existingValue === undefined || existingValue === null || existingValue === '') && value !== null;
+        });
+
+        if (missingTrafficOrigin) {
+          try {
+            const updatePayload: Partial<UserJourneyData> = {
+              utm_source: mergedTrafficOrigin.utm_source,
+              utm_medium: mergedTrafficOrigin.utm_medium,
+              utm_campaign: mergedTrafficOrigin.utm_campaign,
+              utm_term: mergedTrafficOrigin.utm_term,
+              utm_content: mergedTrafficOrigin.utm_content,
+              landing_page: mergedTrafficOrigin.landing_page,
+              referrer: mergedTrafficOrigin.referrer
+            };
+            await supabaseApi.updateUserJourney(sessionId, updatePayload);
+            existingJourney = { ...existingJourney, ...updatePayload };
+          } catch (updateError) {
+            if (process.env.NODE_ENV === 'development') {
+              console.warn('Could not enrich existing journey origin:', updateError);
+            }
+          }
         }
       }
       

--- a/src/utils/__tests__/trafficOrigin.test.ts
+++ b/src/utils/__tests__/trafficOrigin.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { mergeTrafficOrigin, resolveTrafficOrigin } from '../trafficOrigin';
+
+describe('trafficOrigin', () => {
+  it('preserves explicit UTM values from the landing URL', () => {
+    const origin = resolveTrafficOrigin(
+      'https://libracredito.com.br/?utm_source=meta&utm_medium=cpc&utm_campaign=campanha&utm_term=grupo&utm_content=anuncio',
+      null
+    );
+
+    expect(origin).toMatchObject({
+      utm_source: 'meta',
+      utm_medium: 'cpc',
+      utm_campaign: 'campanha',
+      utm_term: 'grupo',
+      utm_content: 'anuncio'
+    });
+  });
+
+  it('infers paid traffic when only a click id is present', () => {
+    const origin = resolveTrafficOrigin('https://libracredito.com.br/?gclid=abc123', null);
+
+    expect(origin.utm_source).toBe('google');
+    expect(origin.utm_medium).toBe('cpc');
+  });
+
+  it('falls back to referrer or direct so admin leads do not show blank origin', () => {
+    expect(resolveTrafficOrigin('https://libracredito.com.br/', 'https://www.instagram.com/').utm_source).toBe(
+      'instagram'
+    );
+    expect(resolveTrafficOrigin('https://libracredito.com.br/', '').utm_source).toBe('direct');
+  });
+
+  it('does not overwrite existing journey attribution when merging fallbacks', () => {
+    const merged = mergeTrafficOrigin(
+      { utm_source: 'google', utm_medium: 'cpc', landing_page: 'https://old.test' },
+      resolveTrafficOrigin('https://new.test/?fbclid=1', 'https://facebook.com')
+    );
+
+    expect(merged.utm_source).toBe('google');
+    expect(merged.utm_medium).toBe('cpc');
+    expect(merged.landing_page).toBe('https://old.test');
+  });
+});

--- a/src/utils/trafficOrigin.ts
+++ b/src/utils/trafficOrigin.ts
@@ -1,0 +1,130 @@
+export interface TrafficOriginData {
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  utm_term: string | null;
+  utm_content: string | null;
+  landing_page: string | null;
+  referrer: string | null;
+}
+
+type TrafficParams = Pick<
+  TrafficOriginData,
+  'utm_source' | 'utm_medium' | 'utm_campaign' | 'utm_term' | 'utm_content'
+>;
+
+const cleanValue = (value?: string | null): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const getParam = (searchParams: URLSearchParams, ...keys: string[]): string | null => {
+  for (const key of keys) {
+    const value = cleanValue(searchParams.get(key));
+    if (value) return value;
+  }
+  return null;
+};
+
+const parseUrl = (url?: string | null): URL | null => {
+  if (!url) return null;
+
+  try {
+    return new URL(url);
+  } catch {
+    try {
+      return new URL(url, 'https://libra.local');
+    } catch {
+      return null;
+    }
+  }
+};
+
+const inferFromClickId = (searchParams: URLSearchParams): Partial<TrafficParams> => {
+  if (getParam(searchParams, 'gclid', 'gbraid', 'wbraid')) {
+    return { utm_source: 'google', utm_medium: 'cpc' };
+  }
+
+  if (getParam(searchParams, 'fbclid')) {
+    return { utm_source: 'facebook', utm_medium: 'social' };
+  }
+
+  if (getParam(searchParams, 'msclkid')) {
+    return { utm_source: 'bing', utm_medium: 'cpc' };
+  }
+
+  if (getParam(searchParams, 'ttclid')) {
+    return { utm_source: 'tiktok', utm_medium: 'social' };
+  }
+
+  if (getParam(searchParams, 'li_fat_id')) {
+    return { utm_source: 'linkedin', utm_medium: 'social' };
+  }
+
+  return {};
+};
+
+const inferFromReferrer = (referrer?: string | null): Partial<TrafficParams> => {
+  const parsed = parseUrl(referrer);
+  const hostname = parsed?.hostname.replace(/^www\./, '').toLowerCase();
+
+  if (!hostname) {
+    return { utm_source: 'direct', utm_medium: 'none' };
+  }
+
+  if (hostname.includes('google.')) return { utm_source: 'google', utm_medium: 'organic' };
+  if (hostname.includes('bing.')) return { utm_source: 'bing', utm_medium: 'organic' };
+  if (hostname.includes('yahoo.')) return { utm_source: 'yahoo', utm_medium: 'organic' };
+  if (hostname.includes('facebook.') || hostname === 'fb.com' || hostname === 'm.facebook.com') {
+    return { utm_source: 'facebook', utm_medium: 'social' };
+  }
+  if (hostname.includes('instagram.')) return { utm_source: 'instagram', utm_medium: 'social' };
+  if (hostname.includes('linkedin.')) return { utm_source: 'linkedin', utm_medium: 'social' };
+  if (hostname.includes('tiktok.')) return { utm_source: 'tiktok', utm_medium: 'social' };
+  if (hostname.includes('youtube.')) return { utm_source: 'youtube', utm_medium: 'social' };
+
+  return { utm_source: hostname, utm_medium: 'referral' };
+};
+
+export const resolveTrafficOrigin = (
+  url?: string | null,
+  referrer?: string | null
+): TrafficOriginData => {
+  const parsed = parseUrl(url);
+  const searchParams = parsed?.searchParams ?? new URLSearchParams();
+  const inferredByClickId = inferFromClickId(searchParams);
+  const inferredByReferrer = inferFromReferrer(referrer);
+
+  const utm_source =
+    getParam(searchParams, 'utm_source', 'source') ??
+    cleanValue(inferredByClickId.utm_source) ??
+    cleanValue(inferredByReferrer.utm_source);
+  const utm_medium =
+    getParam(searchParams, 'utm_medium', 'medium') ??
+    cleanValue(inferredByClickId.utm_medium) ??
+    cleanValue(inferredByReferrer.utm_medium);
+
+  return {
+    utm_source,
+    utm_medium,
+    utm_campaign: getParam(searchParams, 'utm_campaign', 'campaign', 'campaign_id'),
+    utm_term: getParam(searchParams, 'utm_term', 'keyword', 'term', 'adgroup', 'adset'),
+    utm_content: getParam(searchParams, 'utm_content', 'content', 'creative', 'ad'),
+    landing_page: cleanValue(url) ?? null,
+    referrer: cleanValue(referrer) ?? (utm_source === 'direct' ? 'direct' : null)
+  };
+};
+
+export const mergeTrafficOrigin = <T extends Partial<TrafficOriginData>>(
+  current: T | null | undefined,
+  fallback: TrafficOriginData
+): TrafficOriginData => ({
+  utm_source: cleanValue(current?.utm_source) ?? fallback.utm_source,
+  utm_medium: cleanValue(current?.utm_medium) ?? fallback.utm_medium,
+  utm_campaign: cleanValue(current?.utm_campaign) ?? fallback.utm_campaign,
+  utm_term: cleanValue(current?.utm_term) ?? fallback.utm_term,
+  utm_content: cleanValue(current?.utm_content) ?? fallback.utm_content,
+  landing_page: cleanValue(current?.landing_page) ?? fallback.landing_page,
+  referrer: cleanValue(current?.referrer) ?? fallback.referrer
+});


### PR DESCRIPTION
### Motivation
- Evitar que leads no admin apareçam sem origem quando não há UTMs explícitas, cobrindo casos com click‑ids (gclid/fbclid/etc.), referrers e fallback direto.
- Preencher/enriquecer a jornada do usuário na criação/atualização para preservar melhor a atribuição antes do envio de simulação/contato.

### Description
- Adiciona utilitário central `src/utils/trafficOrigin.ts` com `resolveTrafficOrigin` e `mergeTrafficOrigin` que extrai UTMs, infere origem por click‑ids e referrer e fornece fallback `direct/none`.
- Atualiza `useUserJourney` para usar o resolvedor ao criar novas jornadas e para enriquecer jornadas existentes quando faltarem campos de origem, e também passa a reagir a mudanças na query string (`location.search`).
- Faz `SimulationForm` e `ContactForm` usarem `mergeTrafficOrigin` antes de enviar dados, garantindo que `utm_*`, `landing_page` e `referrer` não fiquem em branco quando houver pistas na URL ou referrer.
- Atualiza `UTMDetails` (admin) para inferir origem a partir de landing page/referrer quando os campos UTM estiverem ausentes e adiciona o teste `src/utils/__tests__/trafficOrigin.test.ts` cobrindo UTMs explícitas, click ids, referrer/direct e merge sem sobrescrever atribuição existente.

### Testing
- Executado `npm run typecheck` e passou com sucesso.
- Executado `npm test -- src/utils/__tests__/trafficOrigin.test.ts` e todos os testes passaram (`4 tests`).
- Executado `npm run build` com sucesso; durante `generate:sitemap` o processo fez fallback por falha de fetch no Supabase, mas o build final foi gerado.
- Executado `npm run lint` e falhou devido a problemas pré‑existentes no repositório não relacionados a esta alteração (ex.: `scripts/export-hero.tsx`, `src/components/GlobalTracker.tsx`, `src/components/LoanSimulator.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a048ee3aab8832da02253c4ad6c1ff8)