### PR TITLE
Add WhatsApp redirect landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ const SimulacaoLocal = lazy(() => import("./pages/SimulacaoLocal"));
 const Confirmacao = lazy(() => import("./pages/Confirmacao"));
 const Sucesso = lazy(() => import("./pages/Sucesso"));
 const Atendimento = lazy(() => import("./pages/Atendimento"));
+const WhatsAppRedirect = lazy(() => import("./pages/WhatsAppRedirect"));
 
 let devRoutes = null;
 
@@ -121,6 +122,7 @@ const App = () => {
                 <Route path="/confirmacao" element={<Confirmacao />} />
                 <Route path="/confirmação" element={<Confirmacao />} />
                 <Route path="/atendimento" element={<Atendimento />} />
+                <Route path="/vaunossowhatsapp" element={<WhatsAppRedirect />} />
                 <Route path="/sucesso" element={<Sucesso />} />
                 <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,7 +122,7 @@ const App = () => {
                 <Route path="/confirmacao" element={<Confirmacao />} />
                 <Route path="/confirmação" element={<Confirmacao />} />
                 <Route path="/atendimento" element={<Atendimento />} />
-                <Route path="/vaunossowhatsapp" element={<WhatsAppRedirect />} />
+                <Route path="/WPP-LIBRA" element={<WhatsAppRedirect />} />
                 <Route path="/sucesso" element={<Sucesso />} />
                 <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,7 +122,7 @@ const App = () => {
                 <Route path="/confirmacao" element={<Confirmacao />} />
                 <Route path="/confirmação" element={<Confirmacao />} />
                 <Route path="/atendimento" element={<Atendimento />} />
-                <Route path="/WPP-LIBRA" element={<WhatsAppRedirect />} />
+                <Route path="/WPP" element={<WhatsAppRedirect />} />
                 <Route path="/sucesso" element={<Sucesso />} />
                 <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/AppServer.tsx
+++ b/src/AppServer.tsx
@@ -108,7 +108,7 @@ const AppServer: React.FC<AppServerProps> = ({ url, initialData = {}, helmetCont
                 <Route path="/wizard-test" element={<SimpleWizardTest />} />
                 <Route path="/confirmacao" element={<Confirmacao />} />
                 <Route path="/atendimento" element={<Atendimento />} />
-                <Route path="/vaunossowhatsapp" element={<WhatsAppRedirect />} />
+                <Route path="/WPP-LIBRA" element={<WhatsAppRedirect />} />
                 <Route path="/sucesso" element={<Sucesso />} />
                 <Route path="/home2" element={<Home2 />} />
                 <Route path="*" element={<NotFound />} />

--- a/src/AppServer.tsx
+++ b/src/AppServer.tsx
@@ -108,7 +108,7 @@ const AppServer: React.FC<AppServerProps> = ({ url, initialData = {}, helmetCont
                 <Route path="/wizard-test" element={<SimpleWizardTest />} />
                 <Route path="/confirmacao" element={<Confirmacao />} />
                 <Route path="/atendimento" element={<Atendimento />} />
-                <Route path="/WPP-LIBRA" element={<WhatsAppRedirect />} />
+                <Route path="/WPP" element={<WhatsAppRedirect />} />
                 <Route path="/sucesso" element={<Sucesso />} />
                 <Route path="/home2" element={<Home2 />} />
                 <Route path="*" element={<NotFound />} />

--- a/src/AppServer.tsx
+++ b/src/AppServer.tsx
@@ -38,6 +38,7 @@ const TestWebhook = lazy(() => import("../temp-files/test-pages/TestWebhook"));
 const Confirmacao = lazy(() => import("./pages/Confirmacao"));
 const Sucesso = lazy(() => import("./pages/Sucesso"));
 const Atendimento = lazy(() => import("./pages/Atendimento"));
+const WhatsAppRedirect = lazy(() => import("./pages/WhatsAppRedirect"));
 
 const Loading = () => (
   <div className="min-h-screen flex items-center justify-center bg-gray-50">
@@ -107,6 +108,7 @@ const AppServer: React.FC<AppServerProps> = ({ url, initialData = {}, helmetCont
                 <Route path="/wizard-test" element={<SimpleWizardTest />} />
                 <Route path="/confirmacao" element={<Confirmacao />} />
                 <Route path="/atendimento" element={<Atendimento />} />
+                <Route path="/vaunossowhatsapp" element={<WhatsAppRedirect />} />
                 <Route path="/sucesso" element={<Sucesso />} />
                 <Route path="/home2" element={<Home2 />} />
                 <Route path="*" element={<NotFound />} />

--- a/src/pages/WhatsAppRedirect.tsx
+++ b/src/pages/WhatsAppRedirect.tsx
@@ -3,7 +3,7 @@ import MobileLayout from '@/components/MobileLayout';
 import { setMetaTag } from '@/utils/seoMeta';
 
 const WHATSAPP_REDIRECT_DELAY_MS = 1000;
-const WHATSAPP_LOCAL_PHONE_NUMBER = '16997207767';
+const WHATSAPP_LOCAL_PHONE_NUMBER = '16996064979';
 const WHATSAPP_PHONE_NUMBER = `55${WHATSAPP_LOCAL_PHONE_NUMBER}`;
 const WHATSAPP_MESSAGE = 'Olá Libra Crédito, quero iniciar meu atendimento!';
 const WHATSAPP_URL = `https://wa.me/${WHATSAPP_PHONE_NUMBER}?text=${encodeURIComponent(WHATSAPP_MESSAGE)}`;

--- a/src/pages/WhatsAppRedirect.tsx
+++ b/src/pages/WhatsAppRedirect.tsx
@@ -3,7 +3,8 @@ import MobileLayout from '@/components/MobileLayout';
 import { setMetaTag } from '@/utils/seoMeta';
 
 const WHATSAPP_REDIRECT_DELAY_MS = 1000;
-const WHATSAPP_PHONE_NUMBER = '5516997207767';
+const WHATSAPP_LOCAL_PHONE_NUMBER = '16997207767';
+const WHATSAPP_PHONE_NUMBER = `55${WHATSAPP_LOCAL_PHONE_NUMBER}`;
 const WHATSAPP_MESSAGE = 'Olá Libra Crédito, quero iniciar meu atendimento!';
 const WHATSAPP_URL = `https://wa.me/${WHATSAPP_PHONE_NUMBER}?text=${encodeURIComponent(WHATSAPP_MESSAGE)}`;
 

--- a/src/pages/WhatsAppRedirect.tsx
+++ b/src/pages/WhatsAppRedirect.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect } from 'react';
+import MobileLayout from '@/components/MobileLayout';
+import { setMetaTag } from '@/utils/seoMeta';
+
+const WHATSAPP_REDIRECT_DELAY_MS = 1000;
+const WHATSAPP_PHONE_NUMBER = '5516997207767';
+const WHATSAPP_MESSAGE = 'Olá Libra Crédito, quero iniciar meu atendimento!';
+const WHATSAPP_URL = `https://wa.me/${WHATSAPP_PHONE_NUMBER}?text=${encodeURIComponent(WHATSAPP_MESSAGE)}`;
+
+const WhatsAppRedirect = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+    document.title = 'Redirecionando para o WhatsApp | Libra Crédito';
+
+    const metaDescription = document.querySelector('meta[name="description"]');
+    if (metaDescription) {
+      metaDescription.setAttribute(
+        'content',
+        'Você será redirecionado para iniciar seu atendimento no WhatsApp da Libra Crédito.'
+      );
+    }
+
+    const cleanupRobots = setMetaTag('robots', 'noindex,follow');
+    const timer = window.setTimeout(() => {
+      window.location.replace(WHATSAPP_URL);
+    }, WHATSAPP_REDIRECT_DELAY_MS);
+
+    return () => {
+      cleanupRobots();
+      window.clearTimeout(timer);
+    };
+  }, []);
+
+  return (
+    <MobileLayout>
+      <main className="flex min-h-[60vh] flex-col items-center justify-center bg-white px-4 py-12 text-center">
+        <div className="max-w-md space-y-5 rounded-3xl border border-green-100 bg-green-50/80 px-6 py-8 shadow-sm">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-green-600 text-2xl text-white">
+            💬
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-2xl font-bold text-libra-navy">Estamos te levando ao WhatsApp</h1>
+            <p className="text-base text-gray-700">
+              Aguarde um instante. Você será redirecionado automaticamente para iniciar seu atendimento com a Libra Crédito.
+            </p>
+          </div>
+          <a
+            className="inline-flex items-center justify-center rounded-full bg-green-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
+            href={WHATSAPP_URL}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Abrir WhatsApp agora
+          </a>
+          <p className="text-xs text-gray-500">Redirecionamento automático em aproximadamente 1 segundo.</p>
+        </div>
+      </main>
+    </MobileLayout>
+  );
+};
+
+export default WhatsAppRedirect;


### PR DESCRIPTION
### Motivation
- Criar uma página intermediária que aguarde ~1s e redirecione automaticamente o usuário para um link do WhatsApp com mensagem pré-preenchida, atendendo ao requisito de um URL curto como `/vaunossowhatsapp`.
- Fornecer uma alternativa visível (botão) caso o redirecionamento automático seja bloqueado pelo navegador.

### Description
- Adicionada a nova página `src/pages/WhatsAppRedirect.tsx` que define constantes de configuração, atualiza meta tags, aguarda `1000ms` e executa `window.location.replace` para o link do WhatsApp; a página também exibe um botão "Abrir WhatsApp agora" como fallback.
- Registrado o componente via `lazy` e adicionada a rota `/vaunossowhatsapp` nas árvores de roteamento cliente e servidor em `src/App.tsx` e `src/AppServer.tsx` para suportar navegação e pré-rendering.
- A página usa o utilitário `setMetaTag` para aplicar `robots:noindex,follow` durante a exibição e limpa o timeout/metadata no cleanup do `useEffect`.

### Testing
- Executado `npm run typecheck` e a checagem de tipos completou com sucesso.
- Executado `npx eslint src/App.tsx src/AppServer.tsx src/pages/WhatsAppRedirect.tsx --max-warnings 0` e a verificação para os arquivos alterados passou sem avisos.
- Executado `npm run build` e o build finalizou com sucesso; durante `generate:sitemap` houve falha de fetch no Supabase, mas o script usou o fallback local e concluiu a geração normalmente.
- Executado `npm run lint` e a tarefa falhou por erros e avisos pré-existentes em outros arquivos não relacionados a esta mudança, portanto não bloqueou esta entrega.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b58f084b4832d804021a6b88544f3)