### PR TITLE
Corrige abertura de nova guia ao reproduzir vídeos

### DIFF
--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -62,10 +62,7 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
   const fetchPriorityAttr = fetchPriority ?? (priority ? 'high' : undefined);
 
 
-  const mountPlayer = (
-    container: HTMLElement,
-    Player: new (...args: any[]) => any,
-  ) => {
+  const preparePlayerContainer = (container: HTMLElement) => {
     container.innerHTML = '';
     const div = document.createElement('div');
     div.style.position = 'absolute';
@@ -74,23 +71,47 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
     div.style.height = '100%';
     container.appendChild(div);
 
-    const player = new Player(div, {
+    return div;
+  };
+
+  const mountPlayer = (
+    container: HTMLElement,
+    Player: new (...args: any[]) => any,
+  ) => {
+    const playerContainer = preparePlayerContainer(container);
+
+    new Player(playerContainer, {
       width: '100%',
       height: '100%',
       videoId,
       playerVars: { autoplay: 1, playsinline: 1, modestbranding: 1, rel: 0 },
+      events: {
+        onReady: ({ target: player }: { target: any }) => {
+          player.unMute();
+          player.setVolume(100);
+          player.playVideo();
+        },
+      },
     });
+  };
 
-    player.unMute();
-    player.setVolume(100);
-    player.playVideo();
+  const mountIframe = (container: HTMLElement) => {
+    const playerContainer = preparePlayerContainer(container);
+    const iframe = document.createElement('iframe');
+    iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&playsinline=1&modestbranding=1&rel=0`;
+    iframe.title = title;
+    iframe.allow = 'autoplay; encrypted-media; picture-in-picture';
+    iframe.allowFullscreen = true;
+    iframe.style.width = '100%';
+    iframe.style.height = '100%';
+    iframe.style.border = '0';
+    playerContainer.appendChild(iframe);
   };
 
   const loadVideo = (e: MouseEvent<HTMLButtonElement>) => {
     const container = e.currentTarget.parentElement as HTMLElement | null;
     if (!container || typeof window === 'undefined') return;
 
-    const fallbackUrl = `https://www.youtube.com/watch?v=${videoId}`;
     const w = window as typeof window & {
       YT?: { Player?: new (...args: any[]) => any };
     };
@@ -107,11 +128,11 @@ const OptimizedYouTube: FC<OptimizedYouTubeProps> = ({
           return;
         }
 
-        window.open(fallbackUrl, '_blank', 'noopener');
+        mountIframe(container);
       })
       .catch((error) => {
         console.error('Erro ao carregar a API do YouTube', error);
-        window.open(fallbackUrl, '_blank', 'noopener');
+        mountIframe(container);
       });
   };
 

--- a/src/components/__tests__/OptimizedYouTube.test.tsx
+++ b/src/components/__tests__/OptimizedYouTube.test.tsx
@@ -21,11 +21,15 @@ describe('OptimizedYouTube', () => {
     const setVolume = vi.fn();
     const playVideo = vi.fn();
 
-    const PlayerMock = vi.fn().mockImplementation(() => ({
-      unMute,
-      setVolume,
-      playVideo,
-    }));
+    const PlayerMock = vi.fn().mockImplementation((_element, options) => {
+      options.events.onReady({
+        target: {
+          unMute,
+          setVolume,
+          playVideo,
+        },
+      });
+    });
 
     (window as any).YT = { Player: PlayerMock };
 
@@ -41,5 +45,19 @@ describe('OptimizedYouTube', () => {
     expect(setVolume).toHaveBeenCalledWith(100);
     expect(playVideo).toHaveBeenCalled();
   });
-});
 
+  it('does not open a new tab when the player is started', () => {
+    const openSpy = vi.spyOn(window, 'open');
+    const PlayerMock = vi.fn();
+    (window as any).YT = { Player: PlayerMock };
+
+    const { container } = render(
+      <OptimizedYouTube videoId="abc123" title="Test Video" />
+    );
+
+    fireEvent.click(container.querySelector('button') as HTMLButtonElement);
+
+    expect(PlayerMock).toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Evitar que os vídeos da home abram em uma nova guia ao serem iniciados e garantir que a reprodução aconteça embutida na própria página.
- Fornecer um fallback que mantém o vídeo incorporado mesmo quando a API do YouTube não puder ser usada.

### Description
- Extraí a preparação do container para o player em `preparePlayerContainer` e usei esse container para montar o player ou o iframe de fallback em `src/components/OptimizedYouTube.tsx`.
- Passei a inicializar a reprodução somente no evento `onReady` do player em vez de chamar métodos imediatamente após a construção do player. 
- Substituí o fallback que chamava `window.open(...)` por `mountIframe` que injeta um `iframe` `youtube-nocookie` na página para iniciar a reprodução inline.
- Atualizei os testes em `src/components/__tests__/OptimizedYouTube.test.tsx` para acionar `events.onReady` no mock do player e adicionei um teste de regressão que verifica que `window.open` não é chamado.

### Testing
- Rodei o teste específico com `npm test -- --run src/components/__tests__/OptimizedYouTube.test.tsx` e todos os testes passaram (`3 tests` aprovados).
- Rodei verificação de tipos com `npm run typecheck` e ela passou sem erros.
- Build de produção foi executado com `npx vite build` e concluiu com sucesso.
- Executei ESLint nos arquivos alterados com `npx eslint src/components/OptimizedYouTube.tsx src/components/__tests__/OptimizedYouTube.test.tsx` sem erros (apenas avisos de `any` preexistentes).
- Rodei `npm run lint` e ele falhou devido a erros e avisos preexistentes em outros arquivos não relacionados a esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3415709304832dae126ec4c9918a33)