### PR TITLE
Enviar 'Campanha & Origem' para Ploomes como campo custom (opt‑in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ VITE_API_BASE_URL=https://api.exemplo.com
 # Ploomes CRM Integration
 VITE_PLOOMES_API_KEY=your_ploomes_api_key_here
 VITE_PLOOMES_USER_KEY=your_ploomes_user_key_here
+# Mantém campos customizados desativados por padrão para proteger a integração crítica.
+# Quando validado no ambiente de homologação, use true para enviar Campanha & Origem para o campo "Link de origem".
+VITE_PLOOMES_ENABLE_CUSTOM_FIELDS=false
+VITE_PLOOMES_ORIGIN_FIELD_KEY=deal_4E9D160A-197F-469B-B1C7-228C199694F3
 
 # Webhook Configuration
 # URL para onde os dados da simulação finalizada serão enviados

--- a/src/services/__tests__/ploomesService.test.ts
+++ b/src/services/__tests__/ploomesService.test.ts
@@ -1,44 +1,55 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import PloomesService from '../ploomesService';
+import { PLOOMES_ORIGIN_FIELD } from '@/utils/ploomesOriginLink';
 
 afterEach(() => {
   vi.restoreAllMocks();
-  // @ts-ignore
-  delete global.fetch;
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
-describe('PloomesService', () => {
-  it('sends core payload and UTM params', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ status: true, msg: '', retorno: { nomeCompleto: '', email: '' } })
-    });
-    // @ts-ignore
-    global.fetch = fetchMock;
+const validProposal = {
+  cidade: 'São Paulo',
+  valorEmprestimo: 10000,
+  valorImovel: 20000,
+  parcelas: 36,
+  tipoAmortizacao: 'PRICE',
+  valorParcela: 500,
+  nomeCompleto: 'John Doe',
+  email: 'john@example.com',
+  telefone: '11999999999',
+  imovelProprio: 'proprio' as const,
+  utm_source: 'google',
+  utm_medium: 'cpc',
+  utm_campaign: 'camp',
+  utm_term: 'term',
+  utm_content: 'content',
+  landing_page: 'https://example.com',
+  referrer: 'https://referrer.com'
+};
 
-    await PloomesService.cadastrarProposta({
-      cidade: 'São Paulo',
-      valorEmprestimo: 10000,
-      valorImovel: 20000,
-      parcelas: 36,
-      tipoAmortizacao: 'PRICE',
-      valorParcela: 500,
-      nomeCompleto: 'John Doe',
-      email: 'john@example.com',
-      telefone: '11999999999',
-      imovelProprio: 'proprio',
-      utm_source: 'google',
-      utm_medium: 'cpc',
-      utm_campaign: 'camp',
-      utm_term: 'term',
-      utm_content: 'content',
-      landing_page: 'https://example.com',
-      referrer: 'https://referrer.com'
-    });
+const mockSuccessfulFetch = () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ status: true, msg: '', retorno: { nomeCompleto: '', email: '' } })
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const getRequestBody = (fetchMock: ReturnType<typeof mockSuccessfulFetch>) => {
+  const requestOptions = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+  return JSON.parse(String(requestOptions?.body));
+};
+
+describe('PloomesService', () => {
+  it('sends core payload and UTM params without custom fields by default', async () => {
+    const fetchMock = mockSuccessfulFetch();
+
+    await PloomesService.cadastrarProposta(validProposal);
 
     expect(fetchMock).toHaveBeenCalled();
-    const [, options] = fetchMock.mock.calls[0];
-    const body = JSON.parse((options as any).body);
+    const body = getRequestBody(fetchMock);
 
     expect(body).toMatchObject({
       utm_source: 'google',
@@ -54,5 +65,23 @@ describe('PloomesService', () => {
     expect(body['Link de origem \n']).toBeUndefined();
     expect(body.linkOrigem).toBeUndefined();
     expect(body.link_origem).toBeUndefined();
+    expect(body.OtherProperties).toBeUndefined();
+  });
+
+  it('sends the Ploomes deal custom field for Link de origem when custom fields are enabled', async () => {
+    vi.stubEnv('VITE_PLOOMES_ENABLE_CUSTOM_FIELDS', 'true');
+    const fetchMock = mockSuccessfulFetch();
+
+    await PloomesService.cadastrarProposta(validProposal);
+
+    const body = getRequestBody(fetchMock);
+
+    expect(body[PLOOMES_ORIGIN_FIELD.key]).toContain('Origem: google / cpc');
+    expect(body.OtherProperties).toEqual([
+      {
+        FieldKey: PLOOMES_ORIGIN_FIELD.key,
+        StringValue: body[PLOOMES_ORIGIN_FIELD.key]
+      }
+    ]);
   });
 });

--- a/src/services/localSimulationService.ts
+++ b/src/services/localSimulationService.ts
@@ -17,7 +17,11 @@
 import { getAlertWebhookUrl, getSecondaryWebhookUrl } from '@/lib/env';
 import { WebhookService } from '@/services/webhookService';
 import { validateEmail, validatePhone } from '@/utils/validations';
-import { buildPloomesOriginLink } from '@/utils/ploomesOriginLink';
+import {
+  PLOOMES_ORIGIN_FIELD,
+  buildPloomesOriginLink,
+  buildPloomesOriginOtherProperty
+} from '@/utils/ploomesOriginLink';
 import {
   SIMULATION_PLACEHOLDER_EMAIL,
   SIMULATION_PLACEHOLDER_NAME,
@@ -163,10 +167,10 @@ const pickBetterJourney = (
 };
 
 // Classe principal do serviço local
-const PLOOMES_ORIGIN_FIELD_KEY =
-  (import.meta.env.VITE_PLOOMES_ORIGIN_FIELD_KEY as string | undefined)?.trim() || null;
-const PLOOMES_STAGE_ID = Number(import.meta.env.VITE_PLOOMES_STAGE_ID || 0) || null;
-const PLOOMES_ENABLE_CUSTOM_FIELDS =
+const getPloomesOriginFieldKey = (): string =>
+  (import.meta.env.VITE_PLOOMES_ORIGIN_FIELD_KEY as string | undefined)?.trim() || PLOOMES_ORIGIN_FIELD.key;
+const getPloomesStageId = (): number | null => Number(import.meta.env.VITE_PLOOMES_STAGE_ID || 0) || null;
+const arePloomesCustomFieldsEnabled = (): boolean =>
   String(import.meta.env.VITE_PLOOMES_ENABLE_CUSTOM_FIELDS || '').toLowerCase() === 'true';
 
 export class LocalSimulationService {
@@ -569,15 +573,16 @@ export class LocalSimulationService {
       }
 
       // Preparar payload para API Ploomes com validação de tipos
-      const originLink = buildPloomesOriginLink({
-        utm_source: input.utm_source || null,
-        utm_medium: input.utm_medium || null,
-        utm_campaign: input.utm_campaign || null,
-        utm_term: input.utm_term || null,
-        utm_content: input.utm_content || null,
-        landing_page: input.landing_page || null,
-        referrer: input.referrer || null
-      });
+      const attribution = {
+        utm_source: input.utm_source || simulationData?.utm_source || null,
+        utm_medium: input.utm_medium || simulationData?.utm_medium || null,
+        utm_campaign: input.utm_campaign || simulationData?.utm_campaign || null,
+        utm_term: input.utm_term || simulationData?.utm_term || null,
+        utm_content: input.utm_content || simulationData?.utm_content || null,
+        landing_page: input.landing_page || simulationData?.landing_page || null,
+        referrer: input.referrer || simulationData?.referrer || null
+      };
+      const originLink = buildPloomesOriginLink(attribution);
 
       const ploomesPayload = {
         cidade: input.cidade?.trim() || simulationData?.cidade || 'Não informado',
@@ -591,28 +596,30 @@ export class LocalSimulationService {
         telefone: sanitizedPhone,
         imovelProprio: input.imovelProprio === 'proprio' ? 'Imóvel próprio' : 'Imóvel de terceiro',
         aceitaPolitica: Boolean(input.aceitaPolitica),
-        utm_source: input.utm_source || null,
-        utm_medium: input.utm_medium || null,
-        utm_campaign: input.utm_campaign || null,
-        utm_term: input.utm_term || null,
-        utm_content: input.utm_content || null,
-        landing_page: input.landing_page || null,
-        referrer: input.referrer || null
+        utm_source: attribution.utm_source,
+        utm_medium: attribution.utm_medium,
+        utm_campaign: attribution.utm_campaign,
+        utm_term: attribution.utm_term,
+        utm_content: attribution.utm_content,
+        landing_page: attribution.landing_page,
+        referrer: attribution.referrer
       };
 
 
-      if (PLOOMES_ENABLE_CUSTOM_FIELDS) {
-        (ploomesPayload as Record<string, unknown>)['Link de origem'] = originLink;
-        (ploomesPayload as Record<string, unknown>)['Link de origem \n'] = originLink;
-        (ploomesPayload as Record<string, unknown>).linkOrigem = originLink;
-        (ploomesPayload as Record<string, unknown>).link_origem = originLink;
+      if (arePloomesCustomFieldsEnabled()) {
+        const originFieldKey = getPloomesOriginFieldKey();
+        const ploomesCustomPayload = ploomesPayload as Record<string, unknown>;
 
-        if (PLOOMES_ORIGIN_FIELD_KEY) {
-          (ploomesPayload as Record<string, unknown>)[PLOOMES_ORIGIN_FIELD_KEY] = originLink;
-        }
+        ploomesCustomPayload['Link de origem'] = originLink;
+        ploomesCustomPayload['Link de origem \n'] = originLink;
+        ploomesCustomPayload.linkOrigem = originLink;
+        ploomesCustomPayload.link_origem = originLink;
+        ploomesCustomPayload[originFieldKey] = originLink;
+        ploomesCustomPayload.OtherProperties = [buildPloomesOriginOtherProperty(originLink, originFieldKey)];
 
-        if (PLOOMES_STAGE_ID) {
-          (ploomesPayload as Record<string, unknown>).StageId = PLOOMES_STAGE_ID;
+        const stageId = getPloomesStageId();
+        if (stageId) {
+          ploomesCustomPayload.StageId = stageId;
         }
       }
 

--- a/src/services/ploomesService.ts
+++ b/src/services/ploomesService.ts
@@ -18,7 +18,12 @@
  * - Bloqueio de duplicidade: 7 dias por email
  */
 
-import { buildPloomesOriginLink } from '@/utils/ploomesOriginLink';
+import {
+  PLOOMES_ORIGIN_FIELD,
+  buildPloomesOriginLink,
+  buildPloomesOriginOtherProperty,
+  type PloomesOriginOtherProperty
+} from '@/utils/ploomesOriginLink';
 
 // Interface para payload do Ploomes
 export interface PloomesPayload {
@@ -45,6 +50,7 @@ export interface PloomesPayload {
   'Link de origem \n'?: string;
   linkOrigem?: string;
   link_origem?: string;
+  OtherProperties?: PloomesOriginOtherProperty[];
 }
 
 // Interface para resposta do Ploomes
@@ -72,12 +78,17 @@ const IMOVEL_MAP: Record<string, 'Imóvel próprio' | 'Imóvel de terceiro'> = {
 
 export class PloomesService {
   private static readonly API_URL = 'https://api-ploomes.vercel.app/cadastro/online/env';
-  private static readonly ORIGIN_FIELD_KEY =
-    (import.meta.env.VITE_PLOOMES_ORIGIN_FIELD_KEY as string | undefined)?.trim() || null;
-  private static readonly STAGE_ID =
-    Number(import.meta.env.VITE_PLOOMES_STAGE_ID || 0) || null;
-  private static readonly ENABLE_CUSTOM_FIELDS =
-    String(import.meta.env.VITE_PLOOMES_ENABLE_CUSTOM_FIELDS || '').toLowerCase() === 'true';
+  private static get originFieldKey(): string {
+    return (import.meta.env.VITE_PLOOMES_ORIGIN_FIELD_KEY as string | undefined)?.trim() || PLOOMES_ORIGIN_FIELD.key;
+  }
+
+  private static get stageId(): number | null {
+    return Number(import.meta.env.VITE_PLOOMES_STAGE_ID || 0) || null;
+  }
+
+  private static get enableCustomFields(): boolean {
+    return String(import.meta.env.VITE_PLOOMES_ENABLE_CUSTOM_FIELDS || '').toLowerCase() === 'true';
+  }
   
   /**
    * Cadastra uma proposta no Ploomes
@@ -137,18 +148,16 @@ export class PloomesService {
       };
       
 
-      if (this.ENABLE_CUSTOM_FIELDS) {
+      if (this.enableCustomFields) {
         payload['Link de origem'] = originLink;
         payload['Link de origem \n'] = originLink;
         payload.linkOrigem = originLink;
         payload.link_origem = originLink;
+        payload[this.originFieldKey] = originLink;
+        payload.OtherProperties = [buildPloomesOriginOtherProperty(originLink, this.originFieldKey)];
 
-        if (this.ORIGIN_FIELD_KEY) {
-          payload[this.ORIGIN_FIELD_KEY] = originLink;
-        }
-
-        if (this.STAGE_ID) {
-          payload.StageId = this.STAGE_ID;
+        if (this.stageId) {
+          payload.StageId = this.stageId;
         }
       }
 

--- a/src/utils/__tests__/ploomesOriginLink.test.ts
+++ b/src/utils/__tests__/ploomesOriginLink.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PLOOMES_ORIGIN_FIELD,
+  buildPloomesOriginLink,
+  buildPloomesOriginOtherProperty
+} from '../ploomesOriginLink';
+
+describe('ploomesOriginLink', () => {
+  it('formats admin Campaign & Origin attribution into a compact origin link', () => {
+    const originLink = buildPloomesOriginLink({
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'financiamento maio',
+      utm_term: 'grupo-a',
+      utm_content: 'criativo-1',
+      landing_page: 'https://libracredito.com.br/simulacao',
+      referrer: 'https://google.com'
+    });
+
+    expect(originLink).toContain('Origem: google / cpc');
+    expect(originLink).toContain('Campanha: financiamento maio');
+    expect(originLink).toContain('Grupo: grupo-a');
+    expect(originLink).toContain('Anúncio: criativo-1');
+  });
+
+  it('builds the exact Ploomes OtherProperties entry for Link de origem', () => {
+    expect(buildPloomesOriginOtherProperty('Origem: google / cpc')).toEqual({
+      FieldKey: PLOOMES_ORIGIN_FIELD.key,
+      StringValue: 'Origem: google / cpc'
+    });
+  });
+});

--- a/src/utils/ploomesOriginLink.ts
+++ b/src/utils/ploomesOriginLink.ts
@@ -1,3 +1,9 @@
+export const PLOOMES_ORIGIN_FIELD = {
+  id: 80002454,
+  key: 'deal_4E9D160A-197F-469B-B1C7-228C199694F3',
+  name: 'Link de origem'
+} as const;
+
 export interface PloomesOriginFields {
   utm_source?: string | null;
   utm_medium?: string | null;
@@ -6,6 +12,11 @@ export interface PloomesOriginFields {
   utm_content?: string | null;
   landing_page?: string | null;
   referrer?: string | null;
+}
+
+export interface PloomesOriginOtherProperty {
+  FieldKey: string;
+  StringValue: string;
 }
 
 const MAX_PLOOMES_ORIGIN_LENGTH = 250;
@@ -60,3 +71,11 @@ export const buildPloomesOriginLink = (fields: PloomesOriginFields): string => {
 
   return truncateToLimit(compact);
 };
+
+export const buildPloomesOriginOtherProperty = (
+  originLink: string,
+  fieldKey = PLOOMES_ORIGIN_FIELD.key
+): PloomesOriginOtherProperty => ({
+  FieldKey: normalize(fieldKey) ?? PLOOMES_ORIGIN_FIELD.key,
+  StringValue: originLink
+});


### PR DESCRIPTION
### Motivation
- Permitir enviar ao Ploomes o valor exibido em Admin > “Campanha & Origem” para o campo customizado "Link de origem" (FieldKey fornecido) sem quebrar a integração existente. 
- Manter o envio protegido para evitar impactos na integração crítica, deixando o comportamento desativado por padrão e controlado por variável de ambiente.

### Description
- Adiciona constante `PLOOMES_ORIGIN_FIELD` (Id: `80002454`, Key: `deal_4E9D160A-197F-469B-B1C7-228C199694F3`, Name: `Link de origem`) e o helper `buildPloomesOriginOtherProperty` que monta o objeto `OtherProperties` esperado pela API do Ploomes.
- Atualiza `src/services/ploomesService.ts` para incluir o valor formatado de Campanha & Origem no payload quando `VITE_PLOOMES_ENABLE_CUSTOM_FIELDS=true`, incluindo também `OtherProperties` e a key técnica (`deal_...`) preservando os campos legados para compatibilidade.
- Atualiza `src/services/localSimulationService.ts` para reaproveitar a atribuição (UTMs / landing_page / referrer) salva na simulação quando o formulário não fornecer esses campos, e inserir o `OtherProperties` no payload quando a flag de custom fields estiver habilitada.
- Registra as mudanças de configuração em `.env.example` (flag `VITE_PLOOMES_ENABLE_CUSTOM_FIELDS=false` por padrão e `VITE_PLOOMES_ORIGIN_FIELD_KEY` com o Key fornecido) e adiciona testes unitários que cobrem a formatação e envio condicional do campo customizado.

### Testing
- Executados os testes unitários focados adicionados/alterados com `vitest`: `src/services/__tests__/ploomesService.test.ts` e `src/utils/__tests__/ploomesOriginLink.test.ts`; todos os testes relacionados passaram (4 passed).
- `npm run typecheck` (TS compile check) passou sem erros.
- `npx eslint` nos arquivos alterados/tests passou sem avisos para os arquivos verificados; o `npm run lint` completo falhou por erros preexistentes em arquivos fora deste escopo (não relacionados a esta alteração).
- `npm run build` completou com sucesso; durante o `prebuild` houve avisos de `fetch failed` ao consultar Supabase no ambiente de CI (fallbacks aplicados) mas o build final passou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b57700b0832db4245e578221ead8)